### PR TITLE
[net] Experimental - the ne2k driver now uses heap_alloc() for buffers

### DIFF
--- a/tlvc/arch/i86/drivers/net/ne2k.c
+++ b/tlvc/arch/i86/drivers/net/ne2k.c
@@ -436,6 +436,13 @@ static int ne2k_open(struct inode *inode, struct file *file)
 		}
 		ne2k_reset();
 		ne2k_init();
+#if (NET_OBUFCNT > 0)
+		tnext = netbuf_init(net_obuf, NET_OBUFCNT);
+#endif
+#if (NET_IBUFCNT > 0)
+		rnext = netbuf_init(net_ibuf, NET_IBUFCNT);
+#endif
+
 		ne2k_start();
 	}
 	return 0;
@@ -449,6 +456,10 @@ static void ne2k_release(struct inode *inode, struct file *file)
 {
 	if (--usecount == 0) {
 		ne2k_stop();
+#ifdef USE_HEAP_BUFFER
+		netbuf_release(tnext);
+		netbuf_release(rnext);
+#endif
 		free_irq(net_irq);
 	}
 }
@@ -506,13 +517,6 @@ void INITPROC ne2k_drv_init(void)
 	mac_addr = (byte_t *)&netif_stat.mac_addr;
 
 	net_port = NET_PORT;    // ne2k-asm.S needs this.
