### PR TITLE
[kernel] Block IO bugfixes & enhancements

### DIFF
--- a/image/Make.devices
+++ b/image/Make.devices
@@ -166,6 +166,11 @@ ifeq ($(CONFIG_BLK_DEV_XD), y)
 	$(MKDEV) /dev/xda2 b 6 2
 	$(MKDEV) /dev/xda3 b 6 3
 	$(MKDEV) /dev/xda4 b 6 4
+	$(MKDEV) /dev/rxda  c 6 0 
+	$(MKDEV) /dev/rxda1 c 6 1
+	$(MKDEV) /dev/rxda2 c 6 2
+	$(MKDEV) /dev/rxda3 c 6 3
+	$(MKDEV) /dev/rxda4 c 6 4
 #	$(MKDEV) /dev/xdb b 6 32
 #	$(MKDEV) /dev/xdb1 b 6 33
 #	$(MKDEV) /dev/xdb2 b 6 34

--- a/tlvc/arch/i86/drivers/block/bioshd.c
+++ b/tlvc/arch/i86/drivers/block/bioshd.c
@@ -295,12 +295,12 @@ static unsigned short INITPROC bioshd_gethdinfo(void) {
 #else
 	    drivep->heads = (BD_DX >> 8) + 1;
 	    drivep->sectors = BD_CX & 0x3f;
-	    /* NOTE: some BIOS may underreport cylinders by 1*/
+	    /* NOTE: some BIOS may underreport cylinders by 1 */
 	    drivep->cylinders = (((BD_CX & 0xc0) << 2) | (BD_CX >> 8)) + 1;
 #endif
 	    drivep->fdtype = -1;
 	    drivep->sector_size = 512;
-	    printk("bioshd: hd%c BIOS CHS %d/%d/%d", 'a'+drive, drivep->cylinders,
+	    printk("bioshd: hd%c CHS %d/%d/%d", 'a'+drive, drivep->cylinders,
 		drivep->heads, drivep->sectors);
 	}
 #ifdef CONFIG_IDE_PROBE
@@ -308,13 +308,12 @@ static unsigned short INITPROC bioshd_gethdinfo(void) {
 	    if (!get_ide_data(drive, drivep)) {	/* get CHS from the drive itself */
 		/* sanity checks already done, accepting data */
 		/* (if the IDE ID check fails, the drivep struct stays intact) */
-		printk(", IDE CHS %d/%d/%d\n", drivep->cylinders,
+		printk(", IDE CHS %d/%d/%d", drivep->cylinders,
 			drivep->heads, drivep->sectors);
 	    }
 	}
-#else
-	printk("\n");
 #endif
+	printk("\n");
 	drivep++;
     }
     return ndrives;
@@ -785,15 +784,6 @@ int INITPROC bioshd_init(void)
 
 #ifdef CONFIG_BLK_DEV_BHD
     _hd_count = bioshd_gethdinfo();
-#if NOTNEEDED
-    if (sys_caps & CAP_PC_AT) {	/* PC/AT or greater */
-	enable_irq(HD1_AT_IRQ);	/* AT ST506 */
-	enable_irq(HD2_AT_IRQ);	/* AHA1542 */
-    }
-    else {
-	enable_irq(HD_IRQ);	/* XT ST506 */
-    }
-#endif
     bioshd_gendisk.nr_real = _hd_count;
 #endif /* CONFIG_BLK_DEV_BHD */
 

--- a/tlvc/arch/i86/drivers/block/blk.h
+++ b/tlvc/arch/i86/drivers/block/blk.h
@@ -208,7 +208,7 @@ static void end_request(int uptodate)
     }
 
     bh = req->rq_bh;
-    EBH(bh)->b_nr_sectors = req->rq_nr_sectors;	/* for raw IO */
+    EBH(bh)->b_nr_sectors = req->rq_nr_sectors;	/* Actual # of sectors read */
 
 #ifdef BLOAT_FS
     req->rq_bh = bh->b_reqnext;

