### PR TITLE
Direct floppy driver enhancements

### DIFF
--- a/tlvc/arch/i86/drivers/block/blk.h
+++ b/tlvc/arch/i86/drivers/block/blk.h
@@ -77,6 +77,8 @@ struct drive_infot {            /* CHS per drive*/
 #endif
 };
 extern struct drive_infot *last_drive;	/* set to last drivep-> used in read/write */
+extern int running_qemu;		/* set in directhd if a qemu disk image is detected */
+					/* used to handle QEMU bugs and quirks */
 
 #ifdef CONFIG_BLK_DEV_BHD
 extern unsigned char hd_drive_map[];
@@ -133,6 +135,7 @@ static void floppy_off();	/*(unsigned int nr); */
 #ifdef ATDISK		/* direct hd */
 
 #define DEVICE_NAME "dhd"
+#define DEVICE_INTR do_directhd
 #define DEVICE_REQUEST do_directhd_request
 #define DEVICE_NR(device) (MINOR(device)>>MINOR_SHIFT)
 #define DEVICE_ON(device)
@@ -173,7 +176,7 @@ static void end_request(int uptodate)
     req = CURRENT;
 
     if (!uptodate) {
-	printk("%s[%04x]: I/O error in block %lu\n", DEVICE_NAME, 
+	printk("%s[%04x]: I/O error in sector %lu\n", DEVICE_NAME, 
 		req->rq_dev, req->rq_blocknr);
 
 #ifdef MULTI_BH
@@ -243,6 +246,6 @@ static void end_request(int uptodate)
 		panic("%s: request list destroyed (%d, %d)", \
 			DEVICE_NAME, MAJOR(req->rq_dev), MAJOR_NR); \
 	if (req->rq_bh && !EBH(req->rq_bh)->b_locked) \
-		panic("%s:block not locked", DEVICE_NAME); \
+		panic("%s:buffer not locked", DEVICE_NAME); \
 
 #endif

--- a/tlvc/arch/i86/mm/malloc.c
+++ b/tlvc/arch/i86/mm/malloc.c
@@ -254,12 +254,12 @@ int sys_brk(__pptr newbrk)
     if (newbrk < currentp->t_enddata)
         return -ENOMEM;
 
-    if (currentp->t_begstack > currentp->t_endbrk) {				/* stack above heap?*/
+    if (currentp->t_begstack > currentp->t_endbrk) {		/* stack above heap?*/
         if (newbrk > currentp->t_begstack - currentp->t_minstack) {
-			printk("sys_brk(%d) fail: brk %x over by %u bytes\n",
-				currentp->pid, newbrk, newbrk - (currentp->t_begstack - currentp->t_minstack));
+	    printk("sys_brk(%d) fail: request %d, over by %u bytes\n",
+		currentp->pid, newbrk, newbrk - (currentp->t_begstack - currentp->t_minstack));
             return -ENOMEM;
-		}
+	}
     }
 #ifdef CONFIG_EXEC_LOW_STACK
     if (newbrk > currentp->t_endseg)


### PR DESCRIPTION
An important fix/enhancement update to the direct floppy driver primarily dealing with the 82077 advanced FDC chip and media change detection. Even though the 82077 its now supported,  perpendicular recording (2880k floppies) is still unavailable, a conscious choice based on the fact that media and drives supporting the format are very rare. 

Update summary:

- 82077A FDC support which enables the 16 bit FIFO and implied seeks. No big deal really - the FIFO makes DMA timings more flexible, but the slow systems we're typically running on don't stress memory cycles all that much anyway. The implied seeks are useful in that explicit seeks (and thus seek interrupts) are (almost) eliminated which may speed up things somewhat. OTOH, there aren't many vintage systems out there with this advanced chip anyway, so the advantage is limited.
- The activation of implied seeks delivered a couple of surprises. 
    - A bug in QEMU that manifests itself when running 360k images in 1.2M drives and seeking past track 20, is eliminated by implied seeks (and QEMU always 'runs' the 82077 chip). OTOH, on a physical system, a 360k floppy in a 1.2M drive WILL NOT WORK with implied seeks. Both of these cases are handled in this version of the driver, which uses a global `running_qemu` flag set in the `directhd` driver and defined in `blk.h`. [The QEMU hack that was introduced in an early commit in this PR was removed when the implied seek trick was discovered.]
    - The need to change FDC configuration to accommodate the 360k case complicates the driver logic somewhat: When copying floppy-to-floppy and one of them is 360k medium in a 1.2M drive, the FDC must be (re)configured per transaction, a situation that may call into question the benefit of activating implied seeks in the first place.
- [Experimental] Like before the driver uses a 18 sector track buffer in low memory to speed up reads. New in this version (and somewhat alleviating the problem discussed above) is that the track buffer is now a cylinder buffer for smaller drives, which typically have 18 sectors per cylinder or less. However, the jury is still out as to whether this is advantageous or not. If a small floppy is the root FS, cylinder buffering is most likely a disadvantage, the same goes for file copying between floppies unless the copy buffer exceeds the stack capacity, while file copying from floppy to HD will definitely benefit. Your milage will vary wildly, and this capability will become configurable in the future. An interesting worst case scenario is running the `cmp` command - one file on a 360k FAT floppy in a 1.2M drive, the other on a 720k FAT floppy in a 1.44M drive. `cmp`  reads 2k from each file and compares, then repeats: Every other read operation reads a full cylinder. A detailed benchmark is required in order to find out, preferably using a raw device, bypassing the buffer system. In a more general case, an important question is whether the FDC manages to read the 2nd track without losing a disk rotation. In any case, one rotation being ⅙ of a second is a steep price to pay if the buffered data is useful only half the time or less. BTW - this particular setting (low cap media in high cap drives) is also interesting from another vantage point: Underscoring the importance of keeping track of the FDC configuration, which needs to be changed for just about every operation.
- This version also takes a stab at cleaning up the MEDIA_CHANGE detection logic - in several steps.
    - An `ifdef` enables complete removal of the code dealing with the `DIR` register and media change. This is good for pre-AT systems which have no means of media change detection and the code is wasted. In fact any system will run just fine with the code commented out, but with the risk of compromising floppies if changed while mounted.
    - Further, if the media change code is included, it will disable itself if the system is pre-AT, which means the code will run as is on older systems.
    - What's still missing is the disabling of the media change support on physical 360k drives (CMOS type 1). These drives have no media change line.
    - Also missing is a test for the media change line being permanently on. Some 5.25in drives use the media change line (pin 34) as a ready signal, always on when the motor is spinning and head loaded. Such drives will now hang the driver and (probably) the system/OS.
- The code has been reorganized somewhat so that the configuration-related `ifdefs` appear together for easier apdaption to local requirements.
- The `directhd` driver has been updated to recognize 'QEMU' as part of the IDE drive serial number and set a global flag accordingly. Useful for the floppy driver to get around the 360k floppy bug, and possibly other kernel level subsystems. In order to benefit from they 'magic', the IDE ID string must be set in the qemu startup script, like this: `-global ide-hd.serial=EQUMI_ED`. Notice the byte swapped text. Only the first two bytes of the ID (EQ) are used for the test. 
