### PR TITLE
[directhd] Added 8bit (PC/XT) support for AT/IDE, supports XT/IDE controllers (CF)

### DIFF
--- a/tlvc/arch/i86/drivers/block/config.in
+++ b/tlvc/arch/i86/drivers/block/config.in
@@ -34,6 +34,9 @@ mainmenu_option next_comment
 	    bool '  DIRECT IDE hardisk support'	CONFIG_BLK_DEV_HD	y
 	    bool '  DIRECT floppy disk support'	CONFIG_BLK_DEV_FD	y
 	fi
+	if [ "$CONFIG_HW_PCXT" = "y" ]; then
+	    bool '  XT/CF-lite is primary HD @0x300' CONFIG_HW_CFIDE0	y
+	fi
 
 	if [ "$CONFIG_BLK_DEV_FD" = "y" ]; then
 	    define_bool CONFIG_DMA y

--- a/tlvc/arch/i86/drivers/block/genhd.c
+++ b/tlvc/arch/i86/drivers/block/genhd.c
@@ -367,7 +367,6 @@ void INITPROC setup_dev(register struct gendisk *dev)
 		int first_minor = i << dev->minor_shift;
 		current_minor = (unsigned short) (first_minor + 1);
 		check_partition(dev, MKDEV(dev->major, first_minor));
-		//if (j == dev->nr_real) break;
 	}
 #endif
 

--- a/tlvc/arch/i86/drivers/block/genhd.c
+++ b/tlvc/arch/i86/drivers/block/genhd.c
@@ -24,6 +24,7 @@
 #include <linuxmt/major.h>
 #include <linuxmt/string.h>
 #include <linuxmt/memory.h>
+#include <linuxmt/directhd.h>
 
 #include <arch/system.h>
 
@@ -307,7 +308,7 @@ static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
     first_time = 0;
     first_sector = hd->part[MINOR(dev)].start_sect;
 
-#if UNUSED
+#if 1
     /*
      * This is a kludge to allow the partition check to be
      * skipped for specific drives (e.g. IDE cd-rom drives)
@@ -353,6 +354,7 @@ void resetup_one_dev(struct gendisk *dev, int drive)
 
 void INITPROC setup_dev(register struct gendisk *dev)
 {
+	//int j = 0;
 #ifdef BDEV_SIZE_CHK
 	blk_size[dev->major] = NULL;
 #endif
@@ -361,10 +363,11 @@ void INITPROC setup_dev(register struct gendisk *dev)
 	dev->init(dev);
 
 #if defined(CONFIG_BLK_DEV_BHD) || defined(CONFIG_BLK_DEV_HD)
-	for (int i = 0; i < dev->nr_real; i++) {
+	for (int i = 0; i < MAX_ATA_DRIVES; i++) {
 		int first_minor = i << dev->minor_shift;
 		current_minor = (unsigned short) (first_minor + 1);
 		check_partition(dev, MKDEV(dev->major, first_minor));
+		//if (j == dev->nr_real) break;
 	}
 #endif
 

--- a/tlvc/include/arch/ports.h
+++ b/tlvc/include/arch/ports.h
@@ -9,21 +9,18 @@
  *  2*  Cascade -> 9 on AT  CONFIG_ETH_WD           Optional on XT, not available on AT
  *  3   Com2 (/dev/ttyS1)   CONFIG_CHAR_DEV_RS      Optional
  *  4   Com1 (/dev/ttyS0)   CONFIG_CHAR_DEV_RS      Optional
- *  5*  Unused
- *  5*  Com3 (/devb/ttyS2)  CONFIG_CHAR_DEV_RS      Optional
- *  5*  HW IDE hard drive   CONFIG_BLK_DEV_HD       Driver doesn't work
- *  6*  Unused
- *  6*  HW floppy drive     CONFIG_BLK_DEV_FD       Driver doesn't compile
- *  7   Unused (LPT, Com4)
+ *  5*  PC/XT MFM or IDE HD CONFIG_BLK_DEV_HD
+ *  6*  STD floppy ctrlr    CONFIG_BLK_DEV_FD
+ *  7   Unused (LPT, Com3)
  *  8   Unused (RTC)
  *  9   3C509/EL3 (/dev/eth) CONFIG_ETH_EL3         Optional
- * 10   Unused (USB)                                Turned off
- * 11   Unused (Sound)                              Turned off
+ * 10   Available - use for Com4, Ethernet, ...
+ * 11   Available - use for e.g. Ethernet
  * 12   NE2K (/dev/eth)     CONFIG_ETH_NE2K         Optional
  * 12*  Unused (Mouse)                              Turned off
  * 13   Unused (Math coproc.)                       Turned off
- * 14*  AT HD IDE (/dev/hda) CONFIG_BLK_DEV_HD      Driver doesn't work
- * 15*  AT HD IDE (/dev/hdb) CONFIG_BLK_DEV_HD      Driver doesn't work
+ * 14*  AT HD IDE (/dev/hda+b) CONFIG_BLK_DEV_HD
+ * 15*  AT HD IDE (/dev/hdc+d) CONFIG_BLK_DEV_HD
  *
  * Edit settings below to change port address or IRQ:
  *   Change I/O port and driver IRQ number to match your hardware
@@ -114,11 +111,12 @@
 /* bioshd.c*/
 #define FDC_DOR		0x3F2		/* floppy digital output register*/
 