--- a/tlvc/arch/i86/drivers/block/genhd.c
+++ b/tlvc/arch/i86/drivers/block/genhd.c
@@ -310,9 +310,9 @@ static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
     if (first_time)
 	printk("Partitions:");
     first_time = 0;
+    if (hd->part[MINOR(dev)].nr_sects == 0) return; /* no drive */
     first_sector = hd->part[MINOR(dev)].start_sect;
 
-#if 1
     /*
      * This is a kludge to allow the partition check to be
      * skipped for specific drives (e.g. IDE cd-rom drives)
@@ -321,10 +321,9 @@ static void INITPROC check_partition(register struct gendisk *hd, kdev_t dev)
 	hd->part[MINOR(dev)].start_sect = (sector_t) 0;
 	return;
     }
-#endif
 
     print_minor_name(hd, MINOR(dev));
-	//printk("check_partition: hd %04x dv %04x sec %d\n", hd, dev, (sector_t)first_sector);
+    //printk("check_partition: hd %04x dv %04x sec %d\n", hd, dev, (sector_t)first_sector);
 #ifdef CONFIG_MSDOS_PARTITION
     if (msdos_partition(hd, dev, first_sector))
 	return;
@@ -366,8 +365,7 @@ void INITPROC setup_dev(register struct gendisk *dev)
 	dev->init(dev);
 
 /*
- * FIXME: This will NOT work if we have both directhd and mfm drives,
- * verified not to work on newer (like 386...) systems.
+ * A system can have only one disk 'category' - BIOS, IDE/ATA or XD.
  */
 #ifdef CONFIG_BLK_DEV_BHD
 #define MAX_DRIVES MAX_BIOS_DRIVES

--- a/tlvc/arch/i86/drivers/block/xd.c
+++ b/tlvc/arch/i86/drivers/block/xd.c
@@ -187,8 +187,6 @@ static struct	xdmsg {	/* convert error numbers to messages */
 };
 
 
-extern int boot_xd;		/* set if xd device found to enable boot code to
-				 distinguish between directhd and xd */
 extern int	hdparms[];	/* Get CHS values from /bootopts */
 
 static int	xd_busy;
@@ -707,7 +705,6 @@ void INITPROC xd_init(void)
     	printk("xd: No drives found\n");
 	return;
     }
