### PR TITLE
[ash] Added csh type (simple) history processing (in linenoise)

### DIFF
--- a/tlvccmd/ash/Makefile
+++ b/tlvccmd/ash/Makefile
@@ -21,16 +21,16 @@ include $(BASEDIR)/Make.rules
 SRCS=	builtins.c cd.c dirent.c error.c eval.c exec.c expand.c input.c \
 	jobs.c mail.c main.c memalloc.c miscbltin.c mystring.c nodes.c \
 	options.c parser.c redir.c show.c signames.c syntax.c trap.c \
-	output.c var.c linenoise_elks.c autocomplete.c
+	output.c var.c linenoise_tlvc.c autocomplete.c
 
 OBJS=	builtins.o cd.o dirent.o error.o eval.o exec.o expand.o input.o \
 	jobs.o mail.o main.o memalloc.o miscbltin.o mystring.o nodes.o \
 	options.o parser.o redir.o show.o signames.o syntax.o trap.o \
 	output.o var.o init.o \
-	linenoise_elks.o autocomplete.o
+	linenoise_tlvc.o autocomplete.o
 
 # builtins must be manually added
-OBJS += bltin/echo.o
+OBJS += bltin/echo.o bltin/history.o
 OBJS += bltin/expr.o bltin/regexp.o bltin/operators.o
 
 LDFLAGS += -maout-heap=12288 -maout-stack=2304

--- a/tlvccmd/ash/bltin/makefile.not
+++ b/tlvccmd/ash/bltin/makefile.not
@@ -44,6 +44,9 @@ echocmd.o: echo.c bltin.h ../shell.h
 	$(CC) -DSHELL $(CFLAGS) -c echo.c
 	mv echo.o $@
 
+history: history.c bltin.h ../shell.h
+	$(CC) $(CFLAGS) -o $@ history.c
+
 line: line.c bltin.h ../shell.h
 	$(CC) $(CFLAGS) -o $@ line.c
 

--- a/tlvccmd/ash/builtins.table
+++ b/tlvccmd/ash/builtins.table
@@ -64,6 +64,7 @@ exprcmd 	expr test [
 fgcmd -j	fg
 getoptscmd	getopts
 hashcmd 	hash
+histcmd		history
 jobidcmd -j	jobid
 jobscmd 	jobs
 #lccmd		lc


### PR DESCRIPTION
Added simple `csh` style bang history processing to `ash`. There is also a new `history` command to list the history buffer. The mechanism is using the `linenoise`  history buffer, the code added is minimal.

Limited to bangs as the first char on the line and no ^  ^  editing.
What works is
```
!!                <--- repeat previous command
!<num>            <--- repeat this command # in the history buffer
!-x               <--- repeat this command # counting from the most recent command. !-1 is the same as !!.
```
