### PR TITLE
[Directhd] Add 8bit ISA support (+ minor network update)

### DIFF
--- a/tlvc/arch/i86/drivers/block/directhd.c
+++ b/tlvc/arch/i86/drivers/block/directhd.c
@@ -56,6 +56,7 @@
 #include <linuxmt/directhd.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/errno.h>
+#include <linuxmt/config.h>
 #include <linuxmt/stat.h>	/* for S_ISCHR() */
 
 #include <arch/hdreg.h>
@@ -71,7 +72,7 @@
 
 /* #define USE_ASM */
 /* use asm insw/outsw instead of C version */
-/* asm versions should work on 8088/86, but only with CONFIG_PC_XT */
+/* asm versions should work on 8088/86, but only with CONFIG_HW_PCXT */
 
 /* We've instructed GCC to generate 8086 code, this does not fit */
 /* FIXME: Use #pragmas */
@@ -119,7 +120,7 @@ static int io_ports[2] = { HD1_PORT, HD2_PORT };
 static int cmd_ports[2] = { HD1_CMD, HD2_CMD };
 
 #if defined(USE_LOCALBUF) || defined(CONFIG_FS_XMS_BUFFER)
-static char localbuf[BLOCK_SIZE];	/* bounce buffer for debugging and
+static byte_t localbuf[BLOCK_SIZE];	/* bounce buffer for debugging and
 					 * XMS buffer bouncing */
 #endif
 
@@ -178,6 +179,17 @@ void directhd_geninit(void)
 }
 
 /* assumes current data segment - which is kernel_ds */
+
+#ifdef CONFIG_HW_PCXT
+void insb(unsigned int port, byte_t *buffer, int count)
+{
+    do {
+	*buffer++ = inb(port);
+    } while (--count);
+}
+
+#else
+
 void insw(unsigned int port, word_t *buffer, int count)
 {
     count >>= 1;
@@ -186,6 +198,7 @@ void insw(unsigned int port, word_t *buffer, int count)
 	*buffer++ = inw(port);
     } while (--count);
 }
+#endif
 
 
 void read_data(unsigned int port, ramdesc_t seg, word_t *buffer, int count, int raw)
