### PR TITLE
Another major update - direct drivers and buffer system

### DIFF
--- a/libc/error/Makefile
+++ b/libc/error/Makefile
@@ -2,14 +2,17 @@
 
 include $(TOPDIR)/libc/Makefile.inc
 
-SRCS= __assert.c error.c perror.c
-OBJS= $(SRCS:.c=.o)
+LIB = out.a
 
-$(OBJS): $(SRCS)
+OBJS= \
+    __assert.o \
+    error.o \
+    perror.o \
+    # end of list
 
-all: out.a
+all: $(LIB)
 
-out.a: $(OBJS)
+$(LIB): $(OBJS)
 	$(RM) $@
 	$(AR) $(ARFLAGS_SUB) $@ $^
 

--- a/libc/error/error.c
+++ b/libc/error/error.c
@@ -11,35 +11,30 @@
 char *
 strerror(int err)
 {
-   int fd = -1;
-   int cc;
+   int i, cc, fd;
+   char *p;
    size_t bufoff = 0;
    char inbuf[256];
    static char retbuf[60];
 
-   if( err <= 0 ) goto unknown;	/* NB the <= allows comments in the file */
-   fd = open(_PATH_ERRSTRING, 0);
-   if( fd < 0 ) goto unknown;
+  /* NB the <= allows comments in the file */
+    if (err <= 0 || (fd = open(_PATH_ERRSTRING, 0)) < 0)
+        goto unknown;
 
-   while( (cc=read(fd, inbuf, sizeof(inbuf))) > 0 )
-   {
-      int i;
-      for(i=0; i<cc; i++)
-      {
-         if( inbuf[i] == '\n' )
-	 {
+   while ((cc=read(fd, inbuf, sizeof(inbuf))) > 0 ) {
+      for (i=0; i<cc; i++) {
+         if (inbuf[i] == '\n' ) {
 	    retbuf[bufoff] = '\0';
-	    if( err == atoi(retbuf) )
-	    {
-	       char * p = strchr(retbuf, ' ');
-	       if( p == 0 ) goto done;
-	       while(*++p == ' ') ;
+	    if( err == atoi(retbuf)) {
+	       p = retbuf;
+               while (*p < 'A')
+                  if (!*p++) goto done;
 	       close(fd);
 	       return p;
 	    }
 	    bufoff = 0;
 	 }
-	 else if( bufoff < sizeof(retbuf)-1 )
+	 else if (bufoff < sizeof(retbuf)-1 )
 	    retbuf[bufoff++] = inbuf[i];
       }
    }

--- a/libc/error/perror.c
+++ b/libc/error/perror.c
@@ -3,18 +3,14 @@
 #include <unistd.h>
 
 void
-perror(str)
-__const char * str;
+perror(const char *str)
 {
-   register char * ptr;
-   if(str)
-   {
-      write(2, str, strlen(str));
-      write(2, ": ", 2);
-   }
-   else write(2, "perror: ", 8);
+    char *ptr;
 
-   ptr = strerror(errno);
-   write(2, ptr, strlen(ptr));
-   write(2, "\n", 1);
+    if (!str) str = "perror";
+    write(2, str, strlen(str));
+    write(2, ": ", 2);
+    ptr = strerror(errno);
+    write(2, ptr, strlen(ptr));
+    write(2, "\n", 1);
 }

--- a/libc/string/strrchr.c
+++ b/libc/string/strrchr.c
@@ -3,17 +3,14 @@
 char *
 strrchr (const char * s, int c)
 {
-   register const char * prev = 0;
-   register const char * p = s;
-   /* For null it's just like strlen */
-   if( c == '\0' ) return (char *)p+strlen(p);
+    char *save;
+    char ch;
 
-   /* everything else just step along the string. */
-   while( (p=strchr(p, c)) != 0 )
-   {
-      prev = p; p++;
-   }
-   return (char *)prev;
+    for (save = (char *) 0; (ch = *s); s++) {
+        if (ch == c)
+            save = (char *) s;
+    }
+    return save;
 }
 
 #ifdef __GNUC__

--- a/tlvc/arch/i86/defconfig
+++ b/tlvc/arch/i86/defconfig
@@ -39,11 +39,11 @@ CONFIG_APM=y
 #
 # Kernel settings
 #
+# CONFIG_TRACE is not set
 
 #
 # Memory manager
 #
-# CONFIG_STRACE is not set
 CONFIG_BOOTOPTS=y
 CONFIG_CPU_USAGE=y
 # CONFIG_TIME_RTC_LOCALTIME is not set

--- a/tlvc/arch/i86/drivers/block/directfd.c
+++ b/tlvc/arch/i86/drivers/block/directfd.c
@@ -1585,10 +1585,10 @@ static void floppy_release(struct inode *inode, struct file *filp)
     kdev_t dev = inode->i_rdev;
 
     DEBUG("df%d release", drive);
-    //fsync_dev(dev);	/* umount takes care og this */
+    fsync_dev(dev);
     DEBUG("\n");
     if (!fd_ref[drive & 3]--) {
-	printk("floppy_release with fd_ref == 0");
+	DEBUG("floppy_release with fd_ref == 0");
 	fd_ref[drive & 3] = 0;
     }
     if (fd_ref[drive & 3] == 0) {

--- a/tlvc/arch/i86/drivers/block/genhd.c
+++ b/tlvc/arch/i86/drivers/block/genhd.c
@@ -300,7 +300,7 @@ static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
     first_time = 0;
     first_sector = hd->part[MINOR(dev)].start_sect;
 
-#if 0
+#if UNUSED
     /*
      * This is a kludge to allow the partition check to be
      * skipped for specific drives (e.g. IDE cd-rom drives)
@@ -312,7 +312,7 @@ static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
 #endif
 
     print_minor_name(hd, MINOR(dev));
-
+	//printk("check_partition: hd %04x dv %04x sec %d\n", hd, dev, (sector_t)first_sector);
 #ifdef CONFIG_MSDOS_PARTITION
     if (msdos_partition(hd, dev, first_sector))
 	return;
@@ -349,7 +349,7 @@ void INITPROC setup_dev(register struct gendisk *dev)
 #ifdef BDEV_SIZE_CHK
 	blk_size[dev->major] = NULL;
 #endif
-
+	//printk("setup_dev %04x/%d\n", dev, dev->major);
 	memset((void *)dev->part, 0, sizeof(struct hd_struct)*dev->max_nr*dev->max_p);
 	dev->init(dev);
 

--- a/tlvc/arch/i86/drivers/char/cgatext.c
+++ b/tlvc/arch/i86/drivers/char/cgatext.c
@@ -1,12 +1,9 @@
-#include <linuxmt/cgatext.h>
 #include <linuxmt/errno.h>
-#include <linuxmt/cgatext.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/sched.h>
 #include <arch/cgatext.h>
 
-static size_t
-free_len(struct file * f, size_t len)
+static size_t free_len(struct file * f, size_t len)
 {
   if(f->f_pos >= cgatext_mem_SIZE)
     return 0;
@@ -17,8 +14,7 @@ free_len(struct file * f, size_t len)
   return len;
 }
 
-int
-cgatext_lseek(struct inode *inode, struct file *f, loff_t offset,
+int cgatext_lseek(struct inode *inode, struct file *f, loff_t offset,
   unsigned int origin)
 {
   switch (origin)
@@ -48,38 +44,30 @@ cgatext_lseek(struct inode *inode, struct file *f, loff_t offset,
   return 0;
 }
 
-size_t
-cgatext_read(struct inode *inode, struct file *f, char *data, size_t len)
+size_t cgatext_read(struct inode *inode, struct file *f, char *data, size_t len)
 {
   len = free_len(f, len);
 
-  if(len)
-  {
+  if(len) {
     fmemcpyb(data, current->t_regs.ds, (char *)f->f_pos, cgatext_mem_SEG, len);
-
     f->f_pos += len;
   }
 
   return len;
 }
 
-size_t
-cgatext_write(struct inode *inode, register struct file *f, char *data, size_t len)
+size_t cgatext_write(struct inode *inode, register struct file *f, char *data, size_t len)
 {
   len = free_len(f, len);
 
-  if(len)
-  {
+  if(len) {
     fmemcpyb((char *)f->f_pos, cgatext_mem_SEG, data, current->t_regs.ds, len);
-
     f->f_pos += len;
   }
-
   return len;
 }
 
-static struct file_operations cgatext_fops =
-{
+static struct file_operations cgatext_fops = {
   cgatext_lseek,	/* lseek */
   cgatext_read,		/* read */
   cgatext_write,	/* write */
@@ -90,12 +78,7 @@ static struct file_operations cgatext_fops =
   NULL	/* release */
 };
 
-void
-cgatext_init(void)
+void INITPROC cgatext_init(void)
 {
-  int i;
-
-  i = register_chrdev(CGATEXT_MAJOR, CGATEXT_DEVICE_NAME, &cgatext_fops);
-  if(i)
-	  printk("cgatext: unable to register: %d\n", i);
+	register_chrdev(CGATEXT_MAJOR, CGATEXT_DEVICE_NAME, &cgatext_fops);
 }

--- a/tlvc/arch/i86/drivers/char/eth.c
+++ b/tlvc/arch/i86/drivers/char/eth.c
@@ -93,7 +93,7 @@ static struct file_operations eth_fops = {
     eth_release
 };
 
-void /*INITPROC*/ eth_init(void)
+void INITPROC eth_init(void)
 {
     register_chrdev(ETH_MAJOR, "eth", &eth_fops);
 

--- a/tlvc/arch/i86/drivers/char/init.c
+++ b/tlvc/arch/i86/drivers/char/init.c
@@ -2,7 +2,7 @@
 #include <linuxmt/types.h>
 #include <linuxmt/init.h>
 
-void chr_dev_init(void)
+void INITPROC chr_dev_init(void)
 {
 #ifdef CONFIG_CHAR_DEV_LP
     lp_init();

--- a/tlvc/arch/i86/drivers/char/lp.c
+++ b/tlvc/arch/i86/drivers/char/lp.c
@@ -266,7 +266,7 @@ static struct file_operations lp_fops = {
 
 /*@+type@*/
 
-void lp_init(void)
+void INITPROC lp_init(void)
 {
     register struct lp_info *lp = &ports[0];
     int i;

--- a/tlvc/arch/i86/drivers/char/mem.c
+++ b/tlvc/arch/i86/drivers/char/mem.c
@@ -42,13 +42,15 @@
 #define DEV_RANDOM_MINOR	8
 #define DEV_URANDOM_MINOR	9
 
+//#define debugmem printk
+//#define DEBUG
 /*
  * generally useful code...
  */
 int memory_lseek(struct inode *inode, register struct file *filp,
 		    loff_t offset, unsigned int origin)
 {
-    debugmem("mem_lseek()\n");
+    debugmem("mem_lseek(%ld)\n", offset+filp->f_pos);
     switch (origin) {
     case 1:
 	offset += filp->f_pos;
@@ -214,9 +216,9 @@ size_t kmem_read(struct inode *inode, register struct file *filp,
 {
     unsigned short int sseg, soff;
 
-    debugmem("[k]mem_read()\n");
+    debugmem("[k]mem_read(): ");
     sseg = split_seg_off(&soff, filp->f_pos);
-    debugmem("Reading %u %p %p.\n", len, sseg, soff);
+    debugmem("len %u seg %p off %p.\n", len, sseg, soff);
     fmemcpyb((byte_t *)data, current->t_regs.ds, (byte_t *)soff, sseg, (word_t) len);
     filp->f_pos += len;
     return (size_t) len;
@@ -414,10 +416,9 @@ static struct file_operations memory_fops = {
 
 /*@+type@*/
 
-void mem_dev_init(void)
+void INITPROC mem_dev_init(void)
 {
-    if (register_chrdev(MEM_MAJOR, "mem", &memory_fops))
-	printk("MEM: Unable to get major %d for memory devices\n", MEM_MAJOR);
+    register_chrdev(MEM_MAJOR, "mem", &memory_fops);
 }
 
 #endif

--- a/tlvc/arch/i86/drivers/char/ntty.c
+++ b/tlvc/arch/i86/drivers/char/ntty.c
@@ -70,8 +70,8 @@ int tty_intcheck(register struct tty *ttyp, unsigned char key)
 	if (key == ttyp->termios.c_cc[VSUSP])
 	    sig = SIGTSTP;
 #if DEBUG_EVENT
-	if (key == ('P' & 0x1f)) {	/* ctrl-P*/
-	    debug_event();
+	if (key >= ('N' & 0x1f) && key <= ('P' & 0x1f)) {       /* CTRLN-CTRLP */
+	    debug_event((key - 'N') & 0x1f);
 	    return 1;
 	}
 #endif

--- a/tlvc/arch/i86/drivers/char/pty.c
+++ b/tlvc/arch/i86/drivers/char/pty.c
@@ -182,7 +182,7 @@ struct tty_ops ttyp_ops = {
 
 /*@+type@*/
 
-void pty_init(void)
+void INITPROC pty_init(void)
 {
     register_chrdev(PTY_MASTER_MAJOR, "pty", &pty_fops);
 }

--- a/tlvc/arch/i86/drivers/char/rhd.c
+++ b/tlvc/arch/i86/drivers/char/rhd.c
@@ -58,7 +58,8 @@ int rhd_open(register struct inode *inode, struct file *filp)
 void rhd_close(struct inode *inode, struct file *filp)
 {
     //printk("rdh close\n");
-    return(directhd_release(inode, filp));
+    //return(directhd_release(inode, filp));
+    return; 	/* Nothing to do */
 }
 
 /* FIXME change ops struct to point directly to the block driver entries when appropriate */

--- a/tlvc/arch/i86/drivers/char/tcpdev.c
+++ b/tlvc/arch/i86/drivers/char/tcpdev.c
@@ -176,7 +176,7 @@ static struct file_operations tcpdev_fops = {
 
 /*@+type@*/
 
-void tcpdev_init(void)
+void INITPROC tcpdev_init(void)
 {
     register_chrdev(TCPDEV_MAJOR, "tcpdev", &tcpdev_fops);
     bufin_sem = bufout_sem = 0;

--- a/tlvc/arch/i86/drivers/net/el3.c
+++ b/tlvc/arch/i86/drivers/net/el3.c
@@ -90,7 +90,7 @@ enum RxFilter {
 #define EP_ID_PORT_END 0x200
 #define EP_TAG_MAX		0x7 /* must be 2^n - 1 */
 
-static int el3_isa_probe();
+static int INITPROC el3_isa_probe();
 //static word_t read_eeprom(int, int);
 static word_t id_read_eeprom(int);
 static size_t el3_write(struct inode *, struct file *, char *, size_t);
@@ -141,7 +141,7 @@ struct file_operations el3_fops =
     el3_release
 };
 
-void el3_drv_init(void) {
+void INITPROC el3_drv_init(void) {
 	ioaddr = net_port;		// temporary
 
 	verbose = (net_flags&ETHF_VERBOSE);
@@ -156,7 +156,7 @@ void el3_drv_init(void) {
 
 }
 
-static int el3_find_id_port ( void ) {
+static int INITPROC el3_find_id_port ( void ) {
 
 	for ( el3_id_port = EP_ID_PORT_START ;
 	      el3_id_port < EP_ID_PORT_END ;
@@ -176,7 +176,7 @@ static int el3_find_id_port ( void ) {
 }
 
 /* Return 0 on success, 1 on error */
-static int el3_isa_probe( void )
+static int INITPROC el3_isa_probe( void )
 {
 	short lrs_state = 0xff;
 	int i;

--- a/tlvc/arch/i86/drivers/net/ne2k.c
+++ b/tlvc/arch/i86/drivers/net/ne2k.c
@@ -486,7 +486,7 @@ void ne2k_display_status(void)
  * FIXME: Needs return value to signal that initalization failed.
  */
 
-void ne2k_drv_init(void)
+void INITPROC ne2k_drv_init(void)
 {
 	int err, i;
 	word_t prom[16];/* PROM containing HW MAC address and more 
@@ -585,7 +585,7 @@ void ne2k_drv_init(void)
 		printk(", flags 0x%02x\n", net_flags);
 
 #if DEBUG_ETH
-		debug_setcallback(ne2k_display_status);
+		debug_setcallback(2, ne2k_display_status);	/* ^P lists status */
 #endif
 		break;
 	}

--- a/tlvc/arch/i86/drivers/net/wd.c
+++ b/tlvc/arch/i86/drivers/net/wd.c
@@ -175,7 +175,7 @@ static void wd_get_hw_addr(word_t * data)
  * determine bus width if possible.
  */
 
-static int wd_probe(void) {
+static int INITPROC wd_probe(void) {
 	int i, tmp = 0;
 
 	for (i = 0; i < 8; i++)
@@ -706,7 +706,7 @@ static void wd_int(int irq, struct pt_regs * regs)
  * Ethernet main initialization (during boot)
  */
 
-void wd_drv_init(void)
+void INITPROC wd_drv_init(void)
 {
 	unsigned u;
 	word_t hw_addr[6U];
@@ -734,7 +734,7 @@ void wd_drv_init(void)
 /* Using this wrapper saves 44 bytes of RAM */
 /* Using word transfers when possible improves transfer time ~10%
  * on large packets (measured @ 1200 bytes) */
-void fmemcpy(void *dst_off, seg_t dst_seg, void *src_off, seg_t src_seg, size_t count, int type) {
+static void fmemcpy(void *dst_off, seg_t dst_seg, void *src_off, seg_t src_seg, size_t count, int type) {
 
 	if (type == is_8bit)
 		fmemcpyb(dst_off, dst_seg, src_off, src_seg, count);

--- a/tlvc/arch/i86/kernel/Makefile
+++ b/tlvc/arch/i86/kernel/Makefile
@@ -25,7 +25,7 @@ DEPEND  	=
 
 DISTFILES	= syscall.dat
 
-NOINDENT	= irq.c irqtab.S process.c strace.h system.c timer.c
+NOINDENT	= irqtab.S process.c strace.h system.c timer.c
 
 #########################################################################
 # Include standard commands.

--- a/tlvc/arch/i86/kernel/irqtab.S
+++ b/tlvc/arch/i86/kernel/irqtab.S
@@ -1,8 +1,8 @@
 #include <linuxmt/config.h>
+#include <linuxmt/limits.h>
+#include <linuxmt/trace.h>
 #include <arch/asm-offsets.h>
 #include <arch/ports.h>
-
-#define CHECK_SS	// integrity check interrupt from user mode
 
 	.arch	i8086, nojumps
 	.code16
@@ -96,13 +96,9 @@ int_vector_set:
 	.extern	do_IRQ
 	.extern	stack_check
 	.extern	syscall
-#ifdef CHECK_SS
+	.extern trace_begin
+	.extern trace_end
 	.extern	panic
-#endif
-#ifdef CONFIG_STRACE
-	.extern	strace
-	.extern	ret_strace
-#endif
 
 	.global _irqit
 _irqit:
@@ -129,14 +125,13 @@ ktask:				// Already using interrupt stack
 //
 //	Already using interrupt stack, keep using it
 //
-	//mov	%sp,%si
 	sub	$8,%si		// 14 offsets less 6 already on stack
 	jmp	save_regs
 //
 //	Using a process's kernel stack, switch to interrupt stack
 //
 itask:
-	mov	$_intstack-14,%si // 14 offsets 0-13 of SI below
+	mov	$istack-14,%si	// 14 offsets 0-13 of SI below
 	jmp	save_regs
 //
 //	User mode case
@@ -201,27 +196,21 @@ save_regs:
 //	----------PROCESS SYSCALL----------
 //
 	sti
-	call	stack_check	// Check USER stack
+	call	stack_check	// Check USER mode stack
+
+#ifdef CONFIG_TRACE
+	call	trace_begin
+#endif
+
 	pop	%ax		// Get syscall function code
-#ifdef CONFIG_STRACE
-//
-//	strace(syscall#, params...)
-//
-	push	%ax
-	call	strace		// strace must be compiled with tail function optim off
-	pop     %ax
-#endif
-//
-//	syscall(params...)
-//
 	call	syscall
-	push	%ax		// syscall returns a value in ax
-#ifdef CONFIG_STRACE
-//
-//	ret_strace(retval)
-//
-	call	ret_strace
+	push	%ax
+
+#ifdef CONFIG_TRACE
+	// strace.c must be compiled with tail optimization off to protect top of stack
+	call	trace_end       // syscall return value is top of stack
 #endif
+
 //
 //	Restore registers
 //
@@ -252,7 +241,9 @@ ret_from_syscall:
 !
 */
 updct:
+#ifdef CHECK_SCHED
 	incw	intr_count	// only needed for schedule during interrupt warning
+#endif
 //
 //	Call the C code
 //
@@ -276,15 +267,16 @@ updct:
 //
 	cmp	$16,%ax
 	jge	was_trap	// Traps need no reset
+#ifdef CONFIG_BLK_DEV_BIOS
 #ifdef CONFIG_ARCH_PC98
 	jmp	do_eoi
 #else
 	or	%ax,%ax		// Is int #0?
 	jnz	do_eoi
 #endif
-
 //
 //	IRQ 0 (timer) has to go on to the bios for some systems
+//	Don't use unless we're using BIOS block IO
 //
 	decw	bios_call_cnt	// Will call bios int?
 	jne	do_eoi
@@ -292,7 +284,7 @@ updct:
 	pushf
 	lcall	*org_irq0
 	jmp	was_trap	// EOI already sent by bios int
-
+#endif
 //
 //	Send EOI to interrupt controller
 //
@@ -331,7 +323,9 @@ was_trap:
 //
 //	Restore intr_count
 //
+#ifdef CHECK_SCHED
 	decw	intr_count
+#endif
 //
 //	Now look at rescheduling
 //
@@ -406,21 +400,27 @@ idle_halt:
 
 	.data
 	.global	intr_count
+	.global endistack
 	.extern	current
 	.extern	previous
 
+#ifdef CONFIG_BLK_DEV_BIOS
 bios_call_cnt:                  // call BIOS IRQ 0 handler every 5th interrupt
-	.word	5
+	.word	5		// must be disabled if using direct floppy
+#endif
 org_irq0:			// original BIOS IRQ 0 vector
 	.long	0
+#ifdef CHECK_SCHED
 intr_count:			// Hardware interrupts count
 	.word	0
+#endif
 _gint_count:			// General interrupts count. Start with 1
 	.word	1		// because init_task() is in kernel mode
 #ifdef CHECK_SS
 pmsg:	.ascii "Running unknown code"
 	.byte	0
 #endif
-	.skip 512,0		// 512 byte interrupt stack
-_intstack:
+endistack:
+	.skip ISTACK_BYTES,0		// interrupt stack
+istack:
 

--- a/tlvc/arch/i86/kernel/process.c
+++ b/tlvc/arch/i86/kernel/process.c
@@ -7,7 +7,6 @@
 #include <linuxmt/signal.h>
 #include <linuxmt/types.h>
 #include <linuxmt/memory.h>
-#include <linuxmt/strace.h>
 
 #include <arch/segment.h>
 
@@ -23,8 +22,6 @@ static char *args[] = {
     NULL,
     NULL		/* 18-19*/
 };
-
-extern void ret_from_syscall(void);
 
 int run_init_process(const char *cmd)
 {
@@ -54,9 +51,6 @@ void stack_check(void)
     register __ptask currentp = current;
     register char *end = (char *)currentp->t_endbrk;
 
-#if defined(CONFIG_STRACE) && defined(STRACE_KSTACKUSED)
-    memset(current->t_kstack, 0x55, KSTACK_BYTES-16);
-#endif
 #ifdef CONFIG_EXEC_LOW_STACK
     if (currentp->t_begstack <= currentp->t_enddata) {	/* stack below heap?*/
 	if (currentp->t_regs.sp < (__u16)end)

--- a/tlvc/arch/i86/kernel/strace.c
+++ b/tlvc/arch/i86/kernel/strace.c
@@ -1,126 +1,194 @@
 #include <linuxmt/config.h>
-#include <linuxmt/types.h>
 #include <linuxmt/kernel.h>
-#include <linuxmt/debug.h>
-#include <linuxmt/config.h>
-#include <linuxmt/wait.h>
 #include <linuxmt/sched.h>
+#include <linuxmt/trace.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/string.h>
 
-#ifdef CONFIG_STRACE
+/*
+ * Kernel tracing functions for consistency checking and debugging support
+ */
+
+#ifdef CONFIG_TRACE
 
 /* The table describing the system calls has been moved to a separate
  * header file, and is included by the following include line.
  */
-
 #include "strace.h"
 
-static char *fmtspec[] = {
+static struct sc_info notimp = { "NOTIMP", 0};
+
+static struct sc_info *syscall_info(unsigned int callno)
+{
+    struct sc_info *s;
+
+    if (callno < sizeof(elks_table1)/sizeof(struct sc_info)) {
+        s = &elks_table1[callno];
+        if (s) return s;
+    }
+    else if (callno < sizeof(elks_table2)/sizeof(struct sc_info) + START_TABLE2) {
+        s = &elks_table2[callno-START_TABLE2];
+        if (s) return s;
+    }
+    return &notimp;
+}
+
+#ifdef CHECK_STRACE
+static const char *fmtspec[] = {
     NULL,   "&0x%X", "0x%X",  "0x%X",
     "'%c'", "'%c'",  "\"%t\"","\"%t\"",
     "%u",   "%d",    "&%u",   "&%d",
     NULL,    NULL,    NULL,    NULL
 };
 
-void print_syscall(register struct syscall_params *p, int retval)
+struct sc_args {
+    unsigned int args[3];    /* BX, CX, DX */
+};
+
+static void strace(void)
 {
-    register struct syscall_info *s;
-    unsigned int tmpa;
-    int i;
+    struct sc_info *s = syscall_info(current->t_regs.orig_ax);
+    unsigned int info = (s->s_info >> 4);
+    struct sc_args *p = (struct sc_args *)&current->t_regs.bx;
+    int i = 0;
 
-    if (p->s_num >= sizeof(elks_table)/sizeof(struct syscall_info))
-	printk("Syscall not recognised: %u\n", p->s_num);
-    else if ((((s = &elks_table[p->s_num])->s_params) & 0xf) > 5)
-	printk("Syscall not supported: nosys_%s\n", s->s_name);
-    else {
+    printk("[%d: %s(", current->pid, s->s_name);
+    goto pscl;
 
-#ifdef STRACE_PRINTSTACK
+    while (info >>= 4) {
+        printk(", ");
 
-	printk("[%d/%p: %2d %12s(", current->pid, current->t_regs.sp,
-	       p->s_num, s->s_name);
+pscl:
+        if (fmtspec[info & 0xf] != NULL)
+            printk(fmtspec[info & 0xf], p->args[i]);
+        else switch (info & 0xf) {
+        case P_PULONG:
+            printk("%lu", get_user_long((void *)p->args[i]));
+            break;
 
-#else
+        case P_PSLONG:
+            printk("%ld", get_user_long((void *)p->args[i]));
+            break;
+#if UNUSED
+        case P_SLONG:       /* currently unused*/
+            printk("%ld", *(long *)&p->args[i++]);
+            break;
 
-	printk("[%d: %12s(", current->pid, s->s_name);
-
+        case P_ULONG:       /* currently unused*/
+            printk("%lu", *(unsigned long *)&p->args[i++]);
+            break;
 #endif
-
-	i = 0;
-	tmpa = (s->s_params >> 4);
-	goto pscl;
-	while (tmpa >>= 4) {
-	    printk(", ");
-
-	 pscl:
-	    if (fmtspec[tmpa & 0xf] != NULL)
-		printk(fmtspec[tmpa & 0xf], p->s_param[i]);
-	    else switch (tmpa & 0xf) {
-	    case P_PULONG:
-		printk("%lu", get_user_long((void *)p->s_param[i]));
-		break;
-
-	    case P_PSLONG:
-		printk("%ld", get_user_long((void *)p->s_param[i]));
-		break;
-
-	    case P_SLONG:	/* currently unused*/
-		printk("%ld", *(long *)&p->s_param[i++]);
-		break;
-
-	    case P_ULONG:	/* currently unused*/
-		printk("%lu", *(unsigned long *)&p->s_param[i++]);
-		break;
-	    }
-	    i++;
-
-	}
+        }
+        i++;
 
     }
-#ifdef STRACE_RETWAIT
-    printk(") = %d]\n", retval);
-#else
-    p->s_name = s->s_name;
     printk(")]");
-#endif
 }
 
-/* Funny how syscall_params just happens to match the layout of the system
- * call paramters on the stack, isn't it? :)
+#endif
+
+/* stringize the result of expansion of a macro argument - used in check_kstack */
+#define str(bytes)  str2(bytes)
+#define str2(bytes) #bytes
+
+#ifdef CHECK_KSTACK
+static void check_kstack(int n)
+{
+    int i;
+    __ptask currentp = current;
+    struct sc_info *s;
+    const char *warning = "";
+    static int max;
+    static int maxistack;
+    extern __u16 endistack[];
+
+    /* calc interrupt stack usage */
+    for (i=0; i<ISTACK_BYTES/2; i++) {
+        if (endistack[i] != 0)
+            break;
+    }
+    i = (ISTACK_BYTES/2 - i) << 1;
+    if (i > maxistack) {
+        maxistack = i;
+        printk("ISTACK NEW MAX %d\n", maxistack);
+    }
+
+    s = syscall_info(currentp->t_regs.orig_ax);
+    if (s == &notimp)
+        printk("KSTACK(%d) syscall %d NOTIMP\n", currentp->pid, currentp->t_regs.orig_ax);
+    if (n >= KSTACK_BYTES - KSTACK_GUARD)
+        warning = " (OVERFLOW AT " str(KSTACK_BYTES) ")";
+    if (n > currentp->kstack_max) {
+        currentp->kstack_prevmax = currentp->kstack_max;
+        currentp->kstack_max = n;
+        if (n > max)
+            max = n;
+        if (currentp->kstack_prevmax != 0) {
+            printk("KSTACK(%d) sys_%7s max %3d prevmax %3d sysmax %3d%s",
+                currentp->pid, s->s_name,
+                currentp->kstack_max, currentp->kstack_prevmax, max, warning);
+            if (n == max) printk("*");
+            printk("\n");
+        }
+    }
+}
+#endif
+
+/*
+ * Called before syscall entry
  */
-
-void strace(struct syscall_params p)
+void trace_begin(void)
 {
-    /* First we check the kernel stack magic */
-    if (current->t_kstackm != KSTACK_MAGIC)
-	panic("Process %d had kernel stack overflow before syscall\n",
-	      current->pid);
-    /* set up cur_sys */
-    current->sc_info = p;
-#ifndef STRACE_RETWAIT
-    print_syscall(&current->sc_info, 0);
+#if defined(CONFIG_STRACE) || defined(CHECK_KSTACK)
+    if (tracing & (TRACE_STRACE|TRACE_KSTACK))
+        memset(current->t_kstack, 0x55, KSTACK_BYTES-32);
+#endif
+#ifdef CHECK_STRACE
+    if (tracing & TRACE_STRACE)
+        strace();
 #endif
 }
 
-void ret_strace(unsigned int retval)
+/*
+ * Called after syscall return
+ * Must be compiled with -fno-optimize-siblings-calls (no tail call optimization)
+ * in order to protect top of stack return value since called from _irqit.
+ */
+void trace_end(unsigned int retval)
 {
-#ifdef STRACE_RETWAIT
-    print_syscall(&current->sc_info, retval);
-#else
-#ifdef STRACE_KSTACKUSED
+    __ptask currentp = current;
     int n;
-    static int max = 0;
+    static int max;
 
-    for (n=0; n<KSTACK_BYTES; n++)
-	if (current->t_kstack[n] != 0x55)
-	    break;
-    n = KSTACK_BYTES - n;
-    if (n > max) max = n;
-    printk("[%d:%s/ret=%d,ks=%d/%d]\n",
-	current->pid, current->sc_info.s_name, retval, n, max);
-#else
-    printk("[%d:%s/ret=%d]\n", current->pid, current->sc_info.s_name, retval);
+    /* Check for kernel stack overflow */
+    if (currentp->kstack_magic != KSTACK_MAGIC) {
+        printk("KSTACK(%d) KERNEL STACK OVERFLOW\n", current->pid);
+        do_exit(SIGSEGV);
+    }
+
+    n = 0;
+#if defined(CONFIG_STRACE) || defined(CHECK_KSTACK)
+    if (tracing & (TRACE_STRACE|TRACE_KSTACK)) {
+        for (; n<KSTACK_BYTES/2; n++) {
+        if (currentp->t_kstack[n] != 0x5555)
+                break;
+        }
+        n = (KSTACK_BYTES/2 - n) << 1;
+        if (n > max) max = n;
+    }
 #endif
+
+#ifdef CHECK_STRACE
+    if (tracing & TRACE_STRACE) {
+        struct sc_info *s = syscall_info(currentp->t_regs.orig_ax);
+        printk("[%d:%s/ret=%d,ks=%d/%d]\n", currentp->pid, s->s_name, retval, n, max);
+    }
+#endif
+
+#ifdef CHECK_KSTACK
+    if (tracing & TRACE_KSTACK)
+        check_kstack(n);
 #endif
 }
 
-#endif
+#endif /* CONFIG_TRACE */

--- a/tlvc/arch/i86/kernel/strace.h
+++ b/tlvc/arch/i86/kernel/strace.h
@@ -1,256 +1,173 @@
-/* ELKS (version >= 0.0.49) system call layout.
- * 
+/*
+ * ELKS system call table info for strace and kernel stack checking.
+ * This table needs to be kept synchronised with the syscall.dat file.
+ *
+ * strace.h (C) 1997 Chad Page, 2023 Greg Haerr
+ *
+ * strace allows us to track any system call going into the kernel, and the
+ * return value going out.  This include file has the specs for the strace
+ * tables in strace.c which will let it produce semi-readable output
+ *
+ *
  * syscall_info table format : 
  *
  * { "sys_call_name", # of parameters, {parameter types, explained, below}},
  * 
- * This table needs to be kept synchronised with the syscall.dat file.
- *
  * The following parameter types are available:
  *
- *	P_NONE		No parameter in this position.
+ *      P_NONE          No parameter in this position.
  *
- *	P_SCHAR 	Signed character.
- *	P_UCHAR 	Unsigned character.
+ *      P_SCHAR         Signed character.
+ *      P_UCHAR         Unsigned character.
  *
- *	P_STR		String of characters (signed or unsigned).
- *	P_PSTR		Pointer to string of characters.
+ *      P_STR           String of characters (signed or unsigned).
+ *      P_PSTR          Pointer to string of characters.
  *
- *	P_SSHORT	Signed short integer.
- *	P_USHORT	Unsigned short integer.
+ *      P_SSHORT        Signed short integer.
+ *      P_USHORT        Unsigned short integer.
  *
- *	P_PSSHORT	Pointer to signed short integer.
- *	P_PUSHORT	Pointer to unsigned short integer.
+ *      P_PSSHORT       Pointer to signed short integer.
+ *      P_PUSHORT       Pointer to unsigned short integer.
  *
- *	P_SLONG 	Signed long integer.
- *	P_ULONG 	Unsigned long integer.
+ *      P_SLONG         Signed long integer.
+ *      P_ULONG         Unsigned long integer.
  *
- *	P_PSLONG	Pointer to signed long integer.
- *	P_PULONG	Pointer to unsigned long integer.
+ *      P_PSLONG        Pointer to signed long integer.
+ *      P_PULONG        Pointer to unsigned long integer.
  *
- *	P_DATA		Generic Data.
- *	P_PDATA		Pointer to Generic Data.
+ *      P_DATA          Generic Data.
+ *      P_PDATA         Pointer to Generic Data.
  *
- *	P_POINTER	Generic Pointer.
+ *      P_POINTER       Generic Pointer.
  *
  * A maximum of three parameters can be defined for each system call.
+ *
+ * Values organised as follows:
+ *
+ * Bits  Values  Meaning
+ * ~~~~  ~~~~~~  ~~~~~~~
+ *  1-0    00    Unsigned
+ *         01    Signed
+ *         10    Pointer to unsigned
+ *         11    Pointer to signed
+ *  2+           Data Type
  */
 
-#ifndef __STRACE_H__
-#define __STRACE_H__
+#define P_NONE		  0	/* No parameters                        */
+#define P_DATA		  1	/* Generic Data                         */
+#define P_POINTER	  2	/* Generic Data Pointer                 */
+#define P_PDATA 	  3	/* Pointer to Generic Data              */
 
-#include <linuxmt/strace.h>
+#define P_UCHAR 	  4	/* Unsigned Char                        */
+#define P_SCHAR 	  5	/* Signed Char                          */
+#define P_STR		  6	/* String                               */
+#define P_PSTR  	  7	/* Pointer to String                    */
 
+#define P_USHORT	  8	/* Unsigned Short Int                   */
+#define P_SSHORT	  9	/* Signed Short Int                     */
+#define P_PUSHORT 	 10	/* Pointer to Unsigned Short Int        */
+#define P_PSSHORT 	 11	/* Pointer to Signed Short Int          */
+
+#define P_ULONG 	 12	/* Unsigned Long Int                    */
+#define P_SLONG 	 13	/* Signed Long Int                      */
+#define P_PULONG 	 14	/* Pointer to Unsigned Long Int         */
+#define P_PSLONG	 15	/* Pointer to Signed Long Int           */
+
+#define ENTRY(name, info)   { name, info }
 #define packinfo(n, a, b, c) (unsigned)(n | (a << 4) | (b << 8) | (c << 12))
 
-struct syscall_info elks_table[] = {
-    { "call",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "exit",		packinfo(1, P_SSHORT, P_NONE,    P_NONE   ) },
-    { "fork",		packinfo(0, P_NONE,   P_NONE,    P_NONE   ) },
-    { "read",		packinfo(3, P_USHORT, P_PDATA,   P_USHORT ) },
-    { "write",		packinfo(3, P_USHORT, P_PDATA,   P_USHORT ) },
-    { "open",		packinfo(3, P_PSTR,   P_USHORT,  P_USHORT ) },
-    { "close",		packinfo(1, P_USHORT, P_NONE,    P_NONE   ) },
-    { "wait4",		packinfo(3, P_SSHORT, P_PSSHORT, P_SSHORT ) },
-    { "creat",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "link",		packinfo(2, P_PSTR,   P_PSTR,    P_NONE   ) },
-    { "unlink",		packinfo(1, P_PSTR,   P_NONE,    P_NONE   ) },
-    { "execve",		packinfo(3, P_PSTR,   P_PDATA,   P_USHORT ) },
-    { "chdir",		packinfo(1, P_PSTR,   P_NONE,    P_NONE   ) },
-    { "time",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "mknod",		packinfo(3, P_PSTR,   P_USHORT,  P_USHORT ) },
-    { "chmod",		packinfo(2, P_PSTR,   P_USHORT,  P_NONE   ) },
-    { "chown",		packinfo(3, P_PSTR,   P_USHORT,  P_USHORT ) },
-    { "brk",		packinfo(1, P_POINTER,P_NONE,    P_NONE   ) },
-    { "stat",		packinfo(2, P_PSTR,   P_PDATA,   P_NONE   ) },
-    { "lseek",		packinfo(3, P_USHORT, P_PSLONG,  P_USHORT ) },
-    { "getpid",		packinfo(0, P_NONE,   P_NONE,    P_NONE   ) },
-    { "mount",		packinfo(3, P_PSTR,   P_PSTR,    P_PSTR   ) },
-    { "umount",		packinfo(1, P_PSTR,   P_NONE,    P_NONE   ) },
-    { "setuid",		packinfo(1, P_USHORT, P_NONE,    P_NONE   ) },
-    { "getuid",		packinfo(0, P_NONE,   P_NONE,    P_NONE   ) },
-    { "stime",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "ptrace",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "alarm",		packinfo(1, P_USHORT, P_NONE,    P_NONE   ) },
-    { "fstat",		packinfo(2, P_USHORT, P_PDATA,   P_NONE   ) },
-    { "pause",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "utime",		packinfo(2, P_PSTR,   P_PDATA,   P_NONE   ) },
-    { "chroot",		packinfo(1, P_PSTR,   P_NONE,    P_NONE   ) },
-    { "vfork",		packinfo(0, P_NONE,   P_NONE,    P_NONE   ) },
-    { "access",		packinfo(2, P_PSTR,   P_USHORT,  P_NONE   ) },
-    { "nice",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "sleep",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "sync",		packinfo(0, P_NONE,   P_NONE,    P_NONE   ) },
-    { "kill",		packinfo(2, P_USHORT, P_USHORT,  P_NONE   ) },
-    { "rename",		packinfo(2, P_PSTR,   P_PSTR,    P_NONE   ) },
-    { "mkdir",		packinfo(2, P_PSTR,   P_USHORT,  P_NONE   ) },
-    { "rmdir",		packinfo(1, P_PSTR,   P_NONE,    P_NONE   ) },
-    { "dup",		packinfo(1, P_USHORT, P_NONE,    P_NONE   ) },
-    { "pipe",		packinfo(1, P_PDATA,  P_NONE,    P_NONE   ) },
-    { "times",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "profil",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "dup2",		packinfo(2, P_USHORT, P_USHORT,  P_NONE   ) },
-    { "setgid",		packinfo(1, P_USHORT, P_NONE,    P_NONE   ) },
-    { "getgid",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "signal",         packinfo(2, P_USHORT, P_PDATA,   P_NONE   ) },
-    { "getinfo",	packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "fcntl",		packinfo(3, P_USHORT, P_USHORT,  P_USHORT ) },
-    { "acct",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "phys",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "lock",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "ioctl",		packinfo(3, P_USHORT, P_USHORT,  P_USHORT ) },
-    { "reboot",		packinfo(3, P_USHORT, P_USHORT,  P_SSHORT ) },
-    { "mpx",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "lstat",		packinfo(2, P_PSTR,   P_PDATA,   P_NONE   ) },
-    { "symlink",	packinfo(2, P_PSTR,   P_PSTR,    P_NONE   ) },
-    { "readlink",	packinfo(3, P_PSTR,   P_PDATA,   P_USHORT ) },
-    { "umask",		packinfo(1, P_USHORT, P_NONE,    P_NONE   ) },
-    { "settimeofday",	packinfo(2, P_PDATA,  P_PDATA,   P_NONE   ) },
-    { "gettimeofday",	packinfo(2, P_PDATA,  P_PDATA,   P_NONE   ) },
-    { "select",		packinfo(5, P_SSHORT, P_PDATA,   P_PDATA  ) },
-    { "readdir",	packinfo(3, P_USHORT, P_PDATA,   P_USHORT ) },
-    { "insmod",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "fchown",		packinfo(3, P_USHORT, P_USHORT,  P_USHORT ) },
-    { "dlload",		packinfo(2, P_DATA,   P_DATA,    P_NONE   ) },
-    { "setsid",		packinfo(0, P_NONE,   P_NONE,    P_NONE   ) },
-    { "sbrk",		packinfo(1, P_SSHORT, P_NONE,    P_NONE   ) },
-    { "ustatfs",	packinfo(2, P_USHORT, P_PDATA,   P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "uname",		packinfo(1, P_PDATA,  P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "socket",		packinfo(3, P_SSHORT, P_SSHORT,  P_SSHORT ) },
-    { "",		packinfo(9, P_NONE,   P_NONE,    P_NONE   ) },
-    { "bind",		packinfo(3, P_SSHORT, P_PDATA,   P_USHORT ) },
-    { "listen",		packinfo(2, P_SSHORT, P_SSHORT,  P_NONE   ) },
-    { "accept",		packinfo(3, P_SSHORT, P_DATA,    P_PUSHORT) },
-    { "connect",	packinfo(3, P_SSHORT, P_PDATA,   P_SSHORT ) },
-    { "setsockopt",	packinfo(5, P_SSHORT, P_SSHORT,  P_SSHORT ) }, /* +2 args*/
-    { "getsocknam",	packinfo(4, P_SSHORT, P_DATA,    P_PUSHORT) }, /* +1 arg*/
-    { "fmemalloc",	packinfo(2, P_USHORT, P_PUSHORT, P_NONE)    },
+struct sc_info {
+    const char *s_name;     /* name of syscall */
+    unsigned int s_info;    /* # and type of parameters */
 };
 
-#endif
+struct sc_info elks_table1[] = {
+    ENTRY("none",           packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 0
+    ENTRY("exit",           packinfo(1, P_SSHORT, P_NONE,    P_NONE   )),
+    ENTRY("fork",           packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY("read",           packinfo(3, P_SSHORT, P_PDATA,   P_USHORT )),
+    ENTRY("write",          packinfo(3, P_SSHORT, P_PDATA,   P_USHORT )),
+    ENTRY("open",           packinfo(3, P_PSTR,   P_USHORT,  P_USHORT )),
+    ENTRY("close",          packinfo(1, P_SSHORT, P_NONE,    P_NONE   )),
+    ENTRY("wait4",          packinfo(3, P_SSHORT, P_PSSHORT, P_SSHORT )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 8 creat
+    ENTRY("link",           packinfo(2, P_PSTR,   P_PSTR,    P_NONE   )),
+    ENTRY("unlink",         packinfo(1, P_PSTR,   P_NONE,    P_NONE   )),   // 10
+    ENTRY("execve",         packinfo(3, P_PSTR,   P_PDATA,   P_USHORT )),
+    ENTRY("chdir",          packinfo(1, P_PSTR,   P_NONE,    P_NONE   )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 13 time
+    ENTRY("mknod",          packinfo(3, P_PSTR,   P_USHORT,  P_USHORT )),
+    ENTRY("chmod",          packinfo(2, P_PSTR,   P_USHORT,  P_NONE   )),
+    ENTRY("chown",          packinfo(3, P_PSTR,   P_USHORT,  P_USHORT )),
+    ENTRY("brk",            packinfo(1, P_POINTER,P_NONE,    P_NONE   )),
+    ENTRY("stat",           packinfo(2, P_PSTR,   P_PDATA,   P_NONE   )),
+    ENTRY("lseek",          packinfo(3, P_SSHORT, P_PSLONG,  P_USHORT )),
+    ENTRY("getpid",         packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 20
+    ENTRY("mount",          packinfo(3, P_PSTR,   P_PSTR,    P_PSTR   )),
+    ENTRY("umount",         packinfo(1, P_PSTR,   P_NONE,    P_NONE   )),
+    ENTRY("setuid",         packinfo(1, P_USHORT, P_NONE,    P_NONE   )),
+    ENTRY("getuid",         packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 25 stime
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 26 ptrace
+    ENTRY("alarm",          packinfo(1, P_USHORT, P_NONE,    P_NONE   )),
+    ENTRY("fstat",          packinfo(2, P_SSHORT, P_PDATA,   P_NONE   )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 29 pause
+    ENTRY("utime",          packinfo(2, P_PSTR,   P_PDATA,   P_NONE   )),   // 30
+    ENTRY("chroot",         packinfo(1, P_PSTR,   P_NONE,    P_NONE   )),
+    ENTRY("vfork",          packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY("access",         packinfo(2, P_PSTR,   P_USHORT,  P_NONE   )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 34 nice
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 35 sleep
+    ENTRY("sync",           packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY("kill",           packinfo(2, P_USHORT, P_USHORT,  P_NONE   )),
+    ENTRY("rename",         packinfo(2, P_PSTR,   P_PSTR,    P_NONE   )),
+    ENTRY("mkdir",          packinfo(2, P_PSTR,   P_USHORT,  P_NONE   )),
+    ENTRY("rmdir",          packinfo(1, P_PSTR,   P_NONE,    P_NONE   )),   // 40
+    ENTRY("dup",            packinfo(1, P_SSHORT, P_NONE,    P_NONE   )),
+    ENTRY("pipe",           packinfo(1, P_PDATA,  P_NONE,    P_NONE   )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 43 times
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 44 profil
+    ENTRY("dup2",           packinfo(2, P_SSHORT, P_USHORT,  P_NONE   )),
+    ENTRY("setgid",         packinfo(1, P_USHORT, P_NONE,    P_NONE   )),
+    ENTRY("getgid",         packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY("signal",         packinfo(2, P_USHORT, P_PDATA,   P_NONE   )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 49 getinfo
+    ENTRY("fcntl",          packinfo(3, P_SSHORT, P_USHORT,  P_USHORT )),   // 50
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 51 acct
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 52 phys
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 53 lock
+    ENTRY("ioctl",          packinfo(3, P_SSHORT, P_USHORT,  P_USHORT )),
+    ENTRY("reboot",         packinfo(3, P_USHORT, P_USHORT,  P_SSHORT )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 56 mpx
+    ENTRY("lstat",          packinfo(2, P_PSTR,   P_PDATA,   P_NONE   )),
+    ENTRY("symlink",        packinfo(2, P_PSTR,   P_PSTR,    P_NONE   )),
+    ENTRY("readlink",       packinfo(3, P_PSTR,   P_PDATA,   P_USHORT )),
+    ENTRY("umask",          packinfo(1, P_USHORT, P_NONE,    P_NONE   )),   // 60
+    ENTRY("settimeofday",   packinfo(2, P_PDATA,  P_PDATA,   P_NONE   )),
+    ENTRY("gettimeofday",   packinfo(2, P_PDATA,  P_PDATA,   P_NONE   )),
+    ENTRY("select",         packinfo(5, P_SSHORT, P_PDATA,   P_PDATA  )),
+    ENTRY("readdir",        packinfo(3, P_SSHORT, P_PDATA,   P_USHORT )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 65 insmod
+    ENTRY("fchown",         packinfo(3, P_SSHORT, P_USHORT,  P_USHORT )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),   // 67 dlload
+    ENTRY("setsid",         packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY("sbrk",           packinfo(1, P_SSHORT, P_NONE,    P_NONE   )),
+    ENTRY("ustatfs",        packinfo(2, P_USHORT, P_PDATA,   P_NONE   )),   // 70
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY("uname",          packinfo(1, P_PDATA,  P_NONE,    P_NONE   )),   // 74
+};
+
+#define START_TABLE2  198
+struct sc_info elks_table2[] = {
+    ENTRY("socket",         packinfo(3, P_SSHORT, P_SSHORT,  P_SSHORT )),   // 198
+    ENTRY(0,                packinfo(0, P_NONE,   P_NONE,    P_NONE   )),
+    ENTRY("bind",           packinfo(3, P_SSHORT, P_PDATA,   P_USHORT )),   // 200
+    ENTRY("listen",         packinfo(2, P_SSHORT, P_SSHORT,  P_NONE   )),
+    ENTRY("accept",         packinfo(3, P_SSHORT, P_DATA,    P_PUSHORT)),
+    ENTRY("connect",        packinfo(3, P_SSHORT, P_PDATA,   P_SSHORT )),
+    ENTRY("setsockopt",     packinfo(5, P_SSHORT, P_SSHORT,  P_SSHORT )), /* +2 args*/
+    ENTRY("getsocknam",     packinfo(4, P_SSHORT, P_DATA,    P_PUSHORT)), /* +1 arg*/
+    ENTRY("fmemalloc",      packinfo(2, P_USHORT, P_PUSHORT, P_NONE)   ),   // 206
+};

--- a/tlvc/arch/i86/mm/malloc.c
+++ b/tlvc/arch/i86/mm/malloc.c
@@ -322,16 +322,10 @@ again:
 	}
 }
 
-
-// Initialize the memory manager.
-
-void INITPROC mm_init(seg_t start, seg_t end)
+void INITPROC seg_add(seg_t start, seg_t end)
 {
-	list_init (&_seg_all);
-	list_init (&_seg_free);
-
 	segment_s * seg = (segment_s *) heap_alloc (sizeof (segment_s), HEAP_TAG_SEG);
-	if (seg) {
+	if(seg) {
 		seg->base = start;
 		seg->size = end - start;
 		seg->flags = SEG_FLAG_FREE;
@@ -341,4 +335,14 @@ void INITPROC mm_init(seg_t start, seg_t end)
 		list_insert_before (&_seg_all, &(seg->all));  // add tail
 		list_insert_before (&_seg_free, &(seg->free));  // add tail
 	}
+}
+
+// Initialize the memory manager.
+
+void INITPROC mm_init(seg_t start, seg_t end)
+{
+	list_init (&_seg_all);
+	list_init (&_seg_free);
+
+	seg_add(start, end);
 }

--- a/tlvc/arch/i86/mm/xms.c
+++ b/tlvc/arch/i86/mm/xms.c
@@ -146,6 +146,24 @@ void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
 	fmemcpyb(dst_off, (seg_t)dst_seg, src_off, (seg_t)src_seg, count);
 }
 
+/* memset XMS or far memory, INT 15 not yet supported */
+void xms_fmemset(void *dst_off, ramdesc_t dst_seg, byte_t val, size_t count)
+{
+	int	need_xms_dst = dst_seg >> 16;
+
+	if (need_xms_dst) {
+		if (!xms_enabled) panic("xms_fmemset");
+
+#ifdef CONFIG_FS_XMS_INT15
+		panic("xms_fmemset int15");
+#else
+		linear32_fmemset(dst_off, dst_seg, val, count);
+#endif
+		return;
+	}
+	fmemsetb(dst_off, (seg_t)dst_seg, val, count);
+}
+
 #ifdef CONFIG_FS_XMS_INT15
 struct gdt_table {
 	word_t	limit_15_0;

--- a/tlvc/config.in
+++ b/tlvc/config.in
@@ -54,7 +54,7 @@ mainmenu_option next_comment
 	bool 'Calculate process CPU usage'        CONFIG_CPU_USAGE    y
 	bool 'Real time clock in localtime'       CONFIG_TIME_RTC_LOCALTIME n
 	string 'Compiled-in TZ= timezone string'  CONFIG_TIME_TZ      ''
-	bool 'System Trace'                       CONFIG_STRACE       n
+	bool 'Enable tracing (set on for development)' CONFIG_TRACE   n
 	bool 'Use INT 0Fh in idle loop for timer' CONFIG_TIMER_INT0F  n
 	bool 'Use INT 1Ch from BIOS for timer'    CONFIG_TIMER_INT1C  n
 

--- a/tlvc/elks-small.ld
+++ b/tlvc/elks-small.ld
@@ -6,6 +6,7 @@ SECTIONS {
 		KEEP (*(".inithead!"))
 		KEEP (*(SORT (".preinit!*") SORT (".preinit.*!")))
 		KEEP (*(SORT (".init!*") SORT (".init.*!")))
+		KEEP (*(SORT (".postinit!*") SORT (".postinit.*!")))
 		KEEP (*(".inittail!"))
 		*(".text!*" ".text.*!")
 		KEEP (*(".finihead!"))
@@ -16,6 +17,7 @@ SECTIONS {
 		KEEP (*(.inithead .inithead$))
 		KEEP (*(.preinit SORT (.preinit$*) SORT (".preinit.*[^&]")))
 		KEEP (*(.init SORT (.init$*) SORT (".init.*[^&]")))
+		KEEP (*(.postinit SORT (.postinit$*) SORT (".postinit.*[^&]")))
 		KEEP (*(.inittail .inittail$))
 		*(.text .text$* ".text.*[^&]")
 		KEEP (*(.finihead .finihead$))
@@ -26,6 +28,7 @@ SECTIONS {
 		KEEP (*(".inithead&"))
 		KEEP (*(SORT (".preinit&*") SORT (".preinit.*&")))
 		KEEP (*(SORT (".init&*") SORT (".init.*&")))
+		KEEP (*(SORT (".postinit&*") SORT (".postinit.*&")))
 		KEEP (*(".inittail&"))
 		*(".text&*" ".text.*&")
 		KEEP (*(".finihead&"))
@@ -44,9 +47,17 @@ SECTIONS {
 		 * IA-16 segment start markers.
 		 */
 		*(".fartext!*" ".fartext.*!")
+		"__start_fartext_init!" = .;
+		"__end_fartext_init!" = .;
 
 		/* Actual segment contents. */
-		*(.fartext .fartext$* ".fartext.*[^&]")
+		/* *(.fartext .fartext$* ".fartext.*[^&]") */
+
+		*(.fartext .fartext.
+		".fartext.[^i]*" ".fartext.i[^n]*" ".fartext.in[^i]*" ".fartext.ini[^t]*")
+		 __start_fartext_init = .;
+		*(.fartext .fartext.init)
+		__end_fartext_init = .;
 
 		/* IA-16 segment end markers. */
 		*(".fartext&*" ".fartext.*&")

--- a/tlvc/fs/buffer.c
+++ b/tlvc/fs/buffer.c
@@ -6,8 +6,11 @@
 #include <linuxmt/string.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/heap.h>
+#include <linuxmt/config.h>
+#include <linuxmt/limits.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/debug.h>
+#include <linuxmt/trace.h>
 
 #include <arch/system.h>
 #include <arch/segment.h>
@@ -18,15 +21,17 @@
  * Kernel buffer management.
  */
 
-/* Number of internal L1 buffers,
-   used to map/copy external L2 buffers to/from kernel data segment */
-#ifdef CONFIG_FS_FAT
-#define NR_MAPBUFS  12
-#else
-#define NR_MAPBUFS  8
-#endif
+/* Number of internal L1 buffers/cache blocks,
+ * either used as the system buffer pool (no L2) or
+ * to map/copy external L2 buffers to/from kernel data segment,
+ * default is 12, may be overridden by 'cache=' in /bootopts. */
+int nr_mapbufs = 12;
+#define MAX_NR_MAPBUFS 24
 
-int boot_bufs;		/* /bootopts # buffers override */
+/* The L1 buffers/cache is allocated from heap later. */
+static unsigned char *L1buf;
+
+int L2_bufs;		/* /bootopts # buffers override */
 
 /* Buffer heads: local heap allocated */
 static struct buffer_head *buffer_heads;
@@ -44,15 +49,12 @@ ext_buffer_head *EBH(struct buffer_head *bh)
 /* functions for buffer_head points called outside of buffer.c */
 void mark_buffer_dirty(struct buffer_head *bh)     { EBH(bh)->b_dirty = 1; }
 void mark_buffer_clean(struct buffer_head *bh)     { EBH(bh)->b_dirty = 0; }
-ramdesc_t buffer_seg(struct buffer_head *bh)       { return EBH(bh)->b_seg; }
 unsigned char buffer_count(struct buffer_head *bh) { return EBH(bh)->b_count; }
 block32_t buffer_blocknr(struct buffer_head *bh)   { return EBH(bh)->b_blocknr; }
 kdev_t buffer_dev(struct buffer_head *bh)          { return EBH(bh)->b_dev; }
 
 #endif /* CONFIG_FAR_BUFHEADS */
 
-/* Internal L1 buffers, must be kernel DS addressable */
-static char L1buf[NR_MAPBUFS][BLOCK_SIZE];
 
 /* Buffer cache */
 static struct buffer_head *bh_lru;
@@ -71,23 +73,24 @@ static struct buffer_head *bh_next;
  * Number of extended/xms  (L2) buffers specified in config by CONFIG_FS_NR_XMS_BUFFERS
  */
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
-static struct buffer_head *L1map[NR_MAPBUFS];	/* L1 indexed pointer to L2 buffer */
+static struct buffer_head *L1map[MAX_NR_MAPBUFS]; /* L1 indexed pointer to L2 buffer */
 static struct wait_queue L1wait;		/* Wait for a free L1 buffer area */
 static int lastL1map;
 #endif
+static struct wait_queue bufwait;		/* Wait for buffers to become available */
 
-/* Uncomment next line to debug free buffer_head count */
-/*#define DEBUG_FREE_BH_COUNT */
+static int xms_enabled;
+static unsigned int map_count, remap_count, unmap_count;
 
-#ifdef DEBUG_FREE_BH_COUNT
-static int nr_free_bh = NR_BUFFERS;
+#ifdef CHECK_FREECNTS
+static int nr_free_bh, nr_bh;
+
 #define DCR_COUNT(bh) if(!(--bh->b_count))nr_free_bh++
 #define INR_COUNT(bh) if(!(bh->b_count++))nr_free_bh--
 #define CLR_COUNT(bh) if(bh->b_count)nr_free_bh++
-#define SET_COUNT(bh) if(--nr_free_bh < 0) { \
-	printk("VFS: get_free_buffer: bad free buffer head count.\n"); \
-	nr_free_bh = 0; }
+#define SET_COUNT(bh) if(--nr_free_bh < 0) { panic("VFS: get_free_buffer: bad free buffer head count.\n"); }
 #else
+
 #define DCR_COUNT(bh) (bh->b_count--)
 #define INR_COUNT(bh) (bh->b_count++)
 #define CLR_COUNT(bh)
@@ -96,17 +99,90 @@ static int nr_free_bh = NR_BUFFERS;
 
 #define buf_num(bh)	((bh) - buffer_heads)	/* buffer number, for debugging */
 
+#if defined(CHECK_FREECNTS) && DEBUG_EVENT
+void list_buffer_status(void)
+{
+    int i = 1;
+    int inuse = 0;
+    int isinuse, j;
+    struct buffer_head *bh = bh_llru;
+    ext_buffer_head *ebh;
+
+    printk("\n  #    buf/bh   blk/dev  flgs L1map Mcnt Bcnt\n");
+    do {
+        ebh = EBH(bh);
+        isinuse = ebh->b_count || ebh->b_dirty || ebh->b_locked 
+#ifdef CONFIG_FS_EXTERNAL_BUFFER
+		|| ebh->b_mapcount
+#endif
+		;
+        if (isinuse || bh->b_data) {
+            j = 0;
+#ifdef CONFIG_FS_EXTERNAL_BUFFER
+            if (bh->b_data) {
+                for (; j<nr_mapbufs; j++) {
+                    if (L1map[j] == bh) {
+                        j++;
+                        break;
+                    }
+                }
+            }
+            printk("%3d: %3d/%04x %5ld/%04x %c%c%c   L%02d    %d   %d\n",
+                i, buf_num(bh), bh, ebh->b_blocknr, ebh->b_dev,
+                ebh->b_locked ? 'L':' ', ebh->b_dirty ? 'D':' ', ebh->b_uptodate ? 'U' : ' ',
+                j, ebh->b_mapcount , ebh->b_count);
+	    //if (ebh->b_blocknr == 1) printk("b_data %04x b_L2data %04x\n", bh->b_data, ebh->b_L2data);
+#else
+            printk("%3d: %3d/%04x %5ld/%04x %c%c%c         %d   %d\n",
+                i, buf_num(bh), bh, ebh->b_blocknr, ebh->b_dev,
+                ebh->b_locked ? 'L':' ', ebh->b_dirty ? 'D':' ', ebh->b_uptodate ? 'U' : ' ',
+                j, ebh->b_count);
+#endif
+        }
+        i++;
+        if (isinuse) inuse++;
+    } while ((bh = ebh->b_prev_lru) != NULL);
+#ifdef CONFIG_FS_EXTERNAL_BUFFER
+    printk("Total L2 buffers inuse %d/%d (%d free), %dk L1 (map %u unmap %u remap %u)\n",
+	inuse, nr_bh, nr_free_bh, nr_mapbufs, map_count, unmap_count, remap_count);
+#else
+    printk("Total buffers inuse %d/%d\n",
+	inuse, nr_bh);
+#endif
+}
+
+#if UNUSED
+static void dump_buffer(struct buffer_head *bh, int count) {
+	int i;
+
+	if (bh) {
+		for (i = 0; i < count; i += 2) {
+			if (!i%16) printk("\n");
+			printk("%04x ",  *(unsigned int *)(buffer_data(bh) + i));
+		}
+	} else printk("dump_buf: bh zero\n");
+	printk("\n");
+}
+#endif
+#endif
+
+/*
+ * Put buffer at the end of the list. 
+ */
 static void put_last_lru(struct buffer_head *bh)
 {
     ext_buffer_head *ebh = EBH(bh);
+    flag_t flags;
 
+    save_flags(flags);	/* EXPERIMENTAL */
+    clr_irq();
     if (bh_llru != bh) {
 	struct buffer_head *bhn = ebh->b_next_lru;
 	ext_buffer_head *ebhn = EBH(bhn);
 
-	if ((ebhn->b_prev_lru = ebh->b_prev_lru))	/* Unhook */
+	if ((ebhn->b_prev_lru = ebh->b_prev_lru))	/* Either unhook */
 	    EBH(ebh->b_prev_lru)->b_next_lru = bhn;
-	else					/* Alter head */
+	else					/* .. or alter head */
 	    bh_lru = bhn;
 	/*
 	 *      Put on lru end
@@ -115,12 +191,14 @@ static void put_last_lru(struct buffer_head *bh)
 	EBH(ebh->b_prev_lru = bh_llru)->b_next_lru = bh;
 	bh_llru = bh;
     }
+    restore_flags(flags);
 }
 
-static void add_buffers(int nbufs, char *buf, ramdesc_t seg)
+static void INITPROC add_buffers(int nbufs, unsigned char *buf, ramdesc_t seg)
 {
     struct buffer_head *bh;
     int n = 0;
+    size_t offset;
 
     for (bh = bh_next; n < nbufs; n++, bh = ++bh_next) {
 	ext_buffer_head *ebh = EBH(bh);
@@ -131,14 +209,13 @@ static void add_buffers(int nbufs, char *buf, ramdesc_t seg)
 	}
 
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
-	ebh->b_seg = ebh->b_ds = seg;
-	//bh->b_mapcount = 0;
-	//bh->b_data = (char *)0;	/* not in L1 cache*/
-	ebh->b_L2data = (unsigned char *)((n & 63) << BLOCK_SIZE_BITS);	/* L2 offset*/
+	/* segment adjusted to require no offset to buffer */
+	offset = xms_enabled? ((n & 63) << BLOCK_SIZE_BITS) :
+			      ((n & 63) << (BLOCK_SIZE_BITS - 4));
+	ebh->b_L2seg = seg + offset;
 #else
 	bh->b_data = buf;
 	buf += BLOCK_SIZE;
-	ebh->b_seg = seg;
 #endif
     }
 }
@@ -148,26 +225,38 @@ int INITPROC buffer_init(void)
     /* XMS buffers override EXT buffers override internal buffers*/
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
     int bufs_to_alloc = CONFIG_FS_NR_EXT_BUFFERS;
-    int xms_enabled = 0;
 
 #ifdef CONFIG_FS_XMS_BUFFER
     xms_enabled = xms_init();	/* try to enable unreal mode and A20 gate*/
     if (xms_enabled)
 	bufs_to_alloc = CONFIG_FS_NR_XMS_BUFFERS;
 #endif
-    if (boot_bufs)
-	bufs_to_alloc = boot_bufs;
+    if (L2_bufs)
+	bufs_to_alloc = L2_bufs;
 #ifdef CONFIG_FAR_BUFHEADS
-    if (bufs_to_alloc > 2500) bufs_to_alloc = 2500; /* max 64K far bufheads @26 bytes*/
+    /* FIXME: update max # after reducing the buffer_head struct size */
+    if (bufs_to_alloc > 2975) bufs_to_alloc = 2975; /* max 64K far bufheads @22 bytes*/
 #else
-    if (bufs_to_alloc > 256) bufs_to_alloc = 256; /* protect against high XMS value*/
+    if (bufs_to_alloc > 256) bufs_to_alloc = 64; /* high value likely set for XMS buffers,
+						  * set to something that's likely to work */
 #endif
 
-    printk("%d %s buffers, %ld ram\n", bufs_to_alloc, xms_enabled? "xms": "ext",
+    printk("%d %s buffers (%ldB ram), ", bufs_to_alloc, xms_enabled? "xms": "ext",
 		(long)bufs_to_alloc << 10);
 #else
-    int bufs_to_alloc = NR_MAPBUFS;
+    int bufs_to_alloc = nr_mapbufs;
 #endif
+    printk("%d L1 buffers, %uB ram\n", nr_mapbufs, nr_mapbufs<<10);
+    if (nr_mapbufs > bufs_to_alloc)
+	printk("WARNING: # of L2 buffers is lower than the L1 cache!\n");
+
+    nr_bh = nr_free_bh = bufs_to_alloc;
+#ifdef CHECK_FREECNTS
+    debug_setcallback(1, list_buffer_status);   /* ^O will generate buffer list */
+#endif
+
+    if (!(L1buf = heap_alloc(nr_mapbufs * BLOCK_SIZE, HEAP_TAG_BUFHEAD|HEAP_TAG_CLEAR)))
+        return 1;
 
     buffer_heads = heap_alloc(bufs_to_alloc * sizeof(struct buffer_head),
 	HEAP_TAG_BUFHEAD|HEAP_TAG_CLEAR);
@@ -204,7 +293,7 @@ int INITPROC buffer_init(void)
     } while (bufs_to_alloc > 0);
 #else
     /* no EXT or XMS buffers, internal L1 only */
-    add_buffers(NR_MAPBUFS, (char *)L1buf, kernel_ds);
+    add_buffers(nr_mapbufs, L1buf, kernel_ds);
 #endif
     return 0;
 }
@@ -217,11 +306,23 @@ void wait_on_buffer(struct buffer_head *bh)
 {
     ext_buffer_head *ebh = EBH(bh);
 
-    while (ebh->b_locked) {
-	INR_COUNT(ebh);
-	sleep_on((struct wait_queue *)bh);	/* use bh as wait address*/
-	DCR_COUNT(ebh);
+    ebh->b_count++;
+    wait_set((struct wait_queue *)bh);       /* use bh as wait address */
+    for (;;) {
+
+        current->state = TASK_UNINTERRUPTIBLE;
+        if (!ebh->b_locked)
+            break;
+        schedule();
     }
+
+    wait_clear((struct wait_queue *)bh);
+    current->state = TASK_RUNNING;
+    ebh->b_count--;
+
+#ifdef CHECK_BLOCKIO
+    if (EBH(bh)->b_locked) panic("wait_on_buffer");
+#endif
 }
 
 void lock_buffer(struct buffer_head *bh)
@@ -234,6 +335,9 @@ void unlock_buffer(struct buffer_head *bh)
 {
     EBH(bh)->b_locked = 0;
     wake_up((struct wait_queue *)bh);	/* use bh as wait address*/
+	//FIXME: Check if this one is useful at all or if the one in brelse is enough.
+	// ALSO, if we want to use schedule() instead of sleep/wait on this one.
+    wake_up(&bufwait);	/* If we ran out of buffers, get_free_buffers is waiting */
 }
 
 void invalidate_buffers(kdev_t dev)
@@ -246,17 +350,27 @@ void invalidate_buffers(kdev_t dev)
 
 	if (ebh->b_dev != dev) continue;
 	wait_on_buffer(bh);
-	if (ebh->b_count) continue;
+        if (ebh->b_count) {
+            printk("invalidate_buffers: skipping active block %ld\n", ebh->b_blocknr); /*DEBUG*/
+            continue;
+        }
+	debug_blk("invalidating blk %ld\n", ebh->b_blocknr);
 	ebh->b_uptodate = 0;
-	ebh->b_dirty = 0;
+	mark_buffer_clean(bh);
+	brelseL1(bh, 0);        /* release buffer from L1 if present */
 	unlock_buffer(bh);
     } while ((bh = ebh->b_prev_lru) != NULL);
 }
 
 static void sync_buffers(kdev_t dev, int wait)
 {
-    struct buffer_head *bh = bh_llru;
+    struct buffer_head *bh = bh_lru;
     ext_buffer_head *ebh;
+
+#ifdef CHECK_FREECNTS
+    list_buffer_status();
+#endif
+    debug_blk("sync_buffers dev %p wait %d\n", dev, wait);
 
     do {
 	ebh = EBH(bh);
@@ -268,12 +382,14 @@ static void sync_buffers(kdev_t dev, int wait)
 	   continue;
 
 	/*
-	 *      Locked buffers..
-	 *
 	 *      If buffer is locked; skip it unless wait is requested
 	 *      AND pass > 0.
 	 */
+
 	if (ebh->b_locked) {
+            debug_blk("SYNC: dev %x buf %d block %ld LOCKED mapped %d skipped %d data %04x\n",
+                ebh->b_dev, buf_num(bh), ebh->b_blocknr, ebh->b_mapcount, !wait,
+                bh->b_data);
 	    if (!wait) continue;
 	    wait_on_buffer(bh);
 	}
@@ -281,32 +397,74 @@ static void sync_buffers(kdev_t dev, int wait)
 	/*
 	 *      Do the stuff
 	 */
-	INR_COUNT(ebh);
+	ebh->b_count++;
 	ll_rw_blk(WRITE, bh);
-	DCR_COUNT(ebh);
-    } while ((bh = ebh->b_prev_lru) != NULL);
+	ebh->b_count--;
+    } while ((bh = ebh->b_next_lru) != NULL);
 }
 
+/*
+ * find an available buffer
+ */
 struct buffer_head *get_free_buffer(void)
 {
     struct buffer_head *bh = bh_lru;
     ext_buffer_head *ebh = EBH(bh);
+    int i, sync_loop = 0;
 
+	//printk("lru:%04x/%d|", bh, ebh->b_dirty);
     while (ebh->b_count || ebh->b_dirty || ebh->b_locked
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
 		|| bh->b_data
 #endif
 								) {
 	if ((bh = ebh->b_next_lru) == NULL) {
-	    sync_buffers(0, 0);
-	    bh = bh_lru;
-	}
+	    unsigned long jif = jiffies;
+	    switch (sync_loop) {
+	    case 0:
+		printk("DEBUG: no free bufs, syncing\n"); /* FIXME delete */
+		sync_buffers(0,0);
+		break;
+
+#if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
+	    case 1:
+	    /*
+	     * Skip if we're running with L1 buffers only.
+	     * (in which case brelseL1_index() is a dummy anyway)
+	     */ 
+		printk("RelL1:");
+		for (i=0; i<nr_mapbufs; i++)
+			brelseL1_index(i, 1);
+		printk("\n");
+		break;
+#endif
+
+	    case 2:	/* EXPERIMENTAL: This may not make much sense */
+		printk("SyncWait;");
+		sync_buffers(0, 1);	/* sync w/ wait */
+		break;
+
+	    default:
+		/* we're out of buffers - which happens quite a bit when using floppy
+		 * based file systems: Sleep instead of looping.
+		 */
+		sleep_on(&bufwait);
+		printk("Bufwait %d [%lu] jiffies;", sync_loop, jiffies-jif);
+	    }
+	    bh = bh_lru;	/* start over */
+	    sync_loop++;
+	}	
 	ebh = EBH(bh);
     }
+#ifdef CHECK_BLOCKIO
+    if (ebh->b_mapcount) panic("get_free_buffer"); /* mapped buffer reallocated */
+#endif
     put_last_lru(bh);
     ebh->b_uptodate = 0;
     ebh->b_count = 1;
     SET_COUNT(ebh);
+    //if (sync_loop)
+	//printk("GFB:%04x/%04x\n", bh, *(unsigned int *)bh->b_data);
     return bh;
 }
 
@@ -314,23 +472,21 @@ struct buffer_head *get_free_buffer(void)
  * Release a buffer head
  */
 
-static void __brelse(struct buffer_head *bh)
-{
-    ext_buffer_head *ebh = EBH(bh);
-
-    wait_on_buffer(bh);
-    if (ebh->b_count == 0) panic("brelse");
-#if 0
-    if (!--ebh->b_count)
-	wake_up(&bufwait);
-#else
-    DCR_COUNT(ebh);
-#endif
-}
-
 void brelse(struct buffer_head *bh)
 {
-    if (bh) __brelse(bh);
+    ext_buffer_head *ebh;
+
+    if (!bh) return;
+    wait_on_buffer(bh);
+    ebh = EBH(bh);
+#ifdef CHECK_BLOCKIO
+    if (ebh->b_count == 0) panic("brelse");
+#endif
+    DCR_COUNT(ebh);
+//#ifdef BLOAT_FS
+    if (!ebh->b_count)
+	wake_up(&bufwait);	/* EXPERIMENTAL, probably superfluous */
+//#endif
 }
 
 /*
@@ -343,7 +499,7 @@ void __bforget(struct buffer_head *bh)
     ext_buffer_head *ebh = EBH(bh);
 
     wait_on_buffer(bh);
-    ebh->b_dirty = 0;
+    mark_buffer_clean(bh);
     DCR_COUNT(ebh);
     ebh->b_dev = NODEV;
     wake_up(&bufwait);
@@ -357,6 +513,7 @@ struct buffer_head *readbuf(struct buffer_head *bh)
 {
     ext_buffer_head *ebh = EBH(bh);
 
+	//printk("readbuf %04x/%04x;", bh, bh->b_dev);
     if (!ebh->b_uptodate) {
 	ll_rw_blk(READ, bh);
 	wait_on_buffer(bh);
@@ -365,6 +522,7 @@ struct buffer_head *readbuf(struct buffer_head *bh)
 	    bh = NULL;
 	}
     }
+    //dump_buffer(bh, 64);
     return bh;
 }
 
@@ -433,15 +591,13 @@ struct buffer_head *getblk32(kdev_t dev, block32_t block)
 	if ((bh = find_buffer(dev, block)) != NULL) goto found_it;
     } while (n_bh == NULL);
     bh = n_bh;				/* Block not found, use the new buffer */
+
 /* OK, FINALLY we know that this buffer is the only one of its kind,
  * and that it's unused (b_count=0), unlocked (b_locked=0), and clean
  */
     ebh = EBH(bh);
     ebh->b_dev = dev;
     ebh->b_blocknr = block;
-#if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
-    ebh->b_seg = bh->b_data? kernel_ds: ebh->b_ds;
-#endif
     goto return_it;
 
   found_it:
@@ -458,6 +614,7 @@ struct buffer_head *getblk32(kdev_t dev, block32_t block)
 	put_last_lru(bh);
 
   return_it:
+    //printk("getblk %04x %lu\n", dev, block);
     return bh;
 }
 
@@ -549,7 +706,31 @@ int sys_sync(void)
     return 0;
 }
 
+
+/* clear a buffer area to zeros, used to avoid slow map to L1 if possible */
+void zero_buffer(struct buffer_head *bh, size_t offset, int count)
+{
+#if defined(CONFIG_FS_XMS_INT15) || (!defined(CONFIG_FS_EXTERNAL_BUFFER) && !defined(CONFIG_FS_XMS_BUFFER))
+#define FORCEMAP 1
+#else
+#define FORCEMAP 0
+#endif
+    /* xms int15 doesn't support a memset function, so map into L1 */
+    if (FORCEMAP || bh->b_data) {
+        map_buffer(bh);
+        memset(bh->b_data + offset, 0, count);
+        unmap_buffer(bh);
+    }
+#if !FORCEMAP
+    else {
+        ext_buffer_head *ebh = EBH(bh);
+        xms_fmemset((char *)offset, ebh->b_L2seg, 0, count);
+    }
+#endif
+}
+
 #if defined(CONFIG_FS_EXTERNAL_BUFFER) || defined(CONFIG_FS_XMS_BUFFER)
+
 /* map_buffer copies a buffer into L1 buffer space. It will freeze forever
  * before failing, so it can return void.  This is mostly 8086 dependant,
  * although the interface is not.
@@ -559,20 +740,26 @@ void map_buffer(struct buffer_head *bh)
     ext_buffer_head *ebh = EBH(bh);
     int i;
 
+    /* Just in case we're in a middle of some IO */
+    wait_on_buffer(bh);
+
     /* If buffer is already mapped, just increase the refcount and return */
-    if (bh->b_data /*|| ebh->b_seg != kernel_ds*/) {
+    if (bh->b_data) {
 	if (!ebh->b_mapcount)
 	    debug("REMAP: %d\n", buf_num(bh));
+	//printk("RM%d;", buf_num(bh));
+	remap_count++;
 	goto end_map_buffer;
     }
 
+    //printk("MB:%x/", buf_num(bh));
     i = lastL1map;
     /* search for free L1 buffer or wait until one is available*/
     for (;;) {
 	struct buffer_head *bmap;
 	ext_buffer_head *ebmap;
 
-	if (++i >= NR_MAPBUFS) i = 0;
+	if (++i >= nr_mapbufs) i = 0;
 	debug("map:   %d try %d\n", buf_num(bh), i);
 
 	/* First check for the trivial case, to avoid dereferencing a null pointer */
@@ -581,15 +768,15 @@ void map_buffer(struct buffer_head *bh)
 	ebmap = EBH(bmap);
 
 	/* L1 with zero count can be unmapped and reused for this request*/
+#ifdef CHECK_BLOCKIO
 	if (ebmap->b_mapcount < 0)
 		printk("map_buffer: %d BAD mapcount %d\n", buf_num(bmap), ebmap->b_mapcount);
-	if (!ebmap->b_mapcount) {
+#endif
+	/* don't remap if I/O in progress to prevent bh/req buffer unpairing */
+	if (!ebmap->b_mapcount && !ebmap->b_locked) {
 	    debug("UNMAP: %d <- %d\n", buf_num(bmap), i);
-
-	    /* Unmap/copy L1 to L2 */
-	    xms_fmemcpyw(ebmap->b_L2data, ebmap->b_ds, bmap->b_data, kernel_ds, BLOCK_SIZE/2);
-	    bmap->b_data = (unsigned char *)0;
-	    ebmap->b_seg = ebmap->b_ds;
+	    //printk("F_UNMAP %x;", buf_num(bmap));
+	    brelseL1_index(i, 1);       /* Unmap/copy L1 to L2 */
 	    break;		/* success */
 	}
 	if (i == lastL1map) {
@@ -602,12 +789,14 @@ void map_buffer(struct buffer_head *bh)
     /* Map/copy L2 to L1 */
     lastL1map = i;
     L1map[i] = bh;
-    bh->b_data = (unsigned char *)L1buf + (i << BLOCK_SIZE_BITS);
+    bh->b_data = L1buf + (i << BLOCK_SIZE_BITS);
     if (ebh->b_uptodate)
-	xms_fmemcpyw(bh->b_data, kernel_ds, ebh->b_L2data, ebh->b_ds, BLOCK_SIZE/2);
+	xms_fmemcpyw(bh->b_data, kernel_ds, 0, ebh->b_L2seg, BLOCK_SIZE/2);
     debug("MAP:   %d -> %d\n", buf_num(bh), i);
+    //printk("MAP:   %d -> %d\n", buf_num(bh), i);
+    //printk("%x/%04x;", bh->b_data, (word_t)*bh->b_data);
+    map_count++;
   end_map_buffer:
-    ebh->b_seg = kernel_ds;
     ebh->b_mapcount++;
 }
 
@@ -621,10 +810,14 @@ void unmap_buffer(struct buffer_head *bh)
     if (bh) {
 	ext_buffer_head *ebh = EBH(bh);
 
+	//printk("UB:%d/%d;", buf_num(bh), ebh->b_mapcount);
+#ifdef CHECK_BLOCKIO
 	if (ebh->b_mapcount <= 0) {
 	    printk("unmap_buffer: %d BAD mapcount %d\n", buf_num(bh), ebh->b_mapcount);
 	    ebh->b_mapcount = 0;
-	} else if (--ebh->b_mapcount == 0) {
+	} else
+#endif
+	if (--ebh->b_mapcount == 0) {
 	    debug("unmap: %d\n", buf_num(bh));
 	    wake_up(&L1wait);
 	} else
@@ -636,12 +829,51 @@ void unmap_brelse(struct buffer_head *bh)
 {
     if (bh) {
 	unmap_buffer(bh);
-	__brelse(bh);
+	brelse(bh);
     }
+}
+
+/* release L1 buffer by index with optional copyout */
+void brelseL1_index(int i, int copyout)
+{
+    struct buffer_head *bh = L1map[i];
+    ext_buffer_head *ebh;
+
+    if (!bh) return;
+    ebh = EBH(bh);
+    if (ebh->b_mapcount || ebh->b_locked)
+        return;
+    if (copyout && ebh->b_uptodate && bh->b_data) {
+        xms_fmemcpyw(0, ebh->b_L2seg, bh->b_data, kernel_ds, BLOCK_SIZE/2);
+	unmap_count++;
+    }
+    bh->b_data = 0;
+    //printk("RelL1:%d;", i);
+    L1map[i] = 0;
+}
+
+/* release L1 buffer by buffer head with optional copyout */
+void brelseL1(struct buffer_head *bh, int copyout)
+{
+    int i;
+
+    if (!bh) return;
+    for (i = 0; i < nr_mapbufs; i++) {
+        if (L1map[i] == bh) {
+            brelseL1_index(i, copyout);
+            break;
+        }
+    }
+}
+
+ramdesc_t buffer_seg(struct buffer_head *bh)
+{
+    return (bh->b_data? kernel_ds: EBH(bh)->b_L2seg);
 }
 
 unsigned char *buffer_data(struct buffer_head *bh)
 {
-    return (bh->b_data? bh->b_data: EBH(bh)->b_L2data);
+    return (bh->b_data? bh->b_data: 0);	/* L2 addresses now always @ offset 0 */
 }
-#endif /* CONFIG_FS_EXTERNAL_BUFFER | CONFIG_FS_XMS_BUFFER*/
+
+#endif /* CONFIG_FS_EXTERNAL_BUFFER || CONFIG_FS_XMS_BUFFER */

--- a/tlvc/fs/devices.c
+++ b/tlvc/fs/devices.c
@@ -140,9 +140,7 @@ struct inode_operations blkdev_inode_operations = {
     NULL,			/* mknod */
     NULL,			/* readlink */
     NULL,			/* follow_link */
-#ifdef USE_GETBLK
     NULL,			/* getblk */
-#endif
     NULL			/* truncate */
 };
 
@@ -190,9 +188,7 @@ struct inode_operations chrdev_inode_operations = {
     NULL,			/* mknod */
     NULL,			/* readlink */
     NULL,			/* follow_link */
-#ifdef USE_GETBLK
     NULL,			/* getblk */
-#endif
     NULL			/* truncate */
 };
 

--- a/tlvc/fs/file_table.c
+++ b/tlvc/fs/file_table.c
@@ -8,6 +8,7 @@
 #include <linuxmt/config.h>
 #include <linuxmt/fs.h>
 #include <linuxmt/fcntl.h>
+#include <linuxmt/limits.h>
 #include <linuxmt/stat.h>
 #include <linuxmt/string.h>
 #include <linuxmt/mm.h>

--- a/tlvc/fs/inode.c
+++ b/tlvc/fs/inode.c
@@ -15,6 +15,7 @@
 #include <linuxmt/kdev_t.h>
 #include <linuxmt/wait.h>
 #include <linuxmt/debug.h>
+#include <linuxmt/trace.h>
 
 #include <arch/system.h>
 
@@ -23,18 +24,12 @@ static struct inode *inode_lru = inode_block;
 static struct inode *inode_llru = inode_block;
 static struct wait_queue inode_wait;
 
-/* Uncomment next line to debug free inodes count */
-/*#define DEBUG_FREE_INODES_COUNT */
-
-#ifdef DEBUG_FREE_INODES_COUNT
+#ifdef CHECK_FREECNTS
 static int nr_free_inodes = NR_INODE;
 #define DCR_COUNT(i) if(!(--i->i_count))nr_free_inodes++
 #define INR_COUNT(i) if(!(i->i_count++))nr_free_inodes--
 #define CLR_COUNT(i) if(i->i_count)nr_free_inodes++
-#define SET_COUNT(i) if(--nr_free_inodes < 0) { \
-	printk("VFS: get_empty_inode: bad free inode count.\n"); \
-	nr_free_inodes = 0; \
-    }
+#define SET_COUNT(i) if(--nr_free_inodes < 0) { panic("get_empty_inode: bad free count"); }
 #else
 #define DCR_COUNT(i) (i->i_count--)
 #define INR_COUNT(i) (i->i_count++)
@@ -74,10 +69,30 @@ void clear_inode(register struct inode *inode) /* and put_first_lru() */
     remove_inode_free(inode);
     CLR_COUNT(inode);
     memset(inode, 0, sizeof(struct inode));
-    inode->i_prev = NULL;
+    //inode->i_prev = NULL;
     (inode->i_next = inode_lru)->i_prev = inode;
     inode_lru = inode;
 }
+
+#if defined(CHECK_FREECNTS) && DEBUG_EVENT
+static void list_inode_status(void)
+{
+    int i = 1;
+    int inuse = 0;
+    struct inode *inode = inode_llru;
+
+    do {
+        if (inode->i_count || inode->i_dev || inode->i_dirt) {
+            printk("\n#%2d: dev %D inode %5lu dirty %d count %u", i, inode->i_dev,
+                (unsigned long)inode->i_ino, inode->i_dirt, inode->i_count);
+        }
+        i++;
+        if (inode->i_count) inuse++;
+    } while ((inode = inode->i_prev) != NULL);
+    printk("\nTotal inodes inuse %d/%d (%d free)\n", inuse, NR_INODE, nr_free_inodes);
+
+}
+#endif
 
 void INITPROC inode_init(void)
 {
@@ -87,6 +102,9 @@ void INITPROC inode_init(void)
 	inode->i_next = inode->i_prev = inode;
 	put_last_lru(inode);
     } while (++inode < &inode_block[NR_INODE]);
+#ifdef CHECK_FREECNTS
+    debug_setcallback(0, list_inode_status);    /* ^N will generate inode list */
+#endif
 }
 
 /*
@@ -99,9 +117,9 @@ void INITPROC inode_init(void)
 static void wait_on_inode(register struct inode *inode)
 {
     while (inode->i_lock) {
-	INR_COUNT(inode);
-	sleep_on(&inode->i_wait);
-	DCR_COUNT(inode);
+	inode->i_count++;
+	sleep_on((struct wait_queue *)inode);
+	inode->i_count--;
     }
 }
 
@@ -114,7 +132,7 @@ static void lock_inode(register struct inode *inode)
 static void unlock_inode(register struct inode *inode)
 {
     inode->i_lock = 0;
-    wake_up(&inode->i_wait);
+    wake_up((struct wait_queue *)inode);
 }
 
 void invalidate_inodes(kdev_t dev)
@@ -126,7 +144,7 @@ void invalidate_inodes(kdev_t dev)
         prev = inode->i_prev;	/* clear_inode() changes the queues.. */
 	if (inode->i_dev != dev) continue;
 	if (inode->i_count || inode->i_dirt || inode->i_lock)
-	    printk("VFS: inode busy on removed device %s\n", kdevname(dev));
+	    printk("VFS: inode busy on removed device %D\n", dev);
 	else
 	    clear_inode(inode);
     } while ((inode = prev) != NULL);
@@ -160,55 +178,23 @@ void sync_inodes(kdev_t dev)
     } while ((inode = inode->i_prev) != NULL);
 }
 
-static void list_inode_status(void)
-{
-    int i = 0;
-    register struct inode *inode = inode_llru;
-
-    do {
-        printk("[#%u: c=%u d=%x nr=%lu]", i++,
-			inode->i_count, inode->i_dev, (unsigned long)inode->i_ino);
-    } while ((inode = inode->i_prev) != NULL);
-}
-
 static struct inode *get_empty_inode(void)
 {
-    static ino_t ino = 0;
     register struct inode *inode;
 
     inode = inode_lru;
     while (inode->i_count || inode->i_dirt || inode->i_lock) {
 	if ((inode = inode->i_next) == NULL) {
 	    printk("VFS: No free inodes\n");
-	    list_inode_status();
 	    sleep_on(&inode_wait);
 	    inode = inode_lru;
 	}
     }
-
-/* Here we are doing the same checks again. There cannot be a significant *
- * race condition here - no time has passed */
-#if 0
-    if (inode->i_lock) {	/* This will never happen */
-	wait_on_inode(inode);
-	goto repeat;
-    }
-    if (inode->i_dirt) {
-	write_inode(inode);
-	goto repeat;
-    }
-    if (inode->i_count)
-	goto repeat;
-#endif
     clear_inode(inode);
     put_last_lru(inode);
     inode->i_count = inode->i_nlink = 1;
-    SET_COUNT(inode)
     inode->i_uid = current->euid;
-#ifdef BLOAT_FS
-    inode->i_version = ++event;
-#endif
-    inode->i_ino = ++ino;
+    SET_COUNT(inode)
     return inode;
 }
 
@@ -216,12 +202,13 @@ void iput(register struct inode *inode)
 {
     register struct super_operations *sop;
 
+    debug("iput dev %D ino %lu count %d\n",
+        inode->i_dev, (unsigned long)inode->i_ino, inode->i_count);
     if (inode) {
 	wait_on_inode(inode);
 	if (!inode->i_count) {
-	    printk("VFS: iput: trying to free free inode\n"
-			"VFS: device %s, inode %lu, mode=0%06o\n",
-			kdevname(inode->i_rdev), (unsigned long)inode->i_ino, inode->i_mode);
+	    printk("iput: trying to free free inode dev %D inode %lu mode 0%06o\n",
+	        inode->i_rdev, (unsigned long)inode->i_ino, inode->i_mode);
 	    return;
 	}
 #ifdef NOT_YET
@@ -248,6 +235,12 @@ void iput(register struct inode *inode)
 
 	} while (inode->i_dirt);
 	DCR_COUNT(inode);
+#ifdef CHECK_FREECNTS
+        if (inode->i_count == 0) {
+            inode->i_dev = 0;
+            inode->i_ino = 0;
+        }
+#endif
     }
 }
 
@@ -312,15 +305,13 @@ struct inode *new_inode(register struct inode *dir, __u16 mode)
     return inode;
 }
 
-struct inode *__iget(struct super_block *sb,
-		     ino_t inr /*,int crossmntp */ )
+struct inode *iget(struct super_block *sb, ino_t inr)
 {
     register struct inode *inode;
     register struct inode *n_ino;
 
-    debug("iget called(%x, %lu, %d)\n", sb, (unsigned long)inr, 0 /* crossmntp */ );
-    if (!sb)
-	panic("VFS: iget with sb==NULL");
+    if (!sb) panic("iget sb 0");
+    debug("iget dev %D ino %lu\n", sb->s_dev, (unsigned long)inr);
 
     n_ino = NULL;
     goto start;
@@ -338,24 +329,18 @@ struct inode *__iget(struct super_block *sb,
 
     inode->i_sb = sb;
     inode->i_dev = sb->s_dev;
-    inode->i_flags = ((unsigned short int) sb->s_flags);
+    inode->i_flags = sb->s_flags;
     inode->i_ino = inr;
-    debug("iget: Reading inode\n");
     read_inode(inode);
-    debug("iget: Read it\n");
     goto return_it;
 
   found_it:
     if (n_ino != NULL) iput(n_ino);
     INR_COUNT(inode);
-#if 0
-    /* This will never happen */
-    if (inode->i_dev != sb->s_dev || inode->i_ino != inr) {
-	printk("Whee.. inode changed from under us. Tell _.\n");
-	iput(inode);
-	goto repeat;
-    }
-#endif
+
+    /* This will never happen, FIXME remove */
+    if (inode->i_dev != sb->s_dev || inode->i_ino != inr) panic("iget");
+
     if ( /* crossmntp && */ inode->i_mount) {
 	n_ino = inode;
 	inode = inode->i_mount;

--- a/tlvc/fs/minix/bitmap.c
+++ b/tlvc/fs/minix/bitmap.c
@@ -19,14 +19,31 @@
 
 static char nibblemap[] = { 0, 1, 1, 2, 1, 2, 2, 3, 1, 2, 2, 3, 2, 3, 3, 4 };
 
-static unsigned short count_used(struct buffer_head *map[],
+struct buffer_head *get_map_block(kdev_t dev, block_t block)
+{
+    struct buffer_head *bh;
+
+    bh = get_hash_table(dev, block);
+    if (bh)
+        bh = readbuf(bh);
+    else
+        bh = bread(dev, block);
+    if (!EBH(bh)->b_uptodate) {
+        printk("get_map_block: I/O error on dev/blk %04x/%u\n", dev, block);
+	brelse(bh);
+	return NULL;
+    }
+    return bh;
+}
+
+static unsigned short count_used(kdev_t dev, unsigned int map[],
 				 unsigned int numblocks, unsigned int numbits)
 {
     unsigned int i, j, end, sum = 0;
     register struct buffer_head *bh;
 
     for (i = 0; (i < numblocks) && numbits; i++) {
-	if (!(bh = map[i])) return 0;
+	if (!(bh = get_map_block(dev, map[i]))) return 0;
 	map_buffer(bh);
 	if (numbits >= (8 * BLOCK_SIZE)) {
 	    end = BLOCK_SIZE;
@@ -40,7 +57,7 @@ static unsigned short count_used(struct buffer_head *map[],
 	}
 	for (j = 0; j < end; j++)
 	    sum += nibblemap[bh->b_data[j] & 0xf] + nibblemap[(bh->b_data[j] >> 4) & 0xf];
-	unmap_buffer(bh);
+	unmap_brelse(bh);
     }
     return sum;
 }
@@ -48,14 +65,14 @@ static unsigned short count_used(struct buffer_head *map[],
 unsigned short minix_count_free_blocks(register struct super_block *sb)
 {
     return (sb->u.minix_sb.s_nzones -
-	count_used(sb->u.minix_sb.s_zmap, sb->u.minix_sb.s_zmap_blocks,
+	count_used(sb->s_dev, sb->u.minix_sb.s_zmap, sb->u.minix_sb.s_zmap_blocks,
 	    sb->u.minix_sb.s_nzones)) << sb->u.minix_sb.s_log_zone_size;
 }
 
 unsigned short minix_count_free_inodes(register struct super_block *sb)
 {
     return (sb->u.minix_sb.s_ninodes -
-	count_used(sb->u.minix_sb.s_imap, sb->u.minix_sb.s_imap_blocks,
+	count_used(sb->s_dev, sb->u.minix_sb.s_imap, sb->u.minix_sb.s_imap_blocks,
 	    sb->u.minix_sb.s_ninodes));
 }
 
@@ -73,14 +90,14 @@ void minix_free_block(register struct super_block *sb, unsigned short block)
 	if (bh) mark_buffer_clean(bh);
 	brelse(bh);
 	zone = block - sb->u.minix_sb.s_firstdatazone + 1;
-	bh = sb->u.minix_sb.s_zmap[zone >> 13];
+	bh = get_map_block(sb->s_dev, sb->u.minix_sb.s_zmap[zone >> 13]);
 	if (!bh) s = "null zmap";
 	else {
 	    map_buffer(bh);
 	    if (!clear_bit(zone & 8191, bh->b_data))
 		s = "already cleared";
 	    mark_buffer_dirty(bh);
-	    unmap_buffer(bh);
+	    unmap_brelse(bh);
 	}
     }
     if (s)
@@ -97,24 +114,24 @@ repeat:
     j = 8192;
     for (i = 0; i < sb->u.minix_sb.s_zmap_blocks; i++) {
         if (i > 0)
-            unmap_buffer(bh);
-        if ((bh = sb->u.minix_sb.s_zmap[i]) != NULL) {
+            unmap_brelse(bh);
+        if ((bh = get_map_block(sb->s_dev, sb->u.minix_sb.s_zmap[i])) != NULL) {
             map_buffer(bh);
             if ((j = find_first_zero_bit((void *)bh->b_data, 8192)) < 8192)
                 break;
         }
     }
     if (i >= sb->u.minix_sb.s_zmap_blocks || !bh || j >= 8192) {
-        if (bh) unmap_buffer(bh);
+        if (bh) unmap_brelse(bh);
         return 0;
     }
     if (set_bit(j, bh->b_data)) {
         printk("new_block: bit already set %d\n", j);
-        unmap_buffer(bh);
+        unmap_brelse(bh);
         goto repeat;
     }
     mark_buffer_dirty(bh);
-    unmap_buffer(bh);
+    unmap_brelse(bh);
     j += i*8192 + sb->u.minix_sb.s_firstdatazone - 1;
     if (j < sb->u.minix_sb.s_firstdatazone || j >= sb->u.minix_sb.s_nzones)
         return 0;
@@ -122,11 +139,14 @@ repeat:
         printk("new_block: bad block %u\n", j);
         return 0;
     }
-    map_buffer(bh);
-    memset(bh->b_data, 0, BLOCK_SIZE);
+    //debug_blk("minix_new_block: block %ld uptodate %d\n",
+        //EBH(bh)->b_blocknr, EBH(bh)->b_uptodate);
+    printk("minix_new_block: %ld bh %04x\n", 
+        EBH(bh)->b_blocknr, bh);
+    zero_buffer(bh, 0, BLOCK_SIZE);
     mark_buffer_uptodate(bh, 1);
     mark_buffer_dirty(bh);
-    unmap_brelse(bh);
+    brelse(bh);
     return j;
 }
 
@@ -149,7 +169,7 @@ void minix_free_inode(register struct inode *inode)
     else if ((int)inode->i_ino == 0) s = "inode 0\n";
     else if ((unsigned int)inode->i_ino > inode->i_sb->u.minix_sb.s_ninodes)
 	s = "nonexistent inode\n";
-    else if (!(bh = inode->i_sb->u.minix_sb.s_imap[(unsigned int)inode->i_ino >> 13]))
+    else if (!(bh = get_map_block(inode->i_sb->s_dev, inode->i_sb->u.minix_sb.s_imap[(unsigned int)inode->i_ino >> 13])))
 	s = "nonexistent imap\n";
     if (s) {
 	printk("free_inode: ");
@@ -160,35 +180,37 @@ void minix_free_inode(register struct inode *inode)
 	    printk("free_inode: already cleared %d\n", (int)inode->i_ino & 8191);
 	clear_inode(inode);
 	mark_buffer_dirty(bh);
-	unmap_buffer(bh);
+	unmap_brelse(bh);
     }
 }
 
 struct inode *minix_new_inode(struct inode *dir, __u16 mode)
 {
     struct inode *inode;
+    struct super_block *sb;
     struct buffer_head *bh = NULL;
     block_t i, j;
 
     if (!dir || !(inode = new_inode(dir, mode)))
         return NULL;
     minix_set_ops(inode);
+    sb = inode->i_sb;
 
     j = 8192;
-    for (i = 0; i < inode->i_sb->u.minix_sb.s_imap_blocks; i++) {
-        if (i > 0)
-            unmap_buffer(bh);
-        if ((bh = inode->i_sb->u.minix_sb.s_imap[i]) != NULL) {
+    for (i = 0; i < sb->u.minix_sb.s_imap_blocks; i++) {
+	if (i > 0)
+	    unmap_brelse(bh);
+	if ((bh = get_map_block(sb->s_dev, sb->u.minix_sb.s_imap[i])) != NULL) {
             map_buffer(bh);
             if ((j = find_first_zero_bit((void *)bh->b_data, 8192)) < 8192)
                 break;
         }
     }
-    if (i >= inode->i_sb->u.minix_sb.s_imap_blocks || !bh || j >= 8192)
+    if (i >= sb->u.minix_sb.s_imap_blocks || !bh || j >= 8192)
         goto errout;
 
     j += i*8192;
-    if (!j || j >= inode->i_sb->u.minix_sb.s_ninodes)
+    if (!j || j >= sb->u.minix_sb.s_ninodes)
         goto errout;
 
     if (set_bit(j & 8191, bh->b_data)) {    /* shouldn't happen */
@@ -196,7 +218,7 @@ struct inode *minix_new_inode(struct inode *dir, __u16 mode)
         goto errout2;
     }
     mark_buffer_dirty(bh);
-    unmap_buffer(bh);
+    unmap_brelse(bh);
     inode->i_dirt = 1;
     inode->i_ino = j;
     return inode;
@@ -205,7 +227,7 @@ errout:
     printk("new_inode: Out of inodes\n");
 errout2:
     if (bh)
-        unmap_buffer(bh);
+        unmap_brelse(bh);
     iput(inode);
     return NULL;
 }

--- a/tlvc/fs/minix/dir.c
+++ b/tlvc/fs/minix/dir.c
@@ -53,9 +53,7 @@ struct inode_operations minix_dir_inode_operations = {
     minix_mknod,		/* mknod */
     NULL,			/* readlink */
     NULL,			/* follow_link */
-#ifdef USE_GETBLK
     NULL,			/* getblk */
-#endif
     minix_truncate		/* truncate */
 };
 

--- a/tlvc/fs/minix/file.c
+++ b/tlvc/fs/minix/file.c
@@ -7,164 +7,9 @@
  */
 
 #include <linuxmt/types.h>
-#include <linuxmt/sched.h>
-#include <linuxmt/minix_fs.h>
-#include <linuxmt/kernel.h>
-#include <linuxmt/errno.h>
-#include <linuxmt/fcntl.h>
-#include <linuxmt/stat.h>
-#include <linuxmt/mm.h>
-#include <linuxmt/debug.h>
-
-#include <arch/segment.h>
-#include <arch/system.h>
-
 #include <linuxmt/fs.h>
-
-#ifndef USE_GETBLK
-
-#ifdef DEBUG
-static char inode_equal_NULL[] = "inode = NULL\n";
-static char mode_equal_val[] = "mode = %07o\n";
-#endif
-
-static size_t minix_file_read(struct inode *inode, register struct file *filp,
-			    char *buf, size_t count)
-{
-    loff_t pos;
-    size_t chars;
-    int read = 0;
-
-#ifdef DEBUG
-    {
-	register char *s;
-	if (!inode) {
-	    s = inode_equal_NULL;
-	    goto OUTPUT;
-	} else if (!S_ISREG(inode->i_mode)) {
-	    s = mode_equal_val; /* i_mode */
-	OUTPUT:
-	    printk("minix_file_read: ");
-	    printk(s, inode->i_mode);
-	    return -EINVAL;
-	}
-    }
-#endif
-
-    /* Amount we can do I/O over */
-    pos = ((loff_t)inode->i_size) - filp->f_pos;
-    if (pos <= 0) {
-	debug("MFSREAD: EOF reached.\n");
-	goto mfread;		/* EOF */
-    }
-    if ((loff_t)count > pos) count = (size_t)pos;
-
-    while (count > 0) {
-	register struct buffer_head *bh;
-
-	/*
-	 *      Read the block in
-	 */
-	bh = minix_getblk(inode, (block_t)(filp->f_pos >> BLOCK_SIZE_BITS), 0);
-	/* Offset to block/offset */
-	chars = BLOCK_SIZE - (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1));
-	if (chars > count) chars = count;
-	if (bh) {
-	    if (!readbuf(bh)) {
-		debug("MINREAD: readbuf failed\n");
-		if (!read) read = -EIO;
-		break;
-	    }
-	    xms_fmemcpyb(buf, current->t_regs.ds,
-		buffer_data(bh) + (((size_t)(filp->f_pos)) & (BLOCK_SIZE - 1)), buffer_seg(bh),
-		chars);
-	    brelse(bh);
-	} else fmemsetb(buf, current->t_regs.ds, 0, chars);
-	buf += chars;
-	filp->f_pos += chars;
-	read += chars;
-	count -= chars;
-    }
-
-#ifdef BLOAT_FS
-    filp->f_reada = 1;
-#endif
-#ifdef FIXME
-    if (!IS_RDONLY(inode)) inode->i_atime = CURRENT_TIME;
-#endif
-  mfread:
-    return read;
-}
-
-static size_t minix_file_write(struct inode *inode, register struct file *filp,
-			    char *buf, size_t count)
-{
-    size_t chars, offset;
-    int written = 0;
-
-#ifdef DEBUG
-    {
-	register char *s;
-	if (!inode) {
-	    s = inode_equal_NULL;
-	    goto OUTPUT;
-	}
-	if (!S_ISREG(inode->i_mode)) {
-	    s = mode_equal_val; /* inode->i_mode */
-	OUTPUT:
-	    printk("minix_file_write: ");
-	    printk(s, inode->i_mode);
-	    return -EINVAL;
-	}
-    }
-#endif
-
-    if (filp->f_flags & O_APPEND) filp->f_pos = (loff_t)inode->i_size;
-
-    while (count > 0) {
-	register struct buffer_head *bh;
-
-	bh = minix_getblk(inode, (block_t) (filp->f_pos >> BLOCK_SIZE_BITS), 1);
-	if (!bh) {
-	    if (!written) written = -ENOSPC;
-	    break;
-	}
-	/* Offset to block/offset */
-	offset = ((size_t)filp->f_pos) & (BLOCK_SIZE - 1);
-	chars = BLOCK_SIZE - offset;
-	if (chars > count) chars = count;
-	/*
-	 *      Read the block in, unless we
-	 *      are writing a whole block.
-	 */
-	if (chars != BLOCK_SIZE) {
-	    if (!readbuf(bh)) {
-		if (!written) written = -EIO;
-		break;
-	    }
-	}
-	/*
-	 *      Alter buffer, mark dirty
-	 */
-	xms_fmemcpyb(buffer_data(bh) + offset, buffer_seg(bh), buf, current->t_regs.ds, chars);
-	mark_buffer_uptodate(bh, 1);
-	mark_buffer_dirty(bh);
-	brelse(bh);
-	buf += chars;
-	filp->f_pos += chars;
-	written += chars;
-	count -= chars;
-    }
-    {
-	register struct inode *pinode = inode;
-	if ((loff_t)pinode->i_size < filp->f_pos)
-	    pinode->i_size = (__u32) filp->f_pos;
-	pinode->i_mtime = pinode->i_ctime = CURRENT_TIME;
-	pinode->i_dirt = 1;
-    }
-    return written;
-}
-#endif
+#include <linuxmt/minix_fs.h>
+#include <linuxmt/stat.h>
 
 /*
  * We have mostly NULL's here: the current defaults are ok for
@@ -172,13 +17,8 @@ static size_t minix_file_write(struct inode *inode, register struct file *filp,
  */
 static struct file_operations minix_file_operations = {
     NULL,			/* lseek - default */
-#ifdef USE_GETBLK
     block_read,			/* read */
     block_write,		/* write */
-#else
-    minix_file_read,		/* read */
-    minix_file_write,		/* write */
-#endif
     NULL,			/* readdir - bad */
     NULL,			/* select - default */
     NULL,			/* ioctl - default */
@@ -198,8 +38,6 @@ struct inode_operations minix_file_inode_operations = {
     NULL,			/* mknod */
     NULL,			/* readlink */
     NULL,			/* follow_link */
-#ifdef USE_GETBLK
     minix_getblk,		/* getblk */
-#endif
     minix_truncate		/* truncate */
 };

--- a/tlvc/fs/minix/symlink.c
+++ b/tlvc/fs/minix/symlink.c
@@ -101,8 +101,6 @@ struct inode_operations minix_symlink_inode_operations = {
     NULL,			/* mknod */
     minix_readlink,		/* readlink */
     minix_follow_link,		/* follow_link */
-#ifdef USE_GETBLK
     NULL,			/* getblk */
-#endif
     NULL			/* truncate */
 };

--- a/tlvc/fs/msdos/dir.c
+++ b/tlvc/fs/msdos/dir.c
@@ -55,9 +55,7 @@ struct inode_operations msdos_dir_inode_operations = {
 	NULL,			/* mknod */
 	NULL,			/* readlink */
 	NULL,			/* follow_link */
-#ifdef USE_GETBLK
 	NULL,			/* getblk */
-#endif
 	NULL			/* truncate */
 };
 
@@ -94,8 +92,8 @@ int FATPROC msdos_get_entry_long(
 	off_t oldpos = *pos;	/* location of next directory entry start*/
 	int is_long;
 	unsigned char alias_checksum = 0;
-	/* static not reentrant: conserve stack usage*/
-	static unsigned short unicodename[26+1];	/* Limited to two long entries */
+	/* static not reentrant: conserve stack usage if possible */
+	ASYNCIO_REENTRANT unsigned short unicodename[26+1];	/* Limited to two long entries */
 
 	if ((int)*pos & (sizeof(struct msdos_dir_entry) - 1)) return -ENOENT;
 	is_long = 0;
@@ -153,7 +151,7 @@ int FATPROC msdos_get_entry_long(
 			int i,i2,last;
 			int long_len = 0;
 			unsigned char c;
-			static char longname[14]; /* static not reentrant: conserve stack usage*/
+			ASYNCIO_REENTRANT char longname[14]; /* static if possible, conserve stack usage*/
 
 			if (is_long) {
 				unsigned char sum;
@@ -231,7 +229,7 @@ static int msdos_readdir(struct inode *dir, struct file *filp, char *dirbuf,
 	off_t dirpos;
 	int res, namelen;
 	/* static not reentrant: conserve stack usage*/
-	static char name[14];
+	ASYNCIO_REENTRANT char name[14];
 
 	if (!dir || !S_ISDIR(dir->i_mode)) return -EBADF;
 	if (dir->i_ino == MSDOS_ROOT_INO) {

--- a/tlvc/fs/msdos/misc.c
+++ b/tlvc/fs/msdos/misc.c
@@ -12,18 +12,30 @@
 #include <linuxmt/stat.h>
 #include <linuxmt/debug.h>
 
+struct buffer_head * FATPROC msdos_sread_nomap(struct super_block *s, sector_t sector,
+                                                 size_t *offset)
+{
+    struct buffer_head *bh;
+
+    if (!(bh = bread32(s->s_dev, sector >> (BLOCK_SIZE_BITS - SECTOR_BITS_SB(s)))))
+        return NULL;
+
+    //debug_fat("msread sector %ld block %lu\n", sector, buffer_blocknr(bh));
+    *offset = ((int)sector & (BLOCK_SIZE_BITS - SECTOR_BITS_SB(s))) << SECTOR_BITS_SB(s);
+    return bh;
+}
+
 struct buffer_head * FATPROC msdos_sread(struct super_block *s, sector_t sector, void **start)
 {
-	register struct buffer_head *bh;
+    struct buffer_head *bh;
+    size_t offset;
 
-	if (!(bh = bread32(s->s_dev, sector >> (BLOCK_SIZE_BITS - SECTOR_BITS_SB(s)))))
-		return NULL;
+    if (!(bh = msdos_sread_nomap(s, sector, &offset)))
+        return NULL;
 
-	map_buffer(bh);
-	//debug_fat("msread sector %ld block %lu\n", sector, buffer_blocknr(bh));
-	*start = bh->b_data +
-		(((int)sector & (BLOCK_SIZE_BITS - SECTOR_BITS_SB(s))) << SECTOR_BITS_SB(s));
-	return bh;
+    map_buffer(bh);
+    *start = bh->b_data + offset;
+    return bh;
 }
 
 
@@ -51,7 +63,7 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 	static int lock = 0;
 	cluster_t count, this, limit, curr, last;
 	sector_t sector;
-	void *data;
+	size_t offset;
 	struct buffer_head *bh;
 	struct msdos_sb_info *sb = MSDOS_SB(inode->i_sb);
 	int fatsz = sb->fat_bits;
@@ -114,26 +126,32 @@ int FATPROC msdos_add_cluster(register struct inode *inode)
 
 	for (curr = 0; curr < sb->cluster_size; curr++) {
 		sector = sb->data_start + (this - 2) * sb->cluster_size + curr;
+		printk("zeroing sector %lu\r\n", sector);
 		debug("zeroing sector %lu\r\n", sector);
 
 		if (curr < sb->cluster_size-1 && !(sector & 1)) {
 			if (!(bh = getblk32(inode->i_dev, sector >> 1)))
 				printk("FAT: getblk fail\n");
 			else {
-				map_buffer(bh);
-				memset(bh->b_data,0,BLOCK_SIZE);
+                		debug_blk("msdos_add_cluster1: block %ld uptodate %d\n",
+                    		EBH(bh)->b_blocknr, EBH(bh)->b_uptodate);
+                		zero_buffer(bh, 0, BLOCK_SIZE);
 				mark_buffer_uptodate(bh, 1);
 			}
 			curr++;
 		} else {
-			if (!(bh = msdos_sread(inode->i_sb,sector,&data)))
+			if (!(bh = msdos_sread_nomap(inode->i_sb, sector, &offset)))
 				printk("FAT: sread fail\n");
-			else memset(data,0,SECTOR_SIZE(inode));
+			else {
+				debug_blk("msdos_add_cluster2: block %ld uptodate %d\n",
+					EBH(bh)->b_blocknr, EBH(bh)->b_uptodate);
+				zero_buffer(bh, offset, SECTOR_SIZE(inode));
+			}
 		}
 		if (bh) {
 			debug_fat("add_cluster block write %lu\n", buffer_blocknr(bh));
 			mark_buffer_dirty(bh);
-			unmap_brelse(bh);
+			brelse(bh);
 		}
 	}
 	if (S_ISDIR(inode->i_mode)) {

--- a/tlvc/fs/msdos/namei.c
+++ b/tlvc/fs/msdos/namei.c
@@ -68,8 +68,8 @@ static int FATPROC msdos_find(struct inode *dir,const char *name,int len,
     struct buffer_head **bh,struct msdos_dir_entry **de,ino_t *ino)
 {
 	int res;
-	/* static not reentrant: conserve stack usage*/
-	static char msdos_name[MSDOS_NAME+1];
+	/* static not reentrant: conserve stack usage if possible */
+	ASYNCIO_REENTRANT char msdos_name[MSDOS_NAME+1];
 
 	if ((res = msdos_format_name(name,len, msdos_name)) < 0) return res;
 	res = msdos_scan(dir,msdos_name,bh,de,ino);
@@ -96,9 +96,9 @@ static int FATPROC msdos_find_long(struct inode *dir, const char *name, int len,
 	int i, entry_len, res;
 	off_t dirpos, pos = 0;
 	int nocase = 0;
-	/* static not reentrant: conserve stack usage*/
-	static char entry_name[14];
-	static char msdos_name[14];
+	/* static not reentrant: conserve stack usage if possible */
+	ASYNCIO_REENTRANT char entry_name[14];
+	ASYNCIO_REENTRANT char msdos_name[14];
 
 	for (i=0; i<len; i++)
 		msdos_name[i] = get_fs_byte(name++);
@@ -209,8 +209,8 @@ int msdos_create(register struct inode *dir,const char *name,int len,int mode,
 	struct msdos_dir_entry *de;
 	ino_t ino;
 	int res;
-	/* static not reentrant: conserve stack usage*/
-	static char msdos_name[MSDOS_NAME];
+	/* static not reentrant: conserve stack usage if possible */
+	ASYNCIO_REENTRANT char msdos_name[MSDOS_NAME];
 
 	if ((res = msdos_format_name(name,len, msdos_name)) < 0) {
 		iput(dir);
@@ -238,8 +238,8 @@ int msdos_mkdir(struct inode *dir,const char *name,int len,int mode)
 	struct inode *inode,*dot;
 	ino_t ino;
 	int res;
-	/* static not reentrant: conserve stack usage*/
-	static char msdos_name[MSDOS_NAME];
+	/* static not reentrant: conserve stack usage if running syncIO only  */
+	ASYNCIO_REENTRANT char msdos_name[MSDOS_NAME];
 
 	if ((res = msdos_format_name(name,len, msdos_name)) < 0) {
 		iput(dir);

--- a/tlvc/fs/pipe.c
+++ b/tlvc/fs/pipe.c
@@ -300,9 +300,7 @@ struct inode_operations pipe_inode_operations = {
     NULL,			/* mknod */
     NULL,			/* readlink */
     NULL,			/* follow_link */
-#ifdef USE_GETBLK
     NULL,			/* getblk */
-#endif
     NULL			/* truncate */
 };
 

--- a/tlvc/fs/read_write.c
+++ b/tlvc/fs/read_write.c
@@ -132,8 +132,10 @@ int sys_write(unsigned int fd, char *buf, size_t count)
 #endif
 
 	    }
+	    //printk("WR: f%d i%x b%x c%d\n", fd, inode, buf, count); 
 	    written = (int) fop->write(inode, file, buf, count);
-	    schedule();
+
+	    schedule();	// FIX: Check if this can be removed
 	}
     }
     return written;

--- a/tlvc/fs/romfs/romfs.c
+++ b/tlvc/fs/romfs/romfs.c
@@ -214,9 +214,7 @@ static struct inode_operations romfs_inode_operations = {
 	NULL,             /* mknod */
 	romfs_readlink,   /* readlink */
 	romfs_followlink, /* followlink */
-#ifdef USE_GETBLK
 	NULL,             /* getblk -- not really */
-#endif
 	NULL              /* truncate */
 };
 

--- a/tlvc/fs/super.c
+++ b/tlvc/fs/super.c
@@ -172,6 +172,7 @@ static struct super_block *read_super(kdev_t dev, int t, int flags,
     check_disk_change(dev);
 #endif
     s = get_super(dev);
+    list_buffer_status();
     if (s) return s;
 
 #if CONFIG_FULL_VFS
@@ -479,6 +480,7 @@ void mount_root(void)
     do {
 	fp = *fs_type;
 
+	printk("mount_root: check type %d\n", fp->type);
 #ifdef BLOAT_FS
 	if (!fp->requires_dev) continue;
 #endif
@@ -499,7 +501,7 @@ void mount_root(void)
 	}
     } while (*(++fs_type) && !retval);
 
-#ifdef CONFIG_BLK_DEV_BIOS
+#ifdef CONFIG_BLK_DEV_BIOS	/* FIXME: support this when using the direct driver too */
     if (ROOT_DEV == 0x0380) {
 	if (!filp->f_op->release)
 	    printk("Release not defined\n");

--- a/tlvc/include/arch/ports.h
+++ b/tlvc/include/arch/ports.h
@@ -121,5 +121,4 @@
 #define HD1_AT_IRQ	14		/* missing request_irq call*/
 #define HD2_AT_IRQ	15		/* missing request_irq call*/
 
-/* obsolete - experimental floppy drive, floppy.c (won't compile)*/
-#define FLOPPY_IRQ	6		/* missing request_irq call*/
+#define FLOPPY_IRQ	6

--- a/tlvc/include/linuxmt/config.h
+++ b/tlvc/include/linuxmt/config.h
@@ -4,9 +4,6 @@
 #include <autoconf.h>
 #include <linuxmt/major.h>
 
-/* tunable parameters*/
-#define PIPE_BUFSIZ	80	/* doesn't have to be power of two */
-
 /*
  * Compile-time configuration
  */

--- a/tlvc/include/linuxmt/debug.h
+++ b/tlvc/include/linuxmt/debug.h
@@ -29,9 +29,9 @@
  */
 #define DEBUG_EVENT	1		/* generate debug events on CTRLP*/
 #define DEBUG_STARTDEF	0		/* default startup debug display*/
-#define DEBUG_BLKDRV	1		/* Disk/floppy drivers */
+#define DEBUG_BLKDRV	0		/* Disk/floppy drivers */
 #define DEBUG_RAW	1		/* Raw disk/floppy I/O */
-#define DEBUG_BLK	1		/* block level i/o*/
+#define DEBUG_BLK	0		/* block level i/o*/
 #define DEBUG_ETH	0		/* ethernet*/
 #define DEBUG_FAT	0		/* FAT filesystem*/
 #define DEBUG_FILE	0		/* sys open and file i/o*/
@@ -39,15 +39,15 @@
 #define DEBUG_MM	0		/* mem char device*/
 #define DEBUG_SCHED	0		/* scheduler/wait*/
 #define DEBUG_SIG	0		/* signals*/
-#define DEBUG_SUP	0		/* superblock, mount, umount*/
+#define DEBUG_SUP	1		/* superblock, mount, umount*/
 #define DEBUG_TTY	0		/* tty driver*/
 #define DEBUG_TUNE	0		/* tunable debug statements*/
 #define DEBUG_WAIT	0		/* wait, exit*/
 
 #if DEBUG_EVENT
-void dprintk(char *, ...);		/* printk when debugging on*/
-void debug_event(void);			/* generate debug event*/
-void debug_setcallback(void (*cbfunc)()); /* callback on debug event*/
+void dprintk(const char *, ...);		/* printk when debugging on*/
+void debug_event(int evnum);            /* generate debug event*/
+void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*/
 #define PRINTK		dprintk
 #else
 #define PRINTK		printk

--- a/tlvc/include/linuxmt/directhd.h
+++ b/tlvc/include/linuxmt/directhd.h
@@ -53,7 +53,6 @@
 #define ATA_ERR_BBK	0x80	/* Bad Block mark detected */
 
 /* Per drive config settings */
-#define ATA_CFG_NMULT	0x01	/* multi r/w NOT supported */
 #define ATA_CFG_INT	0x02	/* Interrupts in use for drive */
 #define ATA_CFG_SSD	0x04	/* drive is solid state */
 #define ATA_CFG_OLDIDE	0x10	/* Old IDE drive w/ limited cmd set */

--- a/tlvc/include/linuxmt/init.h
+++ b/tlvc/include/linuxmt/init.h
@@ -7,6 +7,9 @@
 
 #if defined(CONFIG_FARTEXT_KERNEL) && !defined(__STRICT_ANSI__)
 #define INITPROC __far __attribute__ ((far_section, noinline, section (".fartext.init")))
+/* these symbols defined in elks-small.ld linker script */
+extern void INITPROC __start_fartext_init(void);
+extern void INITPROC __end_fartext_init(void);
 #else
 #define INITPROC
 #endif
@@ -24,9 +27,10 @@ extern void INITPROC inode_init(void);
 extern void INITPROC irq_init(void);
 extern void save_timer_irq(void);
 extern void INITPROC mm_init(seg_t,seg_t);
+extern void INITPROC seg_add(seg_t, seg_t);
 extern void INITPROC sched_init(void);
 extern void INITPROC serial_init(void);
-extern void INITPROC rs_setbaud(dev_t dev, unsigned long baud);
+extern void INITPROC rs_setbaud(dev_t, unsigned long);
 extern void INITPROC sock_init(void);
 extern void INITPROC tty_init(void);
 
@@ -41,22 +45,22 @@ extern int INITPROC bioshd_init(void);
 extern int INITPROC get_ide_data(int, struct drive_infot *);
 extern int INITPROC directhd_init(void);
 extern void INITPROC floppy_init(void);
-extern void rd_init(void);
-extern void ssd_init(void);
+extern void INITPROC rd_init(void);
+extern void INITPROC ssd_init(void);
 extern void romflash_init(void);
 
 /* char device init routines*/
-extern void chr_dev_init(void);
-extern void cgatext_init(void);
-extern void eth_init(void);
+extern void INITPROC chr_dev_init(void);
+extern void INITPROC cgatext_init(void);
+extern void INITPROC eth_init(void);
 extern void ne2k_drv_init(void);
-extern void el3_drv_init(void);
-extern void wd_drv_init(void);
-extern void lp_init(void);
-extern void mem_dev_init(void);
-extern void meta_init(void);
-extern void pty_init(void);
-extern void tcpdev_init(void);
+extern void INITPROC el3_drv_init(void);
+extern void INITPROC wd_drv_init(void);
+extern void INITPROC lp_init(void);
+extern void INITPROC mem_dev_init(void);
+extern void INITPROC meta_init(void);
+extern void INITPROC pty_init(void);
+extern void INITPROC tcpdev_init(void);
 
 extern void kfork_proc(void (*addr)());
 extern void arch_setup_user_stack(struct task_struct *, word_t entry);

--- a/tlvc/include/linuxmt/limits.h
+++ b/tlvc/include/linuxmt/limits.h
@@ -1,19 +1,33 @@
 #ifndef __LINUXMT_LIMITS_H
 #define __LINUXMT_LIMITS_H
 
-#define MAX_TASKS	16	/* Max # processes */
+/* tunable parameters - changing these can have a large effect on kernel data size */
+
+/* kernel */
+#define MAX_TASKS       16      /* Max # processes */
 
 #ifdef CONFIG_ARCH_PC98
-#define KSTACK_BYTES	740	/* Size of kernel stacks */
+#define KSTACK_BYTES    740     /* Size of kernel stacks for PC-98 */
 #else
-#define KSTACK_BYTES	640	/* Size of kernel stacks */
+#define KSTACK_BYTES    640     /* Size of kernel stacks w/sync I/O */
 #endif
 
-#define POLL_MAX	6	/* Maximum number of polled queues per process */
+#define ISTACK_BYTES    512     /* Size of interrupt stack */
 
-#define NR_ALARMS	5	/* Max number of simultaneous alarms system-wide */
-#define NGROUPS		13	/* Supplementary groups */
+#define KSTACK_GUARD    100     /* bytes before CHECK_KSTACK overflow warning */
 
-#define MAX_PACKET_ETH 1536	/* Max packet size, 6 blocks of 256 bytes */
+#define POLL_MAX        6       /* Maximum number of polled queues per process */
+
+/* filesystem */
+#define NR_INODE        96      /* this should be bigger than NR_FILE */
+#define NR_FILE         64      /* this can well be larger on a larger system */
+#define NR_SUPER        6       /* max mounts */
+
+#define PIPE_BUFSIZ     80      /* doesn't have to be power of two */
+
+#define NR_ALARMS       5       /* Max number of simultaneous alarms system-wide */
+#define NGROUPS         13      /* Supplementary groups */
+
+#define MAX_PACKET_ETH 1536     /* Max packet size, 6 blocks of 256 bytes */
 
 #endif /* !__LINUXMT_LIMITS_H */

--- a/tlvc/include/linuxmt/major.h
+++ b/tlvc/include/linuxmt/major.h
@@ -7,7 +7,7 @@
 
 /* limits */
 
-#define MAX_CHRDEV 13	/* highest numbered device + 1 */
+#define MAX_CHRDEV 12	/* highest numbered device + 1 */
 #define MAX_BLKDEV  8
 
 /*
@@ -35,7 +35,6 @@
  *  9 - /dev/eth                                      NIC drivers
  * 10 - /dev/cgatext
  * 11 - /dev/ptyp				      char pty master
- * 12 - /dev/ttyaux				      What is this?
  */
 
 
@@ -43,17 +42,16 @@
 
 #define UNNAMED_MAJOR     0
 #define MEM_MAJOR         1
-#define PTY_MASTER_MAJOR  11
+#define RAW_FLOPPY_MAJOR  2
 #define PTY_SLAVE_MAJOR   3
 #define TTY_MAJOR         4
-#define TTYAUX_MAJOR      12
+#define RAW_HD_MAJOR	  5
 #define LP_MAJOR          6
 #define UDD_MAJOR         7
 #define TCPDEV_MAJOR      8
 #define ETH_MAJOR         9  /* should be rather a network-class driver */
 #define CGATEXT_MAJOR     10
-#define RAW_FLOPPY_MAJOR  2
-#define RAW_HD_MAJOR	  5
+#define PTY_MASTER_MAJOR  11
 
 /* These are the block devices */
 

--- a/tlvc/include/linuxmt/memory.h
+++ b/tlvc/include/linuxmt/memory.h
@@ -50,6 +50,7 @@ void xms_fmemcpyw(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
 		size_t count);
 void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src_seg,
 		size_t count);
+void xms_fmemset(void *dst_off, ramdesc_t dst_seg, byte_t val, size_t count);
 
 /* low level copy - must have 386 CPU and xms_enabled before calling! */
 void linear32_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
@@ -62,6 +63,7 @@ void linear32_fmemcpyb(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_
 typedef seg_t ramdesc_t;	/* ramdesc_t is just a regular segment descriptor */
 #define xms_fmemcpyw	fmemcpyw
 #define xms_fmemcpyb	fmemcpyb
+#define xms_fmemset     fmemsetb
 
 #endif /* CONFIG_FS_XMS_BUFFER */
 

--- a/tlvc/include/linuxmt/minix_fs.h
+++ b/tlvc/include/linuxmt/minix_fs.h
@@ -11,7 +11,8 @@
 
 #define MINIX_ROOT_INO 1
 
-/* Not the same as the bogus LINK_MAX in <linux/limits.h>. Oh well. */
+#define MINIX_SUPER_BLOCK	1
+
 #define MINIX_LINK_MAX	250
 
 /* MINIX V1 buffers for inode and zone bitmaps*/
@@ -73,8 +74,9 @@ struct minix_dir_entry {
 
 #ifdef __KERNEL__
 
-extern unsigned short minix_bmap(register struct inode *,block_t,int);
-extern struct buffer_head *minix_bread(struct inode *,block_t,int);
+extern unsigned short minix_bmap(register struct inode *, block_t, int);
+extern struct buffer_head *minix_bread(struct inode *, block_t, int);
+extern struct buffer_head *get_map_block(kdev_t, block_t);
 extern unsigned short minix_count_free_blocks(register struct super_block *);
 extern unsigned short minix_count_free_inodes(register struct super_block *);
 extern int minix_create(register struct inode *,char *,size_t,int,

--- a/tlvc/include/linuxmt/minix_fs_sb.h
+++ b/tlvc/include/linuxmt/minix_fs_sb.h
@@ -14,11 +14,10 @@ struct minix_sb_info {
     unsigned short		s_firstdatazone;
     unsigned short		s_log_zone_size;
     unsigned long		s_max_size;
-    struct buffer_head *	s_imap[MINIX_I_MAP_SLOTS];
-    struct buffer_head *	s_zmap[MINIX_Z_MAP_SLOTS];
+    block_t			s_imap[MINIX_I_MAP_SLOTS];
+    block_t			s_zmap[MINIX_Z_MAP_SLOTS];
     unsigned short		s_dirsize;
     unsigned short		s_namelen;
-    struct buffer_head *	s_sbh;
     unsigned short		s_mount_state;
 };
 

--- a/tlvc/include/linuxmt/msdos_fs.h
+++ b/tlvc/include/linuxmt/msdos_fs.h
@@ -118,6 +118,7 @@ struct fat_cache {
 /* misc.c */
 
 struct buffer_head * FATPROC msdos_sread(struct super_block *s, sector_t sector, void **start);
+struct buffer_head * FATPROC msdos_sread_nomap(struct super_block *s, sector_t sector, size_t *offset);
 void FATPROC lock_creation(void);
 void FATPROC unlock_creation(void);
 int  FATPROC msdos_add_cluster(struct inode *inode);

--- a/tlvc/include/linuxmt/sched.h
+++ b/tlvc/include/linuxmt/sched.h
@@ -11,10 +11,6 @@
 #include <linuxmt/ntty.h>
 #include <arch/param.h>
 
-#ifdef CONFIG_STRACE
-#include <linuxmt/strace.h>
-#endif
-
 struct file_struct {
     fd_mask_t			close_on_exec;
     struct file 		*fd[NR_OPEN];
@@ -85,13 +81,14 @@ struct task_struct {
     gid_t			groups[NGROUPS];
 #endif
 
-#ifdef CONFIG_STRACE
-    struct syscall_params	sc_info;
-#endif
+    /* next two words are only used by CONFIG_TRACE but left in to avoid
+     * changing struct task size and having to recompile 'ps' etc when changed */
+    int                         kstack_max;
+    int                         kstack_prevmax;
 
-    __u16			t_kstackm;	/* To detect stack corruption */
-    __u8			t_kstack[KSTACK_BYTES];
-    __registers 		t_regs;
+    __u16			kstack_magic;	/* To detect stack corruption */
+    __u16			t_kstack[KSTACK_BYTES/2];
+    struct pt_regs 		t_regs;
 };
 
 #define KSTACK_MAGIC 0x5476
@@ -172,6 +169,10 @@ extern unsigned int get_ustack(struct task_struct *,int);
 extern void put_ustack(register struct task_struct *,int,int);
 
 extern void tswitch(void);
+extern int run_init_process(const char *cmd);
+extern int run_init_process_sptr(const char *cmd, char *sptr, int slen);
+extern void ret_from_syscall(void);
+extern void check_stack(void);
 
 void select_wait(struct wait_queue *);
 int select_poll(struct task_struct *, struct wait_queue *);

--- a/tlvc/include/linuxmt/termios.h
+++ b/tlvc/include/linuxmt/termios.h
@@ -82,6 +82,7 @@ struct winsize {
     unsigned short ws_ypixel;
 };
 
+#if NOTSUPPORTED
 #define NCC 8
 struct termio {
     unsigned short c_iflag;	/* input mode flags */
@@ -91,6 +92,7 @@ struct termio {
     unsigned char c_line;	/* line discipline */
     unsigned char c_cc[NCC];	/* control characters */
 };
+#endif
 
 #define NCCS 17
 struct termios {

--- a/tlvc/include/linuxmt/trace.h
+++ b/tlvc/include/linuxmt/trace.h
@@ -1,0 +1,52 @@
+#ifndef __LINUXMT_TRACE_H
+#define __LINUXMT_TRACE_H
+
+#include <linuxmt/config.h>
+
+/*
+ * Kernel tracing functions and their default settings
+ *
+ * By default, most functions (configured below) are included when
+ * CONFIG_TRACE is set, which is very useful for stack overflow and
+ * constistency checking when developing drivers for or porting the kernel.
+ *
+ * When CONFIG_TRACE is enabled, the following can be used in /bootopts:
+ *  strace  - enable system call tracing
+ *  kstack  - display max kernel stack usage per process
+ */
+
+#ifdef CONFIG_TRACE
+
+/* calculate max kernel stack usage per system call, notify when near overflow */
+//#define CHECK_KSTACK
+
+/* display each system call/return value along with max system stack usage */
+//#define CHECK_STRACE
+
+/* check matched sleep/wait and idle task sleeps when writing/testing drivers */
+//#define CHECK_SCHED
+
+/* check buffer and block I/O request system when writing/testing block drivers */
+//#define CHECK_BLOCKIO
+
+/* integrity check application SS on interrupts from user mode */
+#define CHECK_SS
+
+/* check buffer and inode free counts, list inodes w/^N and buffers w/^O */
+#define CHECK_FREECNTS
+
+#endif /* CONFIG_TRACE */
+
+
+/* internal flags for kernel */
+#define TRACE_STRACE    0x01    /* system call tracing enabled */
+#define TRACE_KSTACK    0x02    /* calculate kernel stack used per syscall/process */
+
+#ifndef __ASSEMBLER__
+extern int tracing;
+
+extern void trace_begin(void);
+extern void trace_end(unsigned int retval);
+#endif
+
+#endif /* __LINUXMT_TRACE_H */

--- a/tlvc/kernel/fork.c
+++ b/tlvc/kernel/fork.c
@@ -1,9 +1,11 @@
 #include <linuxmt/config.h>
-#include <linuxmt/debug.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/sched.h>
+#include <linuxmt/trace.h>
+#include <linuxmt/debug.h>
+
 #include <arch/segment.h>
 
 int task_slots_unused = MAX_TASKS;
@@ -56,7 +58,11 @@ struct task_struct *find_empty_process(void)
     t->ticks = 0;
     t->average = 0;
 #endif
-    t->t_kstackm = KSTACK_MAGIC;
+#ifdef CHECK_KSTACK
+    t->kstack_max = 0;
+    t->kstack_prevmax = 0;
+#endif
+    t->kstack_magic = KSTACK_MAGIC;
     t->next_run = t->prev_run = NULL;
     return t;
 }

--- a/tlvc/kernel/printk.c
+++ b/tlvc/kernel/printk.c
@@ -6,16 +6,17 @@
  *	printf() subset is supported:
  *
  *		%%	literal % sign
- *
  *		%c	char
- *		%d	signed decimal
- *		%i	signed decimal
+ *		%d/%i	signed decimal
+ *		%u	unsigned decimal
  *		%o	octal
- *		%p/%P	pointer - same as %x/%X respectively
  *		%s	string in kernel space
  *		%t	string in user space
- *		%u	unsigned decimal
+ *		%T	string w/specified segment
  *		%x/%X	hexadecimal with lower/upper case letters
+ *		%#x/%#X	hexadecimal using 0x alt prefix
+ *		%p/%P	pointer - same as %04x/%04X respectively
+ *		%D      device name as %#04x
  *
  *	All except %% can be followed by a width specifier 1 -> 31 only
  *	and the h/l length specifiers also work where appropriate.
@@ -70,26 +71,6 @@ void kputchar(int ch)
 
 static void kputs(const char *buf)
 {
-#ifdef CONFIG_EMUL_ANSI_PRINTK
-
-    char *p;
-
-    /* Colourizing */
-
-    static char colour[8] = { 27, '[', '3', '0', ';', '4', '0', 'm' };
-
-    if (++(colour[3]) == '8')
-	colour[3] = '1';
-
-    p = colour;
-    do
-	kputchar(*p);
-    while (*p++ != 'm');
-
-    /* END Colourizing */
-
-#endif
-
     while (*buf)
 	kputchar(*buf++);
 }
@@ -99,10 +80,9 @@ static void kputs(const char *buf)
  *	Output a number
  */
 
-const char *hex_string = "0123456789ABCDEF 0123456789abcdef ";	/* Also used by devices */
+char hex_string[] = "0123456789ABCDEF 0123456789abcdef ";
 
-static void numout(__u32 v, int width, int base, int useSign,
-		   int Lower, int Zero)
+static void numout(__u32 v, int width, int base, int useSign, int Lower, int Zero, int alt)
 {
     __u32 dvr;
     int c, vch, i;
@@ -126,6 +106,10 @@ static void numout(__u32 v, int width, int base, int useSign,
     if (Lower)
 	Lower = 17;
     vch = 0;
+    if (alt && base == 16) {
+        kputchar('0');
+        kputchar('x');
+    }
     do {
 	c = (int)(v / dvr);
 	v %= dvr;
@@ -152,7 +136,7 @@ static void numout(__u32 v, int width, int base, int useSign,
 
 static void vprintk(const char *fmt, va_list p)
 {
-    int c, n, width, zero;
+    int c, n, width, zero, alt, ptrfmt;
     unsigned long v;
     char *str;
 
@@ -167,7 +151,11 @@ static void vprintk(const char *fmt, va_list p)
 		continue;
 	    }
 
-	    width = 0;
+	    ptrfmt = alt = width = 0;
+            if (c == '#') {
+                alt = 1;
+                c = *fmt++;
+            }
 	    zero = (c == '0');
 	    while ((n = (c - '0')) <= 9) {
 		width = width*10 + n;
@@ -180,27 +168,36 @@ static void vprintk(const char *fmt, va_list p)
 	    switch (c) {
 	    case 'i':
 	    case 'd':
-		c = 'd'-('X' - 'P');
+		c = 'd';
 		n = 18;
 	    case 'o':
 		n -= 2;
 	    case 'u':
 		n -= 6;
-	    case 'P':
-	    case 'p':
-		c += 'X' - 'P';
 	    case 'X':
 	    case 'x':
-		if (*(fmt-2) == 'l')
+            hex:
+		if (*(fmt-2) == 'l') {
+                    if (ptrfmt) width = 8;
 		    v = va_arg(p, unsigned long);
-		else {
+		} else {
 		    if (c == 'd')
 			v = (long)(va_arg(p, int));
 		    else
 			v = (unsigned long)(va_arg(p, unsigned int));
 		}
-		numout(v, width, n, (c == 'd'), (c != 'X'), zero);
+		numout(v, width, n, (c == 'd'), (c != 'X'), zero, alt);
 		break;
+            case 'D':
+                c += 'X' - 'D';
+                alt = 1;
+	    case 'P':
+	    case 'p':
+                c += 'X' - 'P';
+                ptrfmt = 1;
+                zero = 1;
+                width = 4;
+                goto hex;
 	    case 'T':
 		n = va_arg(p, unsigned int);
 		goto str;
@@ -243,7 +240,7 @@ void halt(void)
     kputs("\nSYSTEM HALTED - Press CTRL-ALT-DEL to reboot:");
 
     while (1)
-	/* Do nothing */;
+	idle_halt();
 }
 
 void panic(const char *error, ...)
@@ -278,22 +275,25 @@ void panic(const char *error, ...)
 
 int dprintk_on = DEBUG_STARTDEF;	/* toggled by debug events*/
 #if DEBUG_EVENT
-static void (*dprintk_cb)();		/* debug event callback function*/
+static void (*debug_cbfuncs[3])();  /* debug event callback function*/
 
-void debug_setcallback(void (*cbfunc)())
+void debug_setcallback(int evnum, void (*cbfunc)())
 {
-    dprintk_cb = cbfunc;
+    if ((unsigned)evnum < 3)
+        debug_cbfuncs[evnum] = cbfunc;
 }
 
-void debug_event(void)
+void debug_event(int evnum)
 {
-    dprintk_on = !dprintk_on;
-    if (dprintk_cb)
-	dprintk_cb();
-    kill_all(SIGURG);
+    if (evnum == 2) {           /* CTRLP toggles dprintk*/
+        dprintk_on = !dprintk_on;
+        kill_all(SIGURG);
+    }
+    if (debug_cbfuncs[evnum])
+	debug_cbfuncs[evnum]();
 }
 
-void dprintk(char *fmt, ...)
+void dprintk(const char *fmt, ...)
 {
     va_list p;
 

--- a/tlvc/kernel/sleepwake.c
+++ b/tlvc/kernel/sleepwake.c
@@ -6,9 +6,11 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/types.h>
 #include <linuxmt/wait.h>
+#include <linuxmt/trace.h>
 #include <linuxmt/debug.h>
 
-//#define CHECK	/* check matched sleep/wakeup when writing/testing drivers */
+#include <arch/irq.h>
+#include <arch/segment.h>
 
 /*
  *	Wait queue functionality for Linux TLVC. Taken from sched.c/h of

--- a/tlvc/net/socket.c
+++ b/tlvc/net/socket.c
@@ -359,9 +359,7 @@ struct inode_operations sock_inode_operations = {
     NULL,			/* mknod */
     NULL,			/* readlink */
     NULL,			/* follow_link */
-#ifdef USE_GETBLK
     NULL,			/* getblk */
-#endif
     NULL			/* truncate */
 };
 

--- a/tlvccmd/Applications
+++ b/tlvccmd/Applications
@@ -63,7 +63,7 @@ file_utils/chmod				:be-fileutil    :360k
 file_utils/chown				:be-fileutil			:1200k	:1440k
 file_utils/cmp					:be-fileutil			:1200k	:1440k
 file_utils/cp					:be-fileutil	:360k
-file_utils/df					:be-fileutil    :360k
+disk_utils/df					:be-fileutil    :360k
 file_utils/dd					:be-fileutil			:1200k	:1440k
 file_utils/mkdir				:fileutil		:360k
 file_utils/mknod				:fileutil		:360k
@@ -160,11 +160,11 @@ disk_utils/mkfat				:diskutil		:360k
 disk_utils/partype				:diskutil				:1200k	:1440k
 disk_utils/ramdisk				:diskutil				:1200k	:1440k
 disk_utils/fdisk				:be-diskutil	:360k
-tui/fm                          :tui                            :1440k
-tui/matrix                      :tui                            :1440k
+#tui/fm                          :tui                            :1440k
+#tui/matrix                      :tui                            :1440k
 tui/cons                        :tui                            :1440k
 tui/ttyinfo                     :tui                            :1440k
-tui/sl                          :tui
+#tui/sl                          :tui
 busyelks/busyelks				:busyelks
 inet/httpd/sample_index.html	::var/www/index.html	:net
 ktcp/ktcp						:net
@@ -196,10 +196,10 @@ test/libc/test_libc				:other
 #mtools/mwrite					:other
 #m4/m4							:other
 #prems/pres/pres				:other
-nano-X/bin/nxclock				:other
-nano-X/bin/nxdemo				:other
-nano-X/bin/nxlandmine			:nanox				:1200k
-nano-X/bin/nxterm				:nanox
-nano-X/bin/nxworld				:nanox
-nano-X/bin/nxworld.map	::lib/nxworld.map	:nanox
-basic/basic						:basic				:1200k
+#nano-X/bin/nxclock				:other
+#nano-X/bin/nxdemo				:other
+#nano-X/bin/nxlandmine			:nanox				:1200k
+#nano-X/bin/nxterm				:nanox
+#nano-X/bin/nxworld				:nanox
+#nano-X/bin/nxworld.map	::lib/nxworld.map	:nanox
+#basic/basic						:basic				:1200k

--- a/tlvccmd/disk_utils/Makefile
+++ b/tlvccmd/disk_utils/Makefile
@@ -10,7 +10,7 @@ include $(BASEDIR)/Make.rules
 
 ###############################################################################
 
-PRGS = ramdisk mkfs mkfat fsck partype fdisk
+PRGS = ramdisk mkfs mkfat fsck partype fdisk df
 
 SPRGS=mkfs
 
@@ -27,6 +27,9 @@ fsck: fsck.o
 
 fdisk: fdisk.o
 	$(LD) $(LDFLAGS) -o fdisk fdisk.o $(LDLIBS)
+
+df: df.o $(TINYPRINTF)
+	$(LD) $(LDFLAGS) -o df df.o $(TINYPRINTF) $(LDLIBS)
 
 mkfs: mkfs.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o mkfs mkfs.o $(TINYPRINTF) $(LDLIBS)

--- a/tlvccmd/disk_utils/df.c
+++ b/tlvccmd/disk_utils/df.c
@@ -25,6 +25,7 @@
 #include <sys/mount.h>
 #include <linuxmt/minix_fs.h>
 #include <linuxmt/fs.h>
+#include <linuxmt/limits.h>
 
 #define BLOCK_SIZE	1024
 

--- a/tlvccmd/disk_utils/fsck.c
+++ b/tlvccmd/disk_utils/fsck.c
@@ -745,7 +745,7 @@ void check_file(struct minix_inode * dir, unsigned long offset)
 	printd("\n");
 	if (ino >= INODES) {
 		print_current_name();
-		printf(" contains a bad inode number %d for file '", ino);
+		printf(" contains a bad inode number %u for file '", ino);
 		printf("%.*s'.",14,name); /* FIXME 14 can be integrated */
 		if (ask(" Remove",1)) {
 			*(unsigned short *)(name-2) = 0;

--- a/tlvccmd/file_utils/Makefile
+++ b/tlvccmd/file_utils/Makefile
@@ -13,7 +13,7 @@ include $(BASEDIR)/Make.rules
 # note: grep doesn't read stdin, replaced with minix1/grep
 # removed: l
 PRGS = ln ls mkdir mkfifo mknod more mv rm rmdir sync touch \
-	cat chgrp chmod chown cmp cp dd df grep split
+	cat chgrp chmod chown cmp cp dd grep split
 
 all: $(PRGS)
 
@@ -34,9 +34,6 @@ cmp: cmp.o
 
 cp: cp.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -maout-heap=0xffff -o cp cp.o $(TINYPRINTF) $(LDLIBS)
-
-df: df.o $(TINYPRINTF)
-	$(LD) $(LDFLAGS) -o df df.o $(TINYPRINTF) $(LDLIBS)
 
 dd: dd.o
 	$(LD) $(LDFLAGS) -maout-heap=12288 -o dd dd.o $(LDLIBS)

--- a/tlvccmd/sys_utils/mount.c
+++ b/tlvccmd/sys_utils/mount.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <sys/mount.h>
 #include <linuxmt/fs.h>
+#include <linuxmt/limits.h>
 
 #define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
 


### PR DESCRIPTION
This PR has a number of important bugfixes, enhancements and cleanups on all levels - from applications to drivers - plus the buffer system. The following summary covers most, but not all.

- The direct drivers - the floppy driver with its very asynchronous behavior in particular - exposed serious problems in the buffer system - as mentioned in the previous 'major' PR: #19 (https://github.com/Mellvik/TLVC/pull/19#issue-1820158608). The subsequent bug hunt was complicated by the fact that the symptoms were timing sensitive and could not be replicated on QEMU. The hunt is detailed in https://github.com/Mellvik/TLVC/pull/16#issuecomment-1666959322
- When the exact problems had been identified, @ghaerr from the ELKS project stepped in to help with fixes and enhancements. The buffer code is identical between TLVC and ELKS, so the results benefit both projects equally. A couple of synchronization statements in the right places solved the main problem.
- The work on buffers led to the discovery of more bugs and problems/inefficiencies with  interesting consequences:
    - Excessive datacopying between the L1 cache and L2 buffers was discovered and located to the file system code. And subsequently eliminated in both Minix and FAT FS code. On the same note, the initialization of newly allocated buffers to zero has been changed and no longer requires the use of the L1 cache and the extra data copying back and forth. This change does not apply to XMS buffers on machines using INT15 for XMS access, which still need to pass thru L1.
    - File system metadata - superblock, bitmaps and inodes were previously locked in L1 cache at mount time and never released, which severely limited the number of full size Minix filesystems that could be mounted - and reduced the usefulness of the buffer cache. A floppy-booted system would in fact hang if such mount was attempted. This 'reservation' of cache space has been eliminated and @ghaerr added code to release cache space safely as part of the regular buffer admin regime. The jury is still out as to whether some stickiness is advantageous for the metadata buffers.
    - The much more efficient use of cache space changed the overall behavior of the buffer system significantly and mandated a serious look at what sizes are optimal for various configurations. A new `bootops` directive `cache=` now sets the size of the L1 cache, making it easier to experiment and run benchmarks with different cache sizes. The memory allocation for the cache is now done at runtime instead of compile time, making the `cache` setting real in terms of resources. The default # of L1 cache blocks is  set in `buffers.c`, `NR_MAPBUFS `, usually 12 or 8.
    - The `bufs=` directive works as before, setting the  number of L2 buffers to use - whether xms or 'external'. Running the system on L1 buffers only is still possible. Practical advice on optimal cache sizes will be posten in the Wiki.
    - During the bug hunt @ghaerr developed a collection of tracing tools, some of which have been ported to TLVC, in particular the buffer status display, triggered by the ^O key and the inode status display, triggered by ^N - if compiled in. `include/linuxmt/trace.h` is the place to look for 'switches' to turn on and off various traces. A trace tools guide will be posted in the developer notes Wiki. The new syscall trace and stack trace facilities have not been tested on TLVC.


# Other fixes & enhancements

- The direct HD driver has been substantially rewritten using experience from hundreds of hours of testing with many different physical (and QEMU) drives, from the 80s, 90s and newer, including CF cards. A number of bugs and inefficiencies have been removed and the code significantly simplified, preparing for an upcoming interrupt driven version. The driver now works with XMS_buffers.
    - The most important change to the HD drivers is the rewrite of the physical IO part, which attempted to take advantage of the IDE/ATA drives' multiIO feature. While this worked,  it did not take advantage of many of the features ATA provides, such as implied seeks and the ability to completely ignore CHS boundaries (which the drives handle automatically).
    - Several adjustments were required to get the driver to work reliably with a 1986 model 40MB vintage IDE drive on a slow 80286 machine. Many of these adjustments (mainly delay loops and status register checks) will be eliminated when the driver goes asynch/interrutpt driven later.
- A lot of inactive code has been removed.
- Various problems related to conditional compile/config variations have been fixed.
- The floppy formatting code has been 'ifdefed' from the driver, reducing the ram footprint.
- A number of bugs have been eliminated from the direct fd driver, including a 64k boundary alignment problem which revealed itself by the changes to memory allocation for the L1 buffers mentioned above.
- The CONFIG option to turn off the floppy read cache has been removed.