### PR TITLE
[kernel] Change bootopts chs0 option in preparation for MFM driver

### DIFF
--- a/tlvc/arch/i86/drivers/block/directhd.c
+++ b/tlvc/arch/i86/drivers/block/directhd.c
@@ -100,7 +100,6 @@ __asm__("cld;rep;outsw"::"d" (port),"S" (buf),"c" (nr))
 #endif
 
 
-//int running_qemu;		/* Detect QEMU from HD serial #, if set in qemu.sh */
 extern int hdparms[];		/* Geometry data from /bootopts */
 
 #include "blk.h"
@@ -531,14 +530,14 @@ int INITPROC directhd_init(void)
 		dp->cylinders = ide_buffer[54];
 		dp->heads = ide_buffer[55];
 		dp->sectors = ide_buffer[56];
-		*hdparm = 0; 	/* IDE takes presedence over bootopts - IS THIS OK? */
+		*hdparms = 0; 	/* IDE takes presedence over bootopts - IS THIS OK? */
 
 	    } else {		/* old drive, limited ID, limited cmd set, allow
 				 * bootopts to override the geometry in ide_data */
-		if (*hdparm > 0 && hdparm[i]) {
-			dp->cylinders = hdparm[i];
-			dp->heads = hdparm[i+1];
-			dp->sectors = hdparm[i+2];
+		if (*hdparms > 0 && hdparms[i]) {
+			dp->cylinders = hdparms[i];
+			dp->heads = hdparms[i+1];
+			dp->sectors = hdparms[i+2];
 		} else {
 			dp->cylinders = ide_buffer[1];
 			dp->heads = ide_buffer[3];
@@ -549,7 +548,7 @@ int INITPROC directhd_init(void)
 
 	    hdcount++;
 	    printk("athd%d: IDE CHS: %d/%d/%d %sserial# %s\n", drive, dp->cylinders,
-		dp->heads, dp->sectors, hdparm[i] ? "(from /bootopts) " : "", &ide_buffer[10]);
+		dp->heads, dp->sectors, hdparms[i] ? "(from /bootopts) " : "", &ide_buffer[10]);
 
 	    /* Initialize settings. Some (old in particular) drives need this
 	     * and will default to some odd default values otherwise */


### PR DESCRIPTION
PC/XT generation systems do not have any standardized means to specify disk drive types or parameters. Some use controller switches, some allow BIOS calls, some have proprietary extensions in the controller firmware etc.
We don't have the luxury (i.e. RAM) to look for all these variants, and `/bootopts` does the trick anyway.

Thus this extension to the `chs0` `/bootopts` option in preparation for introducing the MFM diver.
- The option has been renamed to `hdparms`, which is easier to recognize/understand.
- Instead of a CHS triple, the per drive data is now a quadruple, CHSW, W being the WritePrecompensation track, which many MFM drives require.
- The option supports 2 drives, 4+4 values: `hdparms=406,4,17,128,614,4,17,-1`
- As before, the format is flexible, permitting empty fields and shortened format, as in `=406,4,17` which sets all missing fields to zero. Or `=,,,416,4,17` which sets all drive 0 values and drive 1 wpcomp to zero.
- CHS values will be ignored if the cylinder value is zero.
- -1 is a frequently used wpcomp value in all kinds of tables from yesteryear (and means 'turn off/not used'). Thus -1 is permitted and converted to zero in order to avoid adding support for negative numbers in `init/main.c`. The driver then converts the zero wpcomp to whatever is required by the controller.
- The IDE driver (`directhd.c`) has been updated to take advantage of the 2-drive support.

The drives using `hdparms` will use default values when parameters are missing. For IDE drives, that is the values provided by the drive itself. For MFM it's the values for a type 1 drive, 10MB - 406/4/17/128.
