### PR TITLE
[net, ftp] Add speed info to ftp client, reverted change in tcpdev, more

### DIFF
--- a/image/Make.devices
+++ b/image/Make.devices
@@ -41,7 +41,7 @@ devices:
 # Solid state disk
 
 ifneq ($(CONFIG_DEV_BLK_NONE), y)
-	$(MKDEV) /dev/ssd	b 2 0
+	$(MKDEV) /dev/ssd	b 7 0
 endif
 
 ##############################################################################
@@ -118,15 +118,24 @@ endif
 # Direct PATA / IDE disks. (Not working)
 # Limit to 4 primary partitions per disk (MBR).
 
-#	$(MKDEV) /dev/dhda b 5  0    # Currently.
-#	$(MKDEV) /dev/dhda b 5  0 4  # Currently.
-#	$MKSET   0 15 $(MKDEV) /dev/dhda b 5	# Currently.
-#	$(MKDEV) /dev/dhdb b 5 64    # Currently.
-#	$(MKDEV) /dev/dhdb b 5 64 4  # Currently.
-#	$MKSET  64 15 $(MKDEV) /dev/dhdb b 5	# Currently.
+ifeq ($(CONFIG_BLK_DEV_HD), y)
+	$(MKDEV) /dev/dhda b 5  0    # Currently.
+	$(MKDEV) /dev/dhda b 5  0 4  # Currently.
+	$MKSET   0 15 $(MKDEV) /dev/dhda b 5	# Currently.
+	$(MKDEV) /dev/dhdb b 5 64    # Currently.
+	$(MKDEV) /dev/dhdb b 5 64 4  # Currently.
+	$MKSET  64 15 $(MKDEV) /dev/dhdb b 5	# Currently.
+endif
 
 #	$MKSET   0 63 $(MKDEV) /dev/dhda b 3	# Ought to be.
 #	$MKSET  64 63 $(MKDEV) /dev/dhdb b 3	# Ought to be.
+
+##############################################################################
+# Direct floppy drives (experimental)
+ifeq ($(CONFIG_BLK_DEV_FD), y)
+	$(MKDEV) /dev/dfd0 b 3 0
+	$(MKDEV) /dev/dfd1 b 3 64
+endif
 
 ##############################################################################
 # Virtual consoles, pseudo-tty slaves and serial ports.

--- a/tlvc/arch/i86/drivers/net/ne2k-asm.S
+++ b/tlvc/arch/i86/drivers/net/ne2k-asm.S
@@ -472,11 +472,11 @@ ne2k_pack_get:
 #if 0
 	// -------------------------------------------------------------
 	// Packet size check not required since the NIC will not
-	// accept such packets per our initialization. Note, in order to handle
-	// erroneous packets, rx_get (BOUNDARY) pointer must be updated
-	// to point to the next packet.
+	// accept such packets per our initialization. Note, when handling
+	// erroneous packets manually, the rx_get (BOUNDARY) pointer must subsequently
+	// be updated do point to the next packet.
 	// If oversized packets still occur, it's a driver problem (most likely
-	// reading the wrong buffer page).
+	// reading the wrong buffer page from the NIC).
 	// -------------------------------------------------------------
 	or      %cx,%cx		// zero length
 	jz      npg_err2

--- a/tlvccmd/ktcp/ktcp.c
+++ b/tlvccmd/ktcp/ktcp.c
@@ -118,14 +118,11 @@ void ktcp_run(void)
 
 	loopagain = 0;
 
-	/* reversed the order of these two feb 20th 2023 HS - elimiated ktcp 
-	 * hang situation under heavy incoming telnet load */
-
-	/* process application socket actions*/
-	if (FD_ISSET(tcpdevfd, &fdset)) {
-		tcpdev_process();
-		loopagain = 1;
-	}
+	/* NOTE:
+	 * Changing the order of processing (socket actions before receive actions)
+	 * will reduce the outgoing transfer rate by 80% while increasing incoming
+	 * rate by 10%.
+	 */
 
 	/* process received packets*/
 	if (FD_ISSET(intfd, &fdset)) {
@@ -134,6 +131,13 @@ void ktcp_run(void)
 		else slip_process();
 		loopagain = 1;
 	}
+
+	/* process application socket actions*/
+	if (FD_ISSET(tcpdevfd, &fdset)) {
+		tcpdev_process();
+		loopagain = 1;
+	}
+
 
 	/* check for expired retrans packets and free them*/
 	if (tcp_timeruse > 0)

--- a/tlvccmd/ktcp/tcpdev.c
+++ b/tlvccmd/ktcp/tcpdev.c
@@ -52,8 +52,8 @@ void notify_sock(void *sock, int type, int value)
 /* inform kernel of socket data bytes available*/
 void notify_data_avail(struct tcpcb_s *cb)
 {
-    if (cb->bytes_to_push <= 0)
-	return;
+    //if (cb->bytes_to_push <= 0)	/* always checked before call */
+	//return;
 
     notify_sock(cb->sock, TDT_AVAIL_DATA, cb->bytes_to_push);
 }
@@ -233,7 +233,7 @@ static void tcpdev_connect(void)
 
     if (n->tcpcb.remport == NETCONF_PORT && n->tcpcb.remaddr == 0) {
 	n->tcpcb.state = TS_ESTABLISHED;
-	write(1,"TCN;", 4);
+	//write(1,"TCN;", 4);
 	notify_sock(n->tcpcb.sock, TDT_CONNECT, 0);	/* success*/
     } else
 	tcp_connect(&n->tcpcb);
@@ -347,7 +347,7 @@ static void tcpdev_write(void)
      */
     size = db->size;
 
-    /* This is a bit ugly but I'm to lazy right now */
+    /* This is a bit ugly but I'm too lazy right now */
     if (tcp_retrans_memory > TCP_RETRANS_MAXMEM) {
 	printf("ktcp: RETRANS memory limit exceeded\n");
 	retval_to_sock(sock, -ENOMEM);
@@ -464,17 +464,14 @@ void tcpdev_process(void)
 	switch (sbuf[0]){
 	case TDC_BIND:
 	    debug_tcpdev("tcpdev_bind\n");
-	    //write(1,"TB;", 3);
 	    tcpdev_bind();
 	    break;
 	case TDC_ACCEPT:
 	    debug_tcpdev("tcpdev_accept\n");
-	    //write(1,"TA;", 3);
 	    tcpdev_accept();
 	    break;
 	case TDC_CONNECT:
 	    debug_tcpdev("tcpdev_connect\n");
-	    //write(1,"TC;", 3);
 	    tcpdev_connect();
 	    break;
 	case TDC_LISTEN:


### PR DESCRIPTION
- The `ftp` client will now report transfer speed (kB/s) on both sends and receives, like most other Linux clients.
- A change recently made to `tcpdev.c` while hunting an elusive `ktcp` bug, turned out to have adverse effects on transmit speed, and was reverted.
- Misc small fixes including one to `image/Make.devices` to fix a dependency.