### PR TITLE
[net] fixed lingering zombie problem in net daemons.

### DIFF
--- a/tlvc/init/main.c
+++ b/tlvc/init/main.c
@@ -161,8 +161,8 @@ static void INITPROC kernel_banner(seg_t start, seg_t end)
     printk("8018X machine, ");
 #endif
 
-    printk("syscaps 0x%x, %uK base ram.\n", sys_caps, SETUP_MEM_KBYTES);
-    printk("ELKS kernel %s (%u text, %u ftext, %u data, %u bss, %u heap)\n",
+    printk("syscaps 0x%x, %uK base ram, %d tasks.\n", sys_caps, SETUP_MEM_KBYTES, MAX_TASKS);
+    printk("TLVC kernel %s (%u text, %u ftext, %u data, %u bss, %u heap)\n",
            system_utsname.release,
            (unsigned)_endtext, (unsigned)_endftext, (unsigned)_enddata,
            (unsigned)_endbss - (unsigned)_enddata, heapsize);

--- a/tlvccmd/inet/telnetd/telnetd.c
+++ b/tlvccmd/inet/telnetd/telnetd.c
@@ -11,7 +11,6 @@
 #include <errno.h>
 #include <signal.h>
 #include <termios.h>
-#include <signal.h>
 #include <string.h>
 #include <sys/wait.h>
 #include <sys/socket.h>
@@ -65,7 +64,6 @@ again:
 		close(STDERR_FILENO);
 		close(*pty_fd);
 
-		setsid();
 		pty_name[5] = 't'; /* results in /dev/ttyp%d, slave side (TTY) /dev/ttyp0 = 4,8 */
 		if ((tty_fd = open(pty_name, O_RDWR)) < 0) {
 			errmsg("telnetd: Can't open pty ");
@@ -100,7 +98,10 @@ again:
 		dup2(tty_fd, STDOUT_FILENO);
 		dup2(tty_fd, STDERR_FILENO);
 		execv(binlogin[0], binlogin);	/* try /bin/login first*/
+		//printf("telnetd: %s failed\n", binlogin[0]);
+		perror("execv");
 		execv(binsh[0], binsh);		/* then /bin/sh for small systems*/
+		//printf("telnetd: %s failed\n", binsh[0]);
 		perror("execv");
 		exit(1);
 	}
@@ -121,7 +122,9 @@ static void telnet_init(int ofd)
 #endif
 }
 
-static void client_loop (int fdsock, int fdterm)
+/* read/write loop for the telnet connection */
+
+static void client_loop(int fdsock, int fdterm)
 {
     fd_set fds_read;
     fd_set fds_write;
@@ -188,13 +191,12 @@ static void client_loop (int fdsock, int fdterm)
     }
 }
 
-#if 0
-void sigchild(void)
+void cleanup()
 {
-	waitpid(-1, NULL, WNOHANG);
-	signal(SIGCHLD, sigchild);
+	while (wait4(-1, NULL, WNOHANG, NULL) > 0)
+		;
+	signal(SIGCHLD, cleanup);
 }
