### PR TITLE
[serial console] Serial console losing chars at slow speed - fix

### DIFF
--- a/tlvc/arch/i86/drivers/char/cgatext.c
+++ b/tlvc/arch/i86/drivers/char/cgatext.c
@@ -2,6 +2,7 @@
 #include <linuxmt/kernel.h>
 #include <linuxmt/sched.h>
 #include <arch/cgatext.h>
+#include <linuxmt/cgatext.h>
 
 static size_t free_len(struct file * f, size_t len)
 {

--- a/tlvc/arch/i86/drivers/char/serial-8250.c
+++ b/tlvc/arch/i86/drivers/char/serial-8250.c
@@ -490,7 +490,7 @@ void rs_conout(dev_t dev, int Ch)
 {
     register struct serial_info *sp = &ports[MINOR(dev) - RS_MINOR_OFFSET];
 
-    while (!(INB(sp->io + UART_LSR) & UART_LSR_TEMT))
+    while (!(INB(sp->io + UART_LSR) & UART_LSR_THRE))
 	continue;
     outb(Ch, sp->io + UART_TX);
 }


### PR DESCRIPTION
Fixes the problem in #42 - serial console on old XT/8bit-ISA systems now works fine at low speeds.

Also includes a minor change to `cgatext.c` which now compiles properly.