### PR TITLE
[kernel] fix FATfs mv not releasing blocks

### DIFF
--- a/tlvc/fs/msdos/file.c
+++ b/tlvc/fs/msdos/file.c
@@ -149,6 +149,7 @@ void msdos_truncate(register struct inode *inode)
 {
 	cluster_t cluster;
 
+	debug_fat("truncate inode %ld\n", inode->i_ino);
 	debug_fat("truncate\n");
 	cluster = (cluster_t)SECTOR_SIZE(inode)*MSDOS_SB(inode->i_sb)->cluster_size;
 	(void)fat_free(inode,(inode->i_size + (cluster-1)) / cluster);

--- a/tlvc/fs/msdos/namei.c
+++ b/tlvc/fs/msdos/namei.c
@@ -370,9 +370,10 @@ int msdos_unlink(register struct inode *dir,const char *name,int len)
 	mark_buffer_dirty(bh);
 unlink_done:
 	unmap_brelse(bh);
-	if (inode) debug_fat("unlink iput inode %u dirt %d count %d\n",
-		inode->i_ino, inode->i_dirt, inode->i_count);
-	if (dir) debug_fat("unlink iput dir %u dirt %d count %d\n", dir->i_ino, dir->i_dirt, dir->i_count);
+	if (inode) debug_fat("unlink iput inode %lu dirt %d count %d\n",
+		(unsigned long)inode->i_ino, inode->i_dirt, inode->i_count);
+	if (dir) debug_fat("unlink iput dir %lu dirt %d count %d\n", 
+		(unsigned long)dir->i_ino, dir->i_dirt, dir->i_count);
 	iput(inode);
 	iput(dir);
 	return res;

--- a/tlvc/fs/namei.c
+++ b/tlvc/fs/namei.c
@@ -548,8 +548,11 @@ int sys_link(char *oldname, char *pathname)
 
     debug_file("LINK '%t' '%t'\n", oldname, pathname);
     error = namei(oldname, &oldinode, 0, 0);
-    if (!error)
-	error = do_mknod(pathname, offsetof(struct inode_operations,link), (int)oldinode, 0);
+    if (!error) {
+        error = do_mknod(pathname, offsetof(struct inode_operations,link), (int)oldinode, 0);
+        if (error)
+            iput(oldinode);
+    }
     return error;
 #endif
 }


### PR DESCRIPTION
Fixes the problem with `mv` not releasing blocks on FAT filesystems, as discussed in #28.

Imported from ELKS; thanks, @ghaerr.