### PR TITLE
[ktcp] Fix missing SYN retrans

### DIFF
--- a/tlvccmd/ktcp/tcp_output.c
+++ b/tlvccmd/ktcp/tcp_output.c
@@ -342,7 +342,7 @@ void tcp_retrans_expire(void)
 
     while (n != NULL) {
 	datalen = n->len - TCP_DATAOFF(&n->tcphdr[0]);
-	if (n->tcphdr[0].flags & TF_FIN) datalen++;
+	if (n->tcphdr[0].flags & (TF_SYN | TF_FIN)) datalen++;
 
 	/* calc RTT and remove if seqno was acked*/
 	if (SEQ_LEQ(ntohl(n->tcphdr[0].seqnum) + datalen, n->cb->send_una)) {
@@ -352,9 +352,9 @@ void tcp_retrans_expire(void)
 		    n->cb->rtt = (TCP_RTT_ALPHA * n->cb->rtt + (100 - TCP_RTT_ALPHA) * rtt) / 100;
 		debug_tcp("tcp: rtt %d RTT %ld RTO %ld\n", rtt, n->cb->rtt, n->rto);
 	    }
-	    debug_retrans("tcp retrans: remove seq %lu+%u unack %lu rtrns %d\n",
+	    debug_retrans("tcp retrans: remove seq %lu+%u unack %lu\n",
 		ntohl(n->tcphdr[0].seqnum) - n->cb->iss, datalen,
-		n->cb->send_una - n->cb->iss, n->cb->rtrns);
+		n->cb->send_una - n->cb->iss);
 	    n = rmv_from_retrans(n);
 	    continue;
 	} else


### PR DESCRIPTION
Fix for a minor problem in `ktcp` (`tcp_output.c`) which caused lost SYN packets to hang/timeout a connection attempt.
A SYN packet has sequence # (relative) zero, which is also the initialized value of the variable containing the last ACKed value, so `tcp_retrans_expire()` would immediately kick the SYN out of the retrans list.

SYN is to be treated like FIN as far as ACKs go, expecting an ACK for the starting sequence number +1. Which means the fix is very simple - adding `TF_SYN` to the statement handling FINs:

`if (n->tcphdr[0].flags & (TF_SYN | TF_FIN)) datalen++;` 
