### PR TITLE
[kernel] Fix elusive scheduler bug

### DIFF
--- a/tlvc/kernel/sched.c
+++ b/tlvc/kernel/sched.c
@@ -39,11 +39,11 @@ void del_from_runqueue(register struct task_struct *p)
 	printk("task %d not on run-queue (state=%d)\n", p->pid, p->state);
 	return;
     }
-    if (p == &idle_task) {
-        printk("idle task may not sleep\n");
-        return;
-    }
 #endif
+    if (p == &idle_task) {
+	//printk("idle task may not sleep\n");
+	return;
+    }
     //nr_running--;
     (p->next_run->prev_run = p->prev_run)->next_run = p->next_run;
     p->next_run = p->prev_run = NULL;
@@ -92,8 +92,7 @@ void schedule(void)
         if (prev->signal || (prev->timeout && (prev->timeout <= jiffies))) {
             prev->timeout = 0UL;
             prev->state = TASK_RUNNING;
-        }
-        else {
+        } else {
 	    timeout = prev->timeout;
 	}
     }
@@ -118,7 +117,7 @@ void schedule(void)
 
         previous = prev;
         current = next;
-	debug_sched("sched: %d\n", current->pid);
+	debug_sched("sched: %d %d\n", prev->pid, next->pid);
         tswitch();  /* Won't return for a new task */
 
         if (timeout) {
@@ -246,3 +245,4 @@ void INITPROC sched_init(void)
     t->state = TASK_RUNNING;
     t->next_run = t->prev_run = t;
 }
+


### PR DESCRIPTION
An interesting rabbit hole revealed itself while testing the new (PR forthcoming) MFM disk driver (aka xd.c). As the debugging `printk's` were deleted, the driver suddenly stopped working - that is, it crashed the system in the first read operation (read the partition table). More testing and it turned out that keeping a printk at the end of the io-request (`do_xd_request()`) function eliminated the problem. It definitely had the signature of a race condition/stack corruption/memory pollution issue.

The flow of operation of a TLVC IO request is that a request is passed down through the various levels, ends up in the io-request function - directly or via the request queue (this being an interrupt driven driver) if the drive is busy. The io-request function starts the actual IO, returns immediately and the the call ends up in `wait_on_buffer()` while waiting for the actual IO to complete. 

In this case (the first read since boot) there is no queue (and no processes actually) and the read is initiated right away. Now, since the machine (4.77MHz 8088 PC/XT) is very slow and the DMA IO relatively fast, the completion interrupt may occur before the `wait_on_buffer()` has completed - or even called. In this case, the call to `wait_on_buffer()` finds the buffer already unlocked and returns immediately with IO completed. This is exactly what happens if the return from the driver is slightly delayed - such as by a call to `printk` or even a short delay loop: The interrupt processing completes before  `wait_on_buffer()` is called and everything works fine.

Without the extra delay, `wait_on_buffer()` proceeds and calls `schedule()` to let the system do other stuff while waiting. All good - except that `schedule()` isn't prepared for this particular situation. At this point, the only running process is the `idle_task`, task 0, which is where the system spends its time when there is nothing to do. A task that - per definition - is never really running and thus never has the `RUNNING` flag set.

This is where the proverbial rabbit is hiding. When attempting to switch to the next task, `schedule()` finds that the current task isn't running (no `RUNNING` flag) which means it must be put to sleep - by calling `del_from_runqueue()`. 
Rabbit identified: `del_from_runqueue()` has all sanity checks commented out and does not detect that it's attempting to sleep task 0. It goes ahead and sets the `next` and `prev` task pointers to NULL. On return, the obvious happens in `schedule()`: Instead of task-switching to itself, it task-switches to a NULL pointer and the system is toast.

The simple fix (tiny rabbit indeed) is reenabling the last half of the previously disabled sanity check in `del_from_runqueue()`.

```
void del_from_runqueue(register struct task_struct *p)
{       
#if 0       /* sanity tests */
    if (!p->next_run || !p->prev_run) {
        printk("task %d not on run-queue (state=%d)\n", p->pid, p->state);
        return;
    }
                                                   <—— move the #endif here, comment out the printk
    if (p == &idle_task) {
        printk("idle task may not sleep\n");
        return;
    }   
#endif                                        <——————————^^^^^^^^
    //nr_running--;
    (p->next_run->prev_run = p->prev_run)->next_run = p->next_run;
    p->next_run = p->prev_run = NULL;
    
}
```