-/* experimental IDE hard drive, directhd.c */
+/* IDE hard drive, directhd.c */
 #define HD1_PORT	0x1f0
 #define HD2_PORT	0x170
-#define HD_IRQ		5		/* missing request_irq call*/
-#define HD1_AT_IRQ	14		/* missing request_irq call*/
-#define HD2_AT_IRQ	15		/* missing request_irq call*/
+#define XTIDE_PORT	0x300		/* 8bit XT/IDE or CF cards, usually w/BIOS */
+#define HD_IRQ		5
+#define HD1_AT_IRQ	14
+#define HD2_AT_IRQ	15
 
 #define FLOPPY_IRQ	6

--- a/tlvc/include/linuxmt/directhd.h
+++ b/tlvc/include/linuxmt/directhd.h
@@ -6,14 +6,15 @@
 #define __LINUXMT_DIRECTHD_H
 
 /* define offsets from base port address */
-#define ATA_ERROR		1
+#define ATA_ERROR		1	/* read */
+#define ATA_FEATURES		1	/* write */
 #define ATA_SEC_COUNT		2
 #define ATA_SECTOR		3
 #define ATA_CYLINDER_LO		4
 #define ATA_CYLINDER_HI		5
-#define ATA_DH			6
-#define ATA_STATUS		7
-#define ATA_COMMAND		7
+#define ATA_DH			6	/* drive # + head */
+#define ATA_STATUS		7	/* read */
+#define ATA_COMMAND		7	/* write */
 
 /* define drive masks */
 #define ATA_DRIVE0 0xa0
@@ -57,6 +58,14 @@
 #define ATA_CFG_SSD	0x04	/* drive is solid state */
 #define ATA_CFG_OLDIDE	0x10	/* Old IDE drive w/ limited cmd set */
 #define ATA_CFG_LBA	0x40	/* Drive has LBA support */
+#define ATA_CFG_XTIDE	0x80	/* XTIDE cards have odd addressing */
+				/* there are many variants, may need details */
+
+/* Per drive SET FEATURE commands */
+#define ATA_FEAT_8BIT	0x01	/* set 8 bit mode */
+#define ATA_FEAT_16BIT	0x81	/* disable 8 bit mode */
+#define ATA_FEAT_NO_WCACHE 0x82	/* Disable write cache */
+#define ATA_FEAT_SAVE	0x66	/* make changes semipermanent */
 
 /* other definitions */
 #define MAX_ATA_DRIVES 4		/* 2 per i/o channel and 2 i/o channels */


### PR DESCRIPTION
This update to the TLVC `directhd` driver has 3 main elements:
1. 8bit ISA support for standard (AT) IDE interfaces. Note that there is no BIOS support for such interfaces on XT type systems. IOW a XT system cannot boot from this interface.
2. Full support for 2 IDE interfaces, 4 drives - enabled by a very simple probe to avoid hangs when accessing a non-existant controller (or something else at that address).
3. Support for XT/IDE type interfaces, an 8bit class of IDE interfaces with many variants, all with non-standard register addressing. This implementation is for the XT/CF-Lite card which has the regular IDE registers at even addresses and the control port at base+1C.

8bit mode is activated by selecting PC/XT architecture in `menuconfig` - `CONFIG_HW_PCXT`. This mode works well on both 16bit and 8bit systems if the drive (or CF card) supports 8bit transfers. Most old CF cards (4gb capacity and lower) do so, most pre-2000 IDE/ATA drives too, but not the first generation IDE drives - 20, 40 and 100M drives for the first gen AT systems. In 8bit mode, the driver will ignore drives that fail to switch to 8bit, notably QEMU drives. 

Be aware that some devices just ignore the command and the system boot will fail in mysterious ways. If the system reports very odd CHS values during boot, it's likely that this is the problem.

