### PR TITLE
[directfd] A major cleanup + fix for raw IO + check_media_change + more

### DIFF
--- a/tlvc/arch/i86/drivers/char/rfd.c
+++ b/tlvc/arch/i86/drivers/char/rfd.c
@@ -52,15 +52,14 @@ int rfd_open(register struct inode *inode, struct file *filp)
     //unsigned int minor;
 
     //minor = MINOR(inode->i_rdev);
-    printk("rdf open\n");
+    //printk("rdf open\n");
     return(floppy_open(inode, filp));
 }
 
 void rfd_close(struct inode *inode, struct file *filp)
 {
-    printk("rdf close\n");
-    //return(floppy_release(inode, filp));
-    return; 	/* Nothing to do */
+    //printk("rdf close\n");
+    return(floppy_release(inode, filp));
 }
 
 /* FIXME change ops struct to point directly to the block driver entries when appropriate */

--- a/tlvc/fs/inode.c
+++ b/tlvc/fs/inode.c
@@ -135,7 +135,11 @@ static void unlock_inode(register struct inode *inode)
     wake_up((struct wait_queue *)inode);
 }
 
-void invalidate_inodes(kdev_t dev)
+void invalidate_inodes(kdev_t dev) {
+	finvalidate_inodes(dev, 0);
+}
+
+void finvalidate_inodes(kdev_t dev, int force)
 {
     register struct inode *prev;
     register struct inode *inode = inode_llru;
@@ -143,8 +147,8 @@ void invalidate_inodes(kdev_t dev)
     do {
         prev = inode->i_prev;	/* clear_inode() changes the queues.. */
 	if (inode->i_dev != dev) continue;
-	if (inode->i_count || inode->i_dirt || inode->i_lock)
-	    printk("VFS: inode busy on removed device %D\n", dev);
+	if (!force && (inode->i_count || inode->i_dirt || inode->i_lock))
+	    printk("VFS: inode %04x busy on removed device %D\n", inode, dev);
 	else
 	    clear_inode(inode);
     } while ((inode = prev) != NULL);

--- a/tlvc/fs/minix/bitmap.c
+++ b/tlvc/fs/minix/bitmap.c
@@ -204,7 +204,10 @@ struct inode *minix_new_inode(struct inode *dir, __u16 mode)
             map_buffer(bh);
             if ((j = find_first_zero_bit((void *)bh->b_data, 8192)) < 8192)
                 break;
-        }
+        } else {
+	    printk("new inode: get_map_block returned bh zero\n");
+	    goto errout2;
+	}
     }
     if (i >= sb->u.minix_sb.s_imap_blocks || !bh || j >= 8192)
         goto errout;

