### PR TITLE
[net] ne2k driver enhancements

### DIFF
--- a/tlvc/arch/i86/drivers/net/el3.c
+++ b/tlvc/arch/i86/drivers/net/el3.c
@@ -11,8 +11,6 @@
 
 */
 
-#define ELKS
-
 #include <arch/io.h>
 #include <arch/ports.h>
 #include <arch/segment.h>
@@ -142,9 +140,8 @@ struct file_operations el3_fops =
 };
 
 void INITPROC el3_drv_init(void) {
-	ioaddr = net_port;		// temporary
 
-	if (!ioaddr) {
+	if (!net_port) {
 		printk("el3: ignored\n");
 		return;
 	}
@@ -152,6 +149,7 @@ void INITPROC el3_drv_init(void) {
 	if (el3_isa_probe() == 0) {
 		found++;
 		eths[ETH_EL3].stats = &netif_stat;
+
 		/* The EL3 will grab and hold its default IRQ line
 		 * unless we tell it not to. */
 		EL3WINDOW(0);
@@ -160,7 +158,7 @@ void INITPROC el3_drv_init(void) {
 
 }
 
-static int INITPROC el3_find_id_port ( void ) {
+static int INITPROC el3_find_id_port (void) {
 
 	for ( el3_id_port = EP_ID_PORT_START ;
 	      el3_id_port < EP_ID_PORT_END ;
@@ -180,7 +178,7 @@ static int INITPROC el3_find_id_port ( void ) {
 }
 
 /* Return 0 on success, 1 on error */
-static int INITPROC el3_isa_probe( void )
+static int INITPROC el3_isa_probe(void)
 {
 	short lrs_state = 0xff;
 	int i;
@@ -191,7 +189,7 @@ static int INITPROC el3_isa_probe( void )
 	   ID_PORT.  We find cards past the first by setting the 'current_tag'
 	   on cards as they are found.  Cards with their tag set will not
 	   respond to subsequent ID sequences.
-	   ELKS supports only one card, comment kept for future reference. HS */
+	   TLVC supports only one card, comment kept for future reference. HS */
 
 	if (el3_find_id_port()) return 1;
 
@@ -326,21 +324,21 @@ static size_t el3_write(struct inode *inode, struct file *file, char *data, size
 }
 
 /* *****************************************************************************************************
-	A note about ELKS, EL3 and Interrupts
-	ELKS does not service network interrupts as they arrive. Instead, when the application calls the
+	A note about TLVC, EL3 and Interrupts
+	TLVC does not service network interrupts as they arrive. Instead, when the application calls the
 	driver, the status is checked and a read initiated if data is ready - or a write is initiated if 
 	the interface is ready. Otherwise the application is but to sleep, to be awakened by the wake_up
 	calls from the driver. A more traditional approach is to act on the cause of an interrupt 
 	- e.g. transfer an arrived packet into a buffer, immediately.
 	The 3Com 3C509 family of NICs expect the latter, and the RxComplete and RxEarly interrupt status
 	bits can only be reset by emptying the NIC's FIFO.
-	In order to get this scheme to work with ELKS, we mask off the RxComplete interrupt immediately 
+	In order to get this scheme to work with TLVC, we mask off the RxComplete interrupt immediately 
 	after seeing it, and reenable it in the packet read routine when the FIFO is empty. Not optimal
 	from a performance point of view, but it works and will do for now. 
 
 	As to Transmits, the TxComplete interrupt from the 3c5xx NICs indicate a transmit error. 
 	The TxAvailable interrupt signals the availability of enough space in the output FIFO to hold a
-	packet of a predetermined size. Since ELKS (ktcp) limits the send to 512 bytes and we rarely experiment 
+	packet of a predetermined size. Since TLVC (ktcp) limits the send to 512 bytes and we rarely experiment 
 	with sizes above 1k, this driver sets the limit to 1040 bytes.
 	There are definite performance improvements to be gained by tuning this. 
  *******************************************************************************************************/
@@ -473,7 +471,7 @@ el3_get_stats(struct net_device *dev)
 	operation, and it's simpler for the rest of the driver to assume that
 	window 1 is always valid rather than use a special window-state variable.
 	*/
-/* ELKS: Dummy for now */
+/* TLVC: Dummy for now */
 static void update_stats( void )
 {
 

--- a/tlvc/arch/i86/drivers/net/ne2k-asm.S
+++ b/tlvc/arch/i86/drivers/net/ne2k-asm.S
@@ -1003,13 +1003,13 @@ ne2k_get_hw_addr:
 	mov     4(%bp),%di
 
 	// Effectively a soft reset of the NIC, required in order to get access to the
-	// address PROM. The PROM is 16 bytes, we get 32 back if reading in word mode,
-	// the upper byte of each word is garbage. The MAC address is in the first 6 bytes.
+	// address PROM. The PROM is 16 or 32 bytes depending on the bus widths. We read
+	// it in word mode and always get 32 back.
+	// The MAC address is in the first 6 bytes.
 	// The remaining 10 bytes sometimes identify the card type. The PROM content from 
 	// an 8 bit Weird Electronics (RTL8019AS) card looks like this:
 	// 001f1102602d49534138455448204242, the last 10 bytes being 'ISA8ETH BB'.
-	// Many 16 bit cards have 0x57 in the last 2 bytes, supposedly indicating
-	// 'true ne2k clones'.
+	// The BB means it's an 8bit card, WW would indicate 16bit bus support.
 
 w_reset:
 	call	ne2k_base_init	// basic initialization
@@ -1050,7 +1050,7 @@ w_reset:
 //		0 -> clear input buffer	and reset the NIC
 //		1 -> keep the oldest (next-to-read) packet, always safe
 //		2 and higher: delete this # of packets from the end (BOUNDARY)
-//		towards the head. In 8bit/4k mode, >1 doesn't make much sense.
+//		towards the head. In 8bit/8k mode, >1 doesn't make much sense.
 //	The defaults are set in the _intr routine in the .c part of the driver,
 //	typically 3 if the buffer is 16k, 1 or 0 if lower.
 //


### PR DESCRIPTION
Updated code for 8bit vs 16bit recognition. 

The PROM holding the MAC address also has a dependable bus width flag, a 'B' for 8bit ISA, a 'W' for 16bit ISA. Having 4 physical interfaces at hand, one very old and one 8bit, this flag turns out to be dependable (also in QEMU BTW), which simplifies the code somewhat.

Also added support for forced 16bit mode from `/bootopts`, in the odd case that an interface should not have this (seemingly) standard flag.

Finally, some minor code/comment edits in the `el3` driver.