When the PC/XT architecture is activated (`menuconfig`), XT/IDE may be selected to include support for the XT/CF-Lite card - located at the address specified in `ports.h`, typically 0x300. A standard IDE interface may coexist and work in tandem with a XT/CF interface.

XT/IDE (CF) cards usually come with BIOS software located at a configurable ROM address. As shipped the software will be called by the main board BIOS and attempt to boot from the card/drive. A properly set up TLVC (or DOS, ELKS or something else) will boot off the bat.

This is an attractive configuration for an XT system as the performance becomes quite reasonable. If using a network (which also works well on 8bit systems), remember to stay off 0x300 as the IO address. (The XT/IDE(CF) cards may be set to other IO addresses in the 0x3xx range, but doing so will make the ob-board BIOS unusable unless recompiled and reflashed.)

The MAX_ATA_DRIVES define (in `directhd..h`) is now honored throughout the driver. In order to save RAM it may be reduced to (say) 2 or even 1.

The new driver has been tested on physical PC/XT (IBM 5155), AT (386SX) systems and QEMU.

The XT/IDE family of cards do not support interrupts. When the driver gets interrupt support, interrupts will be disabled when XT/IDE(CF) is selected.

Since the drive now supports more than one controller, the boot messages have changed. Messages related to an interface are identified by `athX:` where X is 1 or 2. Drive-related messages have not changed, `athdX:`, X ranging from 0 to 3. As devices go, `/dev/dhda` and `/dev/dhdb` belong to interface 0, `/dev/dhdc` and `/dev/dhdd` to interface 1. These device names will soon change, removing the leading 'd' and become the more familiar `/dev/hda` etc.

Devices for `/dev/dhdc` and `/dev/dhdd` are not generated in the default configuration and must be created by hand:
```
mknod /dev/dhdc b 5 64
mknod /dev/dhdd b 5 96
etc.
```
Final note: CF (possibly IDE/ATA drives too) retain the 8bit setting through resets and reboots, even if the IDE command to save the feature is not used. When on a 16bit system, this will cause boot failure because the bios expects a full 16 bit drive. Power-cycling the system will reset the card/drive.

Practical hint: When using an (unbootable)IDE interface (no BIOS support) on an XT, boot from floppy and use the `root=dhda1` (example) setting in `/bootopts to make the hard drive root.

A boot sequence on a PC/XT may look like this:
```
Direct console, scan kbd 80x25 emulating ANSI (3 virtual consoles)
ttyS0 at 0x3f8, irq 4 is an 8250
24 ext buffers (24576B ram), 12 L1 buffers, 12288B ram
eth: ne0 at 0x320, irq 2, (ne1k) MAC 00:1f:11:02:60:2d, flags 0x80, bufs 2r/2t
eth: wd0 at 0x320, irq 11, ram 0xcc00 not found
ath: PC/XT-mode, 8bit bus transfers
ath0: XT/IDE controller at 0x300
athd0: IDE CHS: 993/16/63 serial#     1186202I02E88273
athd0: Multisector I/O, max 4 sects
athd1 (port 0x300) not found (0)
ath2: AT/IDE controller at 0x1f0
athd: found 1 hard drive 
athd: /dev/dhda: 16 heads, 993 cylinders, 63 sectors (~500MB)
Floppy drive(s) [no CMOS]: df0 is 360k/PC (1)
df: Direct floppy driver, FDC (8272A) @ irq 6, DMA 2
Partitions: dhda:(0,1000944)  dhda1:(63,131985)  dhda2:(132048,133056)  dhda3:(265104,133056)
      dhda4:(398160,601776) 
device_setup: root device 0x501
PC/XT class machine, syscaps 0x0, 640K base ram, 16 tasks.
TLVC kernel 0.6.0 (59664 text, 14848 ftext, 11264 data, 29856 bss, 24414 heap)
Kernel text 2d0:0, ftext 1161:0, init 1319:0, data 1501:0, top a000:0, 499K free
read_super, got 0; MINIX: inodes 21845 imap 3 zmap 8, first data 696

MINIX-fs: mounting unchecked file system 0x501, running fsck is recommended.
VFS: Mounted root 0x0501 (minix filesystem).
Running /etc/rc.sys script
Starting networking on ne0
ktcp -b -p ne0 10.0.2.16 10.0.2.2 255.255.255.0
ktcp: ip 10.0.2.16, gateway 10.0.2.2, netmask 255.255.255.0
ktcp: /dev/ne0 mac 00.1f.11.02.60.2d mtu 1500
```

XT/CF-Lite card:
![IMG_8944 2](https://github.com/Mellvik/TLVC/assets/3629880/9e111698-2fe9-4610-9258-2a6730fa96dd)