@@ -193,13 +206,24 @@ void read_data(unsigned int port, ramdesc_t seg, word_t *buffer, int count, int 
 
 #if defined(CONFIG_FS_XMS_BUFFER) || defined(USE_LOCALBUF) /* use bounce buffer */
     if (!raw) {	
+#ifdef CONFIG_HW_PCXT
+	insb(port, (byte_t *)localbuf, count);
+#else
 	insw(port, (word_t *)localbuf, count);
+#endif
 	//printk("insw %d %04x %04x %04x;", count, localbuf, buffer, *(word_t *)localbuf);
 	xms_fmemcpyw(buffer, seg, localbuf, kernel_ds, count/2);
     } else
 #endif
     {
 
+#ifdef CONFIG_HW_PCXT
+	byte_t __far *locbuf = _MK_FP(seg, (unsigned)buffer);
+
+	do {
+	    *locbuf++ = inb(port);
+	} while (--count);
+#else
 	unsigned int __far *locbuf = _MK_FP(seg, (unsigned)buffer);
 
 	count >>= 1;	/* bytes -> words */
@@ -207,15 +231,28 @@ void read_data(unsigned int port, ramdesc_t seg, word_t *buffer, int count, int 
 	do {
 	    *locbuf++ = inw(port);
 	} while (--count);
+#endif
     }
 }
 
 #if defined(USE_LOCALBUF) || defined(CONFIG_FS_XMS_BUFFER)
 
-void outsw(unsigned int port, word_t *buffer, int count)
+#ifdef CONFIG_HW_PCXT
+void outsb(unsigned int port, byte_t *buffer, int count)
 {
     int i;
 
+    for (i = 0; i < count; i++) {
+	outb(buffer[i], port);
+    }
+    return;
+}
+
+#else
+
+void outsw(unsigned int port, word_t *buffer, int count)
+{
+    int i;
     count >>= 1;
     //printk("%04x:", buffer);
     for (i = 0; i < count; i++) {
@@ -224,6 +261,7 @@ void outsw(unsigned int port, word_t *buffer, int count)
     return;
 }
 #endif
+#endif
 
 void write_data(unsigned int port, ramdesc_t seg, word_t *buffer, int count, int raw)
 {
@@ -231,17 +269,30 @@ void write_data(unsigned int port, ramdesc_t seg, word_t *buffer, int count, int
 
     if (!raw) {
 	xms_fmemcpyw(localbuf, kernel_ds, buffer, seg, count/2);
+#ifdef CONFIG_HW_PCXT
+	outsb(port, localbuf, count);
+#else
 	outsw(port, (word_t *)localbuf, count);
+#endif
     } else 
 #endif
     {
+
+	//printk("%x,%x,%x,%lx,%d;", port, buffer, seg, locbuf, count);
+#ifdef CONFIG_HW_PCXT
+	byte_t __far *locbuf = _MK_FP(seg, (unsigned)buffer);
+
+	do {
+	    outb(*locbuf++, port);
+	} while (--count);
+#else
 	unsigned int __far *locbuf = _MK_FP(seg, (unsigned)buffer);
 
 	count >>= 1;
-	//printk("%x,%x,%x,%lx,%d;", port, buffer, seg, locbuf, count);
 	do {
 	    outw(*locbuf++, port);
 	} while (--count);
+#endif
     }
 }
 
@@ -266,9 +317,7 @@ void swap_order(unsigned char *buffer,int count)
 void out_hd(unsigned int drive, unsigned int nsect, unsigned int sect,
 	    unsigned int head, unsigned int cyl, unsigned int cmd)
 {
-    word_t port;
-
-    port = io_ports[drive >> 1];
+    word_t port = io_ports[drive >> 1];
 
     /* setting WPCOM to 0 is not good. this change uses the last value input to
      * the drive. (my BIOS sets this correctly, so it works for now but we should
@@ -280,6 +329,7 @@ void out_hd(unsigned int drive, unsigned int nsect, unsigned int sect,
 
     //outb_p(0x20, ++port);		/* means 128 (x4), test value for conner 40M */
     outb_p(0xff, ++port);		/* the supposedly correct value for WPCOM on IDE */
+					/* CF cards ignore this */
     outb_p(nsect, ++port);
     outb_p(sect, ++port);
     outb_p(cyl, ++port);
@@ -301,6 +351,27 @@ static void dump_ide(word_t *buffer, int size) {
                 }
         } while (--size);
         if (counter) printk("\n");
+}
+#endif
+
+#ifdef CONFIG_HW_PCXT
+static int ata_set_feature(unsigned int drive, unsigned int cmd)
+{
+	word_t port = io_ports[drive >> 1];
+	int err = 0;
+
+	outb_p(drive<<4, port + ATA_DH);
+	outb_p(cmd, port + ATA_FEATURES);
+	outb_p(ATA_SET_FEAT, port + ATA_COMMAND);
+
+	while(WAITING(port)) mdelay(1000);
+	if (STATUS(port) & ERR_STAT) {
+		printk("athd%d: feature not available: %x, %x\n", 
+			drive, cmd, ERROR(port));
+		err++;	/* 'Abort' is the only possible error condition here, */
+			/* which means 'command not implemented'. */
+	}
+	return err;
 }
 #endif
 
@@ -327,10 +398,21 @@ int INITPROC directhd_init(void)
 
     for (drive = 0; drive < 2/*MAX_ATA_DRIVES*/; drive++) {
 	if (!drive&1) reset_controller(drive/2);
-	/* send drive_ID command to drive */
-	out_hd(drive, 0, 0, 0, 0, ATA_DRIVE_ID);
-
 	port = io_ports[drive / 2];
+
+#ifdef CONFIG_HW_PCXT
+	i = 0;
+	i += ata_set_feature(drive, ATA_FEAT_8BIT);
+	i += ata_set_feature(drive, ATA_FEAT_NO_WCACHE);	/* disable write cache */
+	i += ata_set_feature(drive, ATA_FEAT_SAVE);	/* features will now survive soft reset */
+	if (i) {
+	    printk("athd%d: Failed to set 8bit mode, drive disabled\n", drive);
+	    continue;
+	}
+#endif
+
+	/* Get drive specs */
+	out_hd(drive, 0, 0, 0, 0, ATA_DRIVE_ID);
 
 	/* wait -- if status is 0xff, there is no drive with this number */
 	mdelay(OLD_IDE_DELAY);
@@ -347,7 +429,11 @@ int INITPROC directhd_init(void)
 	/* get drive info */
 	while (WAITING(port)) mdelay(OLD_IDE_DELAY);
 
+#ifdef CONFIG_HW_PCXT
+	insb(port, (byte_t *)ide_buffer, 512);
+#else
 	insw(port, ide_buffer, 512);
+#endif
 #if 0
 	swap_order(buffer, 512);
 #endif
@@ -385,7 +471,7 @@ int INITPROC directhd_init(void)
 	dp->ctl = 0;
 #ifdef DEBUG
 	dump_ide(ide_buffer, 64);
-	//ide_buffer[53] = 0; /* force old ide behaviour for debuging */
+	//ide_buffer[53] = 0; /* force old ide behaviour for debugging */
 #endif
 	ide_buffer[20] = 0; /* String termination */
 	if (ide_buffer[10] == 0x4551)	/* Crude QEMU detection */
@@ -394,14 +480,15 @@ int INITPROC directhd_init(void)
 	    /* Physical CHS data @ (word) offsets: cyl@1, heads@3, sectors@6 */
 	    /* Actual CHS data @ (word) offsets: cyl@54, heads@55, sectors@56 */
 
-	    dp->multio_max = ide_buffer[47] & 0xff; /* max sectors per multi io op */
-	    					    /* zero if unsupported */
+	    if ((dp->multio_max = ide_buffer[47] & 0xff) == 1)  /* max sectors per multi io op */
+		dp->multio_max = 0;	/* zero if unsupported, 1 is useless */
 	    if (ide_buffer[53]&1) {	/* check the 'validity bit'. If set, use 
 	    				 * 'current' values, otherwise defaults.
 					 * Usually indicates old vs new tech. */
 		dp->cylinders = ide_buffer[54];
 		dp->heads = ide_buffer[55];
 		dp->sectors = ide_buffer[56];
+		*ide_chs = 0; 	/* ignore bootopts value */
 	    } else {		/* old drive, limited ID, limited cmd set */
 		if (drive == 0 && *ide_chs > 0) {
 			dp->cylinders = ide_chs[0];
@@ -416,20 +503,22 @@ int INITPROC directhd_init(void)
 	    }
 
 	    hdcount++;
-	    printk("IDE CHS: %d/%d/%d %sserial# %s\n", dp->cylinders, dp->heads, dp->sectors,
-		ide_chs[0] ? "(from /bootopts) " : "", &ide_buffer[10]);
+	    printk("athd%d: IDE CHS: %d/%d/%d %sserial# %s\n", drive, dp->cylinders,
+		dp->heads, dp->sectors, ide_chs[0] ? "(from /bootopts) " : "", &ide_buffer[10]);
+#ifdef CONFIG_HW_PCXT
+	    printk("athd%d: XT-mode, 8bit bus transfers\n", drive);
+#endif
 
 	    /* Initialize settings. Some (old in particular) drives need this
 	     * and will default to some odd default values otherwise */
 	    /* NOTE: In older docs this cmd is known as 'Initialize Drive Parameters' */
 	    out_hd(drive, dp->sectors, 0, dp->heads - 1, 0, ATA_SPECIFY);
 	    while(WAITING(port)) mdelay(1000);
-	    if (STATUS(port) & ERR_STAT) printk("err %x;", ERROR(port)); /* DEBUG */
+	    if (STATUS(port) & ERR_STAT) printk("athd%d err in specify: %x;", ERROR(port)); /* DEBUG */
 
 #ifdef USE_MULTISECT_IO	
 	    if (dp->multio_max) {
-		/* Set multiple IO mode, default to 2 sectors per op - if available */
-		/* EDIT: set to max always, experimental */
+		/* Set multiple IO mode, set to max always, experimental */
 		out_hd(drive, dp->multio_max, 0, 0, 0, ATA_SET_MULT);
 		while (WAITING(port));
 		if (!(STATUS(port) & ERR_STAT)) {

--- a/tlvc/arch/i86/drivers/block/genhd.c
+++ b/tlvc/arch/i86/drivers/block/genhd.c
@@ -215,7 +215,9 @@ static int INITPROC msdos_partition(struct gendisk *hd,
 #ifdef CONFIG_ARCH_PC98
     struct partition_pc98 *p98;
 #endif
+#ifdef USE_EXTENDED_PARTITION
     register struct hd_struct *hdp;
+#endif
     unsigned short int i, minor = current_minor;
 
     if (!(bh = bread(dev, (block_t) 0))) {
@@ -250,11 +252,11 @@ out:
     p = (struct partition *) (bh->b_data + 0x1be);
     current_minor += 4;
     for (i = 1; i <= 4; minor++, i++, p++) {
-	hdp = &hd->part[minor];
 	if (!NR_SECTS(p))
 	    continue;
 	add_partition(hd, minor, first_sector + START_SECT(p), NR_SECTS(p));
 #ifdef USE_EXTENDED_PARTITION
+	hdp = &hd->part[minor];
 	if (is_extended_partition(p)) {
 	    printk(" <");
 	    /*

--- a/tlvc/arch/i86/drivers/block/init.c
+++ b/tlvc/arch/i86/drivers/block/init.c
@@ -47,7 +47,7 @@ void INITPROC device_init(void)
 
     for (p = gendisk_head; p; p = p->next)
 	setup_dev(p);
-    printk("boot_rootdev 0x%x, ", boot_rootdev);
+    //printk("boot_rootdev 0x%x, ", boot_rootdev);
 
     /*
      * The bootloader may have passed us a ROOT_DEV which is actually a BIOS

--- a/tlvc/arch/i86/drivers/net/el3.c
+++ b/tlvc/arch/i86/drivers/net/el3.c
@@ -144,6 +144,10 @@ struct file_operations el3_fops =
 void INITPROC el3_drv_init(void) {
 	ioaddr = net_port;		// temporary
 
+	if (!ioaddr) {
+		printk("el3: ignored\n");
+		return;
+	}
 	verbose = (net_flags&ETHF_VERBOSE);
 	if (el3_isa_probe() == 0) {
 		found++;

--- a/tlvc/arch/i86/drivers/net/ne2k-asm.S
+++ b/tlvc/arch/i86/drivers/net/ne2k-asm.S
@@ -928,7 +928,7 @@ ne2k_probe:
 	in	%dx,%al
 	cmp	$0xff,%al	// cannot be FF
 	jz	np_err
-	cmp	$0,%al		// cannot be 0
+	test	%al,%al		// cannot be 0
 	jz	np_err
 	
 	xor     %ax,%ax

--- a/tlvc/arch/i86/drivers/net/ne2k.c
+++ b/tlvc/arch/i86/drivers/net/ne2k.c
@@ -533,6 +533,10 @@ void INITPROC ne2k_drv_init(void)
 	mac_addr = (byte_t *)&netif_stat.mac_addr;
 
 	net_port = NET_PORT;    // ne2k-asm.S needs this.
+	if (!net_port) {
+		printk("eth: %s ignored\n", dev_name);
+		return;
+	}
 
 	err = ne2k_probe();
 	verbose = (net_flags&ETHF_VERBOSE);

--- a/tlvc/arch/i86/drivers/net/netbuf.h
+++ b/tlvc/arch/i86/drivers/net/netbuf.h
@@ -8,8 +8,9 @@
 
 /* Buffer configuration for TLVC Ethernet NICs
  *
- * There are 3 strastegies:
- * - No buffers: Data is moved to/from the requester (via far mem move).
+ * There are 3 buffer strategies:
+ * - No buffers: The driver is moving data directly to/from the requester
+ *	(via far mem move).
  * - Static buffers: The number of send and receive buffers specified in the
  *	NET_OBUFCNT and NET_IBUFCNT defines are allocated statically at
  *	compile time. The BUFCNT numbers may be 0, in which case the driver

--- a/tlvc/arch/i86/drivers/net/wd.c
+++ b/tlvc/arch/i86/drivers/net/wd.c
@@ -712,6 +712,10 @@ void INITPROC wd_drv_init(void)
 	word_t hw_addr[6U];
 	byte_t *mac_addr = (byte_t *)&netif_stat.mac_addr;
 
+	if (!net_port) {
+		printk("eth: %s ignored\n", dev_name);
+		return;
+	}
 	u = wd_probe();
 	printk("eth: %s at 0x%x, irq %d, ram 0x%x",
 		dev_name, net_port, net_irq, net_ram);

--- a/tlvc/config.in
+++ b/tlvc/config.in
@@ -16,6 +16,7 @@ mainmenu_option next_comment
 
 		bool 'Compaq DeskPro Hardware (fast mode)' CONFIG_HW_COMPAQFAST n
 		bool 'MK-88 Hardware (IRQ 3 keyboard)' CONFIG_HW_MK88 n
+		bool 'IBM PC/XT or compatible (8bit ISA)' CONFIG_HW_PCXT n
 
 		comment 'Devices'
 


### PR DESCRIPTION
## Add 8bit ISA (PC/XT) support to the directhd driver

This PR adds `directhd` support for the XT and other PC compatibles with 8 bit ISA bus. The 'XT-mode' is activated via `menuconfig`, setting the `CONFIG_HW_PCXT` define. When activated, the XT-mode will be noted in the boot messages along with the normal configuration output:
```
athd0: XT-mode, 8bit bus transfers
```
When XT-mode is active, the driver may or may not work on a 16 bit system, see below. 
The (relatively simple) driver changes includes switching from word IO to byte IO operations, and setting the IDE device to 8bit mode.

Also included are a few bug fixes for problems discovered while testing on new hardware.

Notable experiences/observations:
- The driver expects an AT compatible IDE controller installed in the machine at the standard AT premier disk IO address.
- In the near future the driver will be interrupt driven. On XT compatible (8bit ISA) systems, the driver will then expect IRQ5 to be available.
- There is NO BIOS support for such controllers on XT-level systems, so there is no direct booting from the IDE drive (using `root=dhda1` or similar in the floppy `/bootopts` (or XT-IDE/XT-CF, see below) works fine). 
- The IDE device must be capable of 8bit mode. Most older CF cards have this capability - 128M, 512M, 2G. Newer cards may or may not work. Very old IDE disks (like the ones included with the first generation of AT-kompatible systems) will NOT work, drives from the 90s are more likely to work. The driver will report (then ignore) drives/cards that refuse the 'set 8bit' feature command. Be aware though that some devices just ignore the command silently and the system boot will fail in mysterious ways. If the system reports very odd CHS values during boot, it's likely that this is the problem.
- QEMU does NOT support switching to 8bit mode.
- This driver does not support XT-IDE type controllers (including XT-CF variants) for several reasons, the most important being that they modify the register addresses of the device. Also, there is no IRQ support on these cards. A dedicated XT-IDE driver is in the works. (XT-IDE has other problems too, covered in a Wiki document).
- While waiting for an XT-IDE/CF driver, such card may still be useful: Using the `root=` directive in `bootopts`, the IDE-CF drive can bootstrap the IDE-card and -drive by either using the FAT bootstrap and placing the TLVC kernel + `bootopts` file in the root directory of a bootable FAT partition. Or creating a small Minix partition on the drive with the same two files. It may sound complicated - but isn't.

Developed and tested on an IBM 5155 Portable.

## network update 
It is sometimes convenient to avoid probing of nonexistent network interfaces - or just disable them even if present. In particular when diagnosing mysterious boot problems - a common situation with old hardware.

This PR adds checking for IO address 0x0 in all ethernet drivers - presumably set in `bootopts`. If true, the interface is not probed and reported as `ignored`.

```
wd0=10,0x00,0xCC00,0x80
```