-#endif
 
 int main(int argc, char **argv)
 {
@@ -242,7 +244,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	/* become daemon, debug output on 1 and 2*/
+	/* become daemon, debug output on 1 and 2 */
 	if ((ret = fork()) == -1) {
 		perror("telnetd");
 		return 1;
@@ -254,13 +256,15 @@ int main(int argc, char **argv)
 	dup2(fd, STDERR_FILENO);
 	if (fd > STDERR_FILENO)
 		close(fd);
-	setsid();
-	//signal(SIGCHLD, sigchild);
+	setsid();	/* create new process group */
+	signal(SIGCHLD, cleanup);
 
 	while (1) {
 		unsigned int len = sizeof(addr_in);
 		connectionfd = accept(sockfd, (struct sockaddr *)&addr_in, &len);
 		if (connectionfd < 0) {
+			/* interrupted accept() returns 512 (errno) on signal (SIGCHLD), not EINTR */
+			if (errno == 512 || errno == EINTR) continue;
 			perror ("telnetd accept");
 			break;
 		}
@@ -269,7 +273,8 @@ int main(int argc, char **argv)
 
 		if ((ret = fork()) == -1)		/* handle new accept*/
 			perror("telnetd");
-		else if (ret == 0) {
+		else if (ret == 0) {			/* child processing */
+
 #if 0 /* test code for accept and getpeername */
 			fprintf(stderr, "accept from %s:%u\n", in_ntoa(addr_in.sin_addr.s_addr),
 				ntohs(addr_in.sin_port));
@@ -286,8 +291,8 @@ int main(int argc, char **argv)
 				kill (pid, SIGKILL);
 				waitpid(pid, NULL, 0);
 			}
-			close (connectionfd);
-			close (pty_fd);
+			close(connectionfd);
+			close(pty_fd);
 			exit(0);
 		} else {
 			close(connectionfd);


### PR DESCRIPTION
This update fixes the problem with lingering zombies left by the network daemons (`ftpd` and `telnetd`). This is what a `ps` used to look like after some networking activity:
```
elks17# ps
  PID   GRP  TTY USER STAT CPU  HEAP  FREE   SIZE COMMAND
    1     0      root    S   0  3072  2016  12944 /bin/init 3 
   17    17    1 root    S   0     0  1970   8544 /bin/getty /dev/tty1 
   38    38   S0 root    S   0  1188 13108  71120 -/bin/sh 
   19    19   S2 root    S   0  1188 13186  71120 -/bin/sh 
   20     0      root    Z   0
   11    11      root    S   0  5894 29880  75920 ktcp -b -p ne0 10.0.2.17 10.0.2.2 255.255.255.0 
   13    13      root    S   0     0  1994   9696 telnetd 
   15    15      root    S   0     0  7318  28672 ftpd -d 
   21     0      root    Z   0
   44    19   S2 root    R   0  1024  1182  11344 ps 
   23     0      root    Z   0
   24     0      root    Z   0
   29     0      root    Z   0
   32     0      root    Z   0
elks17# 
```
The system would run out of task slots fast.

The obvious problem is that the deamons don't read the child processes' exit status would would remove the zombies. The real reason was slightly more complicated, but not much:

Using the `ftpd` server as an example, this is how it works:
1. After becoming a daemon, the server enters a loop which starts with a call to `accept()`. When accept returns, either because of an error or (usually) because a connection has been made, it forks off a copy of itself to handle the connection. The daemon - the 'mother server' so to speak, loops back to the `accept()` call and waits for a new connection.
2. When the subprocess serving a connection exits, it becomes a zombie until the mother process gets around to call a `wait()` on it, thus freeing the slot in the system's task list. However, the mother process is sitting idle in an `accept()` call and cannot call a `wait()` until a new connection comes in.
3. Thus the zombie process keeps lingering, but interestingly its task slot seemingly gets reused by the next connection. This is not the case however. What happens is that the new connection causes the while loop in the daemon to call `wait()` and release the zombie process before again entering `accept()` to wait for yet another connection.
4. In order ro remedy this situation, the daemon (mother process) needs to be awaken by the exiting subprocess, which is easy. Just add a `signal(SIGCHLD, handler)` call and let the handler call `wait` to release the exiting process properly.
5. There is one caveat however. When receiving the exit signal from the child, the `accept()` call in which the daemon process is waiting, gets interrupted and must be restarted. No problem now that we know what to expect, except there is a bug in the TLVC socket-code causing the interrupted `accept()`call to not return `EINTR` as it should but instead error code (`errno`) 512.
6. Again, no problem now that we know about it, and the socket library bug has been added to the bug list.

The same goes for `telnetd`, which is admittedly slightly more complicated but works fine after some small adjustments.

This PR also contains a minor change to `init/main.c` replacing the ELKS name with TLVC in boot messages.