--- a/tlvc/fs/minix/inode.c
+++ b/tlvc/fs/minix/inode.c
@@ -55,7 +55,7 @@ static int minix_set_super_state(struct super_block *sb, int notflags, int state
 	debug_sup("MINIX set super state %d\n", ms->s_state);
 	if (ms->s_state != oldstate)
 	    mark_buffer_dirty(bh);
-	printk("set_super_state %04x/%04x\n", *(int *)(bh->b_data), *(int *)(bh->b_data+16));
+	//printk("set_super_state %04x/%04x\n", *(int *)(bh->b_data), *(int *)(bh->b_data+16));
 	//printk("set_super_state %04x/%04x/%04x/%04x\n", bh, bh->b_data, *(int *)(bh->b_data), *(int *)(bh->b_data+16));
 	unmap_brelse(bh);
 	return oldstate;
@@ -315,6 +315,7 @@ struct buffer_head *minix_bread(struct inode *inode,
 {
     register struct buffer_head *bh;
 
+    //printk("m_bread %d;", block);
     return !(bh = minix_getblk(inode, block, create)) ? NULL : readbuf(bh);
 }
 
@@ -351,17 +352,16 @@ static struct buffer_head *minix_get_inode(register struct inode *inode,
     unsigned int ino;
 
     ino = inode->i_ino;
+    //printk("get_inode %d/%x;", ino, ino);
     if (!ino || ino > inode->i_sb->u.minix_sb.s_ninodes) {
 	printk("Bad inode number on dev %s: %d is out of range\n",
 		kdevname(inode->i_dev), ino);
-    }
-    else {
+    } else {
 	block = inode->i_sb->u.minix_sb.s_imap_blocks + 2 +
 	    inode->i_sb->u.minix_sb.s_zmap_blocks + (ino - 1) / MINIX_INODES_PER_BLOCK;
 	if (!(bh = bread(inode->i_dev, (block_t) block))) {
 	    printk("unable to read i-node block\n");
-	}
-	else {
+	} else {
 	    map_buffer(bh);
 	    *raw_inode = ((struct minix_inode *) bh->b_data) +
 		(ino - 1) % MINIX_INODES_PER_BLOCK;

--- a/tlvc/fs/minix/namei.c
+++ b/tlvc/fs/minix/namei.c
@@ -450,6 +450,7 @@ int minix_unlink(register struct inode *dir, char *name, size_t len)
 	retval = -ENOENT;
 	inode = NULL;
 	bh = minix_find_entry(dir, name, len, &de);
+	//printk("unlnk %04x/%t;", bh, name);
 	if (!bh) goto end_unlink2;
 	if (!(inode = iget(dir->i_sb, (ino_t) de->inode))) goto end_unlink1;
 	retval = -EPERM;

--- a/tlvc/include/linuxmt/debug.h
+++ b/tlvc/include/linuxmt/debug.h
@@ -30,7 +30,7 @@
 #define DEBUG_EVENT	1		/* generate debug events on CTRLP*/
 #define DEBUG_STARTDEF	0		/* default startup debug display*/
 #define DEBUG_BLKDRV	0		/* Disk/floppy drivers */
-#define DEBUG_RAW	1		/* Raw disk/floppy I/O */
+#define DEBUG_RAW	0		/* Raw disk/floppy I/O */
 #define DEBUG_BLK	0		/* block level i/o*/
 #define DEBUG_ETH	0		/* ethernet*/
 #define DEBUG_FAT	0		/* FAT filesystem*/
@@ -39,10 +39,11 @@
 #define DEBUG_MM	0		/* mem char device*/
 #define DEBUG_SCHED	0		/* scheduler/wait*/
 #define DEBUG_SIG	0		/* signals*/
-#define DEBUG_SUP	1		/* superblock, mount, umount*/
+#define DEBUG_SUP	0		/* superblock, mount, umount*/
 #define DEBUG_TTY	0		/* tty driver*/
 #define DEBUG_TUNE	0		/* tunable debug statements*/
 #define DEBUG_WAIT	0		/* wait, exit*/
+#define DEBUG_BUFFER	0		/* low level buffer tracing */
 
 #if DEBUG_EVENT
 void dprintk(const char *, ...);		/* printk when debugging on*/

--- a/tlvc/include/linuxmt/fd.h
+++ b/tlvc/include/linuxmt/fd.h
@@ -26,7 +26,7 @@
 struct floppy_struct {
     unsigned int size,		/* nr of 512-byte sectors total */
 	sect,			/* sectors per track */
-	head,			/* nr of heads */
+	//head,			/* nr of heads */
 	track,			/* nr of tracks */
 	stretch;		/* !=0 means double track steps */
     unsigned char gap,		/* gap1 size */

--- a/tlvc/include/linuxmt/fs.h
+++ b/tlvc/include/linuxmt/fs.h
@@ -466,7 +466,9 @@ extern void ll_rw_page(void);
 
 extern void print_bufmap_status(void);
 
+extern struct super_block *get_super(kdev_t);
 extern void put_super(kdev_t);
+extern int do_umount(kdev_t);
 extern kdev_t ROOT_DEV;
 
 extern void show_buffers(void);
@@ -500,6 +502,14 @@ extern size_t block_write(struct inode *, struct file *, char *, size_t);
 
 #ifdef CONFIG_EXEC_COMPRESS
 extern size_t decompress(char *buf, seg_t seg, size_t orig_size, size_t compr_size, int safety);
+#endif
+
+//#define CHECK_MEDIA_CHANGE	/* enable media change handing in direct floppy driver */
+
+#if defined(CONFIG_BLK_DEV_FD) && defined(CHECK_MEDIA_CHANGE)
+extern int check_disk_change(kdev_t);
+#else
+#define check_disk_change(dev)      0
 #endif
 
 #ifdef BLOAT_FS

--- a/tlvc/include/linuxmt/heap.h
+++ b/tlvc/include/linuxmt/heap.h
@@ -7,7 +7,7 @@
 #include <linuxmt/types.h>
 #include <linuxmt/list.h>
 
-/*#define HEAP_DEBUG*/
+//#define HEAP_DEBUG
 
 // Heap block header
 

--- a/tlvc/include/linuxmt/trace.h
+++ b/tlvc/include/linuxmt/trace.h
@@ -21,7 +21,7 @@
 //#define CHECK_KSTACK
 
 /* display each system call/return value along with max system stack usage */
-//#define CHECK_STRACE
+#define CHECK_STRACE
 
 /* check matched sleep/wait and idle task sleeps when writing/testing drivers */
 //#define CHECK_SCHED


### PR DESCRIPTION
A major update to the `directfd` driver:
- The raw/char driver now works regardless of requested transfer size. Previously the driver did not check whether requests would span cylinders, which does not work unless we're using the 82077 FDC (implicit seek). Now, requests are split into appropriate sizes to work correctly regardless. Also, the actual number of bytes read/written are now reported back correctly to the calling application.
- Support for media change detection and forced unmounts on floppy removal (actually 'door open') is implemented but not activated. There are still cases which do not get handled properly and the code is too complicated. To be revisited. Quite a bit of debugging code has been left in place for this 'project' - which has low priority.
- The density selection data structures and code have been simplified and optimized, providing higher reliability and reduced data size, partly inspired by @ghaerr's similar work in ELKS. 
- When running on XT class systems, the floppy drive type defaults to 360k (type 1), which is the only type generally supported on such systems.
- The config option for CONFIG_BLK_DEV_CHAR has been eliminated. Raw device support is now always available, as required by coming changes in some system utilities like `fdisk` and `fsck`.