-    boot_xd++;	/* will fail if unit 0 is missing, unit 1 present */
     xd_gendisk.nr_real = hdcount;
     blk_dev[MAJOR_NR].request_fn = DEVICE_REQUEST;
     if (gendisk_head == NULL) {

--- a/tlvc/arch/i86/drivers/char/Makefile
+++ b/tlvc/arch/i86/drivers/char/Makefile
@@ -45,6 +45,10 @@ ifeq ($(CONFIG_BLK_DEV_FD), y)
     OBJS += rfd.o
 endif
 
+ifeq ($(CONFIG_BLK_DEV_XD), y)
+    OBJS += rxd.o
+endif
+
 ifeq ($(CONFIG_BLK_DEV_HD), y)
     OBJS += rhd.o
 endif

--- a/tlvc/arch/i86/drivers/char/init.c
+++ b/tlvc/arch/i86/drivers/char/init.c
@@ -32,6 +32,10 @@ void INITPROC chr_dev_init(void)
     pty_init();    
 #endif
 
+#ifdef CONFIG_BLK_DEV_XD
+    rxd_init();
+#endif
+
 #ifdef CONFIG_BLK_DEV_HD
     rhd_init();
 #endif

--- a/tlvc/arch/i86/drivers/char/rfd.c
+++ b/tlvc/arch/i86/drivers/char/rfd.c
@@ -31,9 +31,6 @@
 #include <arch/segment.h>
 
 #define	SECSIZ		512	/* Fixed sector size for now */
-#define FLOPPY		/* required for blk.h definitions */
-#include "../block/blk.h"
-#define DEVICE_NAME "r" DEVICE_NAME
 
 int floppy_open(struct inode *, struct file *);
 int fd_ioctl(struct inode *, struct file *, unsigned int, unsigned int);
@@ -42,16 +39,13 @@ size_t block_wr(struct inode *, struct file *, char *, size_t);
 size_t block_rd(struct inode *, struct file *, char *, size_t);
 
 /*
- * Let the blocl device open function do whatever is required - it will
+ * Let the blocK device open function do whatever is required - it will
  * recognize char device access and act accordingly.
- * There is no keeping track of opens/closes when doing raw access.
+ * There is (currently) no keeping track of opens/closes when doing raw access.
  */
 
 int rfd_open(register struct inode *inode, struct file *filp)
 {
-    //unsigned int minor;
-
-    //minor = MINOR(inode->i_rdev);
     //printk("rdf open\n");
     return(floppy_open(inode, filp));
 }

--- a/tlvc/arch/i86/drivers/char/rhd.c
+++ b/tlvc/arch/i86/drivers/char/rhd.c
@@ -1,13 +1,16 @@
 /*
- * TLVC implementation of raw access to direct (non BIOS) hard disk devices.
+ * TLVC implementation of raw access to direct (IDE) hard disk devices.
  *
  * Helge Skrivervik 06/23
  */
 
 /* 
  * /dev/rhd[a..c][0..4]
- * Physical IO is shared with the block driver.
+ * Physical IO via the block driver.
  * Data are copied directly to/from user process space.
+ *
+ * NOTE: The major device numbers must be the same for the 
+ * block and corresponding raw device
  */
 
 #include <linuxmt/config.h>

--- a/tlvc/arch/i86/drivers/char/rxd.c
+++ b/tlvc/arch/i86/drivers/char/rxd.c
@@ -1,11 +1,11 @@
 /*
- * TLVC implementation of raw access to direct (IDE) hard disk devices.
+ * Raw/char driver for the TLVC XD (MFM) disk driver - copy of the raw HD driver
  *
- * Helge Skrivervik 06/23
+ * Helge Skrivervik 04/24
  */
 
 /* 
- * /dev/rhd[a..c][0..4]
+ * /dev/rxd[a..c][0..4]
  * Physical IO via the block driver.
  * Data are copied directly to/from user process space.
  *
@@ -15,7 +15,7 @@
 
 #include <linuxmt/config.h>
 
-#ifdef CONFIG_BLK_DEV_HD
+#ifdef CONFIG_BLK_DEV_XD
 
 #include <linuxmt/kernel.h>
 #include <linuxmt/major.h>
@@ -34,9 +34,9 @@
 
 #define	SECSIZ		512	/* Fixed sector size for now */
 
-int directhd_open(struct inode *, struct file *);
-int directhd_ioctl(struct inode *, struct file *, unsigned int, unsigned int);
-void directhd_release(struct inode *, struct file *);
+int xd_open(struct inode *, struct file *);
+int xd_ioctl(struct inode *, struct file *, unsigned int, unsigned int);
+void xd_release(struct inode *, struct file *);
 size_t block_wr(struct inode *, struct file *, char *, size_t);
 size_t block_rd(struct inode *, struct file *, char *, size_t);
 
@@ -45,40 +45,39 @@ size_t block_rd(struct inode *, struct file *, char *, size_t);
  * at/uses the minor device.
  */
 
-int rhd_open(register struct inode *inode, struct file *filp)
+int rxd_open(register struct inode *inode, struct file *filp)
 {
-    //printk("rdh open\n");
-    return(directhd_open(inode, filp));
+    //printk("rxd open\n");
+    return(xd_open(inode, filp));
 }
 
-void rhd_close(struct inode *inode, struct file *filp)
+void rxd_close(struct inode *inode, struct file *filp)
 {
-    //printk("rdh close\n");
-    //return(directhd_release(inode, filp));
+    //printk("rxd close\n");
+    //return(x_release(inode, filp));
     return; 	/* Nothing to do */
 }
 
 /* FIXME change ops struct to point directly to the block driver entries when appropriate */
-static struct file_operations rhd_fops = {
+static struct file_operations rxd_fops = {
     NULL,			/* lseek */
     block_rd,			/* read */
     block_wr,			/* write */
     NULL,			/* readdir */
     NULL,			/* select */
-    directhd_ioctl,		/* ioctl - FIXME: Useful or dangerous? */	
-    rhd_open,			/* open */
-    rhd_close			/* release */
+    xd_ioctl,			/* ioctl - FIXME: Useful or dangerous? */	
+    rxd_open,			/* open */
+    rxd_close			/* release */
 };
 
 /*@+type@*/
 
-void INITPROC rhd_init(void)
+void INITPROC rxd_init(void)
 {
     /* Device initialization done by the block driver, nothing required */
-
-    if (register_chrdev(RAW_HD_MAJOR, "rhd", &rhd_fops))
-	printk("RHD: Unable to get major %d for raw disk devices\n", RAW_HD_MAJOR);
-    //printk("rhd: Raw access to block devices configured\n");
+    if (register_chrdev(RAW_XD_MAJOR, "rxd", &rxd_fops))
+	printk("RXD: Unable to get major %d for raw disk devices\n", RAW_XD_MAJOR);
+    printk("rxd: Raw access to block devices configured\n");
 }
 
 #endif

--- a/tlvc/include/arch/hdreg.h
+++ b/tlvc/include/arch/hdreg.h
@@ -1,10 +1,9 @@
 #ifndef __LINUXMT_HDREG_H
 #define __LINUXMT_HDREG_H
 
-/* This file contains some defines for the AT-hd-controller. Various sources.
+/* 
+ * This file contains some defines for the AT-hd-controller. Various sources.
  */
-
-/* ide.c has it's own port definitions in "ide.h" */
 
 /* First Hd controller regs. Ref: IBM AT Bios-listing */
 #define HD_DATA		0x1f0	/* _CTL when writing */
@@ -21,8 +20,6 @@
 
 #define HD_CMD		0x3f6	/* used for resets */
 #define HD_ALTSTATUS	0x3f6	/* same as HD_STATUS but doesn't clear irq */
-
-/* remainder is shared between hd.c, ide.c, ide-cd.c, and the hdparm utility */
 
 /*@-namechecks@*/
 

--- a/tlvc/include/linuxmt/init.h
+++ b/tlvc/include/linuxmt/init.h
@@ -33,7 +33,6 @@ extern void INITPROC serial_init(void);
 extern void INITPROC rs_setbaud(dev_t, unsigned long);
 extern void INITPROC sock_init(void);
 extern void INITPROC tty_init(void);
-extern void INITPROC xd_init(void);
 
 extern void INITPROC device_init(void);
 extern void INITPROC setup_dev(register struct gendisk *);
@@ -48,9 +47,8 @@ extern int INITPROC directhd_init(void);
 extern void INITPROC floppy_init(void);
 extern void INITPROC rd_init(void);
 extern void INITPROC ssd_init(void);
-extern void INITPROC rhd_init(void);
-extern void INITPROC rfd_init(void);
 extern void romflash_init(void);
+extern void INITPROC xd_init(void);
 
 /* char device init routines*/
 extern void INITPROC chr_dev_init(void);
@@ -64,6 +62,9 @@ extern void INITPROC mem_dev_init(void);
 extern void INITPROC meta_init(void);
 extern void INITPROC pty_init(void);
 extern void INITPROC tcpdev_init(void);
+extern void INITPROC rhd_init(void);
+extern void INITPROC rfd_init(void);
+extern void INITPROC rxd_init(void);
 
 extern void kfork_proc(void (*addr)());
 extern void arch_setup_user_stack(struct task_struct *, word_t entry);


### PR DESCRIPTION
Misc block/raw device updates

This PR fixes some minor (and not so minor) bugs and problems in the block IO subsystems, such as
- The raw driver would skip every other sector if the block size was smaller than the sector size (`fs/block_dev.c`)
- The raw driver would in some cases report wrong # of bytes read/written if reaching the end of the drive (`fs/block_dev.c`)
- Raw floppy access would some times collide with the driver track buffer end deliver wrong data. (`block/directfd.c`)
- The root_dev detection has been cleaned up - no longer attempts to accommodate several drive categories concurrently (which doesn't work anyway). (`block/init.c`)
- BIOS FD+HD now works

Plus a number of minor cleanups.