-
-#if (NET_OBUFCNT > 0)	/* redo this if we add more than 2 buffers */
-	tnext = netbuf_init(net_obuf, NET_OBUFCNT);
-#endif
-#if (NET_IBUFCNT > 0)	/* redo this if we add more than 2 buffers */
-	rnext = netbuf_init(net_ibuf, NET_IBUFCNT);
-#endif
 
 	while (1) {
 		int j, k;

--- a/tlvc/arch/i86/drivers/net/netbuf.c
+++ b/tlvc/arch/i86/drivers/net/netbuf.c
@@ -3,13 +3,35 @@
  */
 
 #include "netbuf.h"
+#include <linuxmt/kernel.h>
+#include <linuxmt/heap.h>
 
-struct netbuf * netbuf_init(struct netbuf *buf, int cnt) {
+struct netbuf *netbuf_init(struct netbuf *buf, int cnt) {
 	int i;
 	for (i = 0; i < cnt; i++) {
+#ifdef USE_HEAP_BUFFER
+		buf[i].data = NULL;
+		if (!(buf[i].data = heap_alloc(MAX_PACKET_ETH, HEAP_TAG_BUFHEAD))) {
+			printk("eth: Buffer alloc failed\n");
+			netbuf_release(&buf[0]);
+			return(NULL);
+		}
+		printk("netbuf got %x\n", buf[i].data);
+#endif
 		buf[i].len = 0;
 		buf[i].next = &buf[i+1];
 	}
 	buf[--i].next = &buf[0];
 	return(&buf[0]);
 }
+
+#ifdef USE_HEAP_BUFFER
+void netbuf_release(struct netbuf *buf) {
+	struct netbuf *n = buf;
+	do {
+		heap_free(n->data);
+		printk("netbuf rel %x\n", n->data);
+		n = n->next;
+	} while (n != buf);
+}
+#endif

--- a/tlvc/arch/i86/drivers/net/netbuf.c
+++ b/tlvc/arch/i86/drivers/net/netbuf.c
@@ -10,7 +10,7 @@ struct netbuf *netbuf_init(struct netbuf *buf, int cnt) {
 	int i;
 	for (i = 0; i < cnt; i++) {
 #ifdef USE_HEAP_BUFFER
-		if (!(buf[i].data = heap_alloc(MAX_PACKET_ETH, HEAP_TAG_BUFHEAD))) {
+		if (!(buf[i].data = heap_alloc(MAX_PACKET_ETH, HEAP_TAG_NETWORK))) {
 			printk("eth: Buffer alloc failed\n");
 			netbuf_release(&buf[0]);
 			return(NULL);

--- a/tlvc/arch/i86/drivers/net/netbuf.c
+++ b/tlvc/arch/i86/drivers/net/netbuf.c
@@ -10,13 +10,12 @@ struct netbuf *netbuf_init(struct netbuf *buf, int cnt) {
 	int i;
 	for (i = 0; i < cnt; i++) {
 #ifdef USE_HEAP_BUFFER
-		buf[i].data = NULL;
 		if (!(buf[i].data = heap_alloc(MAX_PACKET_ETH, HEAP_TAG_BUFHEAD))) {
 			printk("eth: Buffer alloc failed\n");
 			netbuf_release(&buf[0]);
 			return(NULL);
 		}
-		printk("netbuf got %x\n", buf[i].data);
+		//printk("netbuf got %x\n", buf[i].data);
 #endif
 		buf[i].len = 0;
 		buf[i].next = &buf[i+1];
@@ -30,7 +29,7 @@ void netbuf_release(struct netbuf *buf) {
 	struct netbuf *n = buf;
 	do {
 		heap_free(n->data);
-		printk("netbuf rel %x\n", n->data);
+		//printk("netbuf rel %x\n", n->data);
 		n = n->next;
 	} while (n != buf);
 }

--- a/tlvc/arch/i86/drivers/net/netbuf.h
+++ b/tlvc/arch/i86/drivers/net/netbuf.h
@@ -8,6 +8,7 @@
 
 #define NET_OBUFCNT 2
 #define NET_IBUFCNT 2
+#define USE_HEAP_BUFFER
 
 #ifndef __ASSEMBLER__
 
@@ -16,8 +17,14 @@
 struct netbuf {
 	int len;			/* ZERO if available */
 	struct netbuf *next;
-	char data[MAX_PACKET_ETH];	/* full size for now */
+#ifdef USE_HEAP_BUFFER
+	char *data;	/* allocate from heap */
+#else
+	char data[MAX_PACKET_ETH];
+#endif
 };
+
+void netbuf_release(struct netbuf *);
 
 #if (NET_IBUFCNT > 0)
 struct netbuf net_ibuf[NET_IBUFCNT];

--- a/tlvc/include/linuxmt/heap.h
+++ b/tlvc/include/linuxmt/heap.h
@@ -23,6 +23,7 @@
 #define HEAP_TAG_INTHAND 0x04
 #define HEAP_TAG_BUFHEAD 0x05
 #define HEAP_TAG_PIPE    0x06
+#define HEAP_TAG_NETWORK 0x07	/* packet buffer allocations */
 
 
 // TODO: move free list node from header to body

--- a/tlvccmd/sys_utils/meminfo.c
+++ b/tlvccmd/sys_utils/meminfo.c
@@ -54,7 +54,7 @@ void dump_heap(int fd)
 	word_t total_size = 0;
 	word_t total_free = 0;
 	long total_segsize = 0;
-	static char *heaptype[] = { "free", "SEG ", "STR ", "TTY ", "INT ", "BUFH", "PIPE" };
+	static char *heaptype[] = { "free", "SEG ", "STR ", "TTY ", "INT ", "BUFH", "PIPE", "NETW" };
 	static char *segtype[] = { "free", "CSEG", "DSEG", "BUF ", "RDSK", "PROG" };
 
 	printf("  HEAP   TYPE  SIZE    SEG   TYPE    SIZE  CNT\n");


### PR DESCRIPTION
This PR (optionally) changes network driver I/O buffer allocation from static to using the kernel heap (`heap_alloc()`). Buffer configuration is still done in `netbuf.h` and the allocation scheme is easily switched between static (old) and heap (new) (`#define USE_HEAP_BUFFER`).

Only the `ne2k` driver fully implements this ability at this time, the other drivers are pending (more testing needed).

Heap buffer allocation can be tracked via the `meminfo` command which will reveal that the buffers are allocated individually, not in one (or two) chunks. For now this is the simplest. However tempting (and efficient) it may be to allocate one buffer and split it in the driver(s), the current scheme is more flexible and will allow (future) backtracking in case we run out of heap space while allocating.

In order to add more flexibility, a `bootopts` option to set the # of receive and transmit buffers (and their sizes) is attractive, not the least to investigate the relationship between buffers and speed.
