### PR TITLE
[net/ee16] Added shared mem support and fixes to driver

### DIFF
--- a/tlvc/arch/i86/drivers/net/ee16-asm.S
+++ b/tlvc/arch/i86/drivers/net/ee16-asm.S
@@ -20,8 +20,8 @@
 	.text
 
 //-----------------------------------------------------------------------------
-// Read data from port
-// Handles words only, count is words
+// Read data into process memory from port
+// Handles words only - for now. Count is bytes
 //-----------------------------------------------------------------------------
 // void ee16_insw(int port, char *data, int count)
 //
@@ -35,17 +35,20 @@ ee16_insw:
 	push	%es
 
 	mov	4(%di),%dx	// Port
-	mov	8(%di),%cx	// length (words)
+	mov	8(%di),%cx	// byte count
 	mov	6(%di),%di	// Buffer pointer
 
-        mov     current,%bx
-        mov     TASK_USER_DS(%bx),%es	// destination segment = user process
+	inc	%cx
+	shr	%cx		// make word count
+	cld
+        mov	current,%bx
+        mov	TASK_USER_DS(%bx),%es	// destination segment = user process
 	//cli
 
 word_loop:
-        in      %dx,%ax
+        in	%dx,%ax
         stosw
-        loop    word_loop
+        loop	word_loop
 
 	//sti
         pop     %es
@@ -55,27 +58,26 @@ word_loop:
 
 
 //-----------------------------------------------------------------------------
-// Write data to port
+// Write data buffer to port
 // Words only - will not work bit 8bit bus for now
 //-----------------------------------------------------------------------------
-// void ee16_sendpk(int port, char *data, int count)
+// void ee16_outsw(int port, char *data, seg_t seg, int count)
 //
 
-	.global ee16_sendpk
+	.global ee16_outsw
 
-ee16_sendpk:
+ee16_outsw:
         push    %si
 	mov	%sp,%si
 	push	%ds
 
 	mov	4(%si),%dx	// Port
-        mov     8(%si),%cx      // byte count
-        mov     6(%si),%si      // buffer addr
+        mov     10(%si),%cx	// byte count
+	lds	6(%si),%si	// buf -> %si, seg -> %ds
 
 	inc	%cx
 	shr	%cx		// make word count
-	mov     current,%bx	// setup for far memory xfer
-	mov     TASK_USER_DS(%bx),%ds
+	cld
 	//cli
 
 wr_loop:

--- a/tlvc/arch/i86/drivers/net/ee16.c
+++ b/tlvc/arch/i86/drivers/net/ee16.c
@@ -6,9 +6,13 @@
 */
 /*
  * TODO:
- * - Many optimizations to take full advantage of the NIC buffers
- * - Honor the verbose bit in the bootopts flag
  * - Fix and test 8bit bus functionality
+ * - More testing with 16k, currently seems to work fine with both PIO and shmem,
+ *   shmem is slightly (4-5%) faster.
+ * - There are still occasional hangs in probe() when changing from shmem to pio mode
+ *   w/o powercycling (ie. via /bootopts and reboot)
+ * - Much of the error handling code is untested as it's hard to get errors to happen in 
+ *   protected environments. This also applied to the CUwedged recovery code.
  *
  */
 
@@ -50,6 +54,7 @@
 #include <arch/io.h>
 #include <arch/ports.h>
 #include <arch/segment.h>
+#include <linuxmt/memory.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/major.h>
 #include <linuxmt/ioctl.h>
@@ -61,6 +66,7 @@
 #include <linuxmt/heap.h>
 #include <linuxmt/debug.h> 
 #include <linuxmt/kernel.h>	/* for ARRAY_SIZE(x) */
+#include <linuxmt/string.h>	/* for memset */
 #include <linuxmt/netstat.h>
 #include <netinet/in.h>
 #include "eth-msgs.h"
@@ -69,7 +75,11 @@
 /* TLVC environment */
 
 #define NET_DEBUG	0
-//#define NOP_REGIME	1
+#if NET_DEBUG == 1
+void kputchar(int);
+#else
+#define kputchar(x)
+#endif
 
 extern struct eth eths[];
 
@@ -87,8 +97,10 @@ static char dev_name[] = "ee0";
 static const char *ee16_ifmap[] = {"AUI", "BNC", "TP"};
 enum ee16_iftype {AUI=0, BNC=1, TPE=2};
 
+static unsigned long last_tx;		/* jiffies when last transmit started */
 static unsigned short num_tx_bufs;	/* number of transmit buffers */
 static unsigned short num_rx_bufs;	/* number of receive buffers */
+static unsigned short real_mem_top;	/* real end of (phys) memory */
 static unsigned short rx_buf_end;	/* where the rx buffer chain ends */
 static unsigned short rx_buf_start;	/* start of the receive buffer chain */
 static unsigned short rx_first;		/* First RX buffer (= rx_buf_start) */
@@ -97,16 +109,19 @@ static unsigned short rx_ptr;		/* next packet buffer to read */
 static unsigned short tx_head;		/* Next free transmit buffer */
 static unsigned short tx_reap;		/* Last tx buffer processed, possibly in-use */
 static unsigned short tx_tail;		/* The tx buffer before tx_head in the chain */
-static unsigned short tx_link;
+static unsigned short tx_link;		/* Last known executing TX command */
+static unsigned short tx_last;		/* Last TX buffer in chain, for convenience */
 static unsigned short tx_buf_start;	/* start of TX buffer chain */
 //static unsigned long init_time;		/* counts jiffies since last init, do we need this ?? */
 static unsigned char dev_started;
 static unsigned char tx_avail;		/* set when NIC transmit buffers are available */
-//static unsigned short last_tx_restart;
+static ramdesc_t shmem_seg;		/* share mem segment */
+static unsigned short __far *shmem;	/* Base pointer for shared memory */
+static unsigned char pio_mode;		/* set if no shared memory */
 
 static unsigned char found;
-static unsigned short verbose;
 static unsigned char usecount;
+static unsigned short verbose;
 static struct wait_queue rxwait;
 static struct wait_queue txwait;
 
@@ -116,16 +131,17 @@ static size_t ee16_write(struct inode *, struct file *, char *, size_t);
 static int ee16_ioctl(struct inode *, struct file *, unsigned int, unsigned int);
 static int ee16_open(struct inode *, struct file *);
 static void ee16_release(struct inode *, struct file *);
-static void udelay(int);
 static void ee16_hw_set_interface(void);
 static unsigned short INITPROC ee16_hw_readeeprom(unsigned short, unsigned char);
-static void ee16_hw_init586(unsigned int);
+static int ee16_hw_init586(unsigned int);
 static void ee16_hw_rxinit(unsigned int);
 static unsigned short ee16_hw_lasttxstat(unsigned int);
 static void ee16_put_packet(unsigned int, char *, int);
 static int ee16_get_packet(char *, int);
-void ee16_sendpk(int, char *, int);
+void ee16_outsw(int, unsigned short *, seg_t, int);
 void ee16_insw(int, unsigned short *, int);
+void ee16_udelay(int);
+
 
 struct file_operations ee16_fops =
 {
@@ -145,6 +161,8 @@ struct file_operations ee16_fops =
 /* macros from Linux jiffies.h, typecheck() removed */
 #define time_after(a,b)	 ((long)((b) - (a)) < 0)
 #define time_before(a,b)	time_after(b,a)
+
+#define eeprom_delay()	ee16_udelay(40)
 
 /* This is the code and data that is downloaded to the EtherExpress card's
  * memory at boot time.
@@ -177,7 +195,7 @@ static unsigned short start_code[] = {
 #define CONF_PROMISC  0x2e
 	0x0000,                 /* no HDLC : normal CRC : enable broadcast
 				 * disable promiscuous/multicast modes */
-	0x0040,                 /* minimum frame length = 60 octets) */
+	0x003c,                 /* minimum frame length = 60 octets) */
 	0x0000,Cmd_SetAddr,
 	0x003e,                 /* link to next command */
 #define CONF_HWADDR  0x38
@@ -210,22 +228,20 @@ static unsigned short start_code[] = {
 static char irqrmap[] = { 0,0,1,2,3,4,0,0,0,1,5,6,0,0,0,0 };
 
 /*
- * Primitive hardware access functions. Could be 'inline', but we don't do that right now ...
+ * Primitive hardware access functions
  */
-// FIXME: Turn most of these into macros
-//
-//static unsigned short scb_status(unsigned short ioaddr) {
-	//return inw(ioaddr + 0xc008);
-//}
-#define disable_irq(port)	outb(SIRQ_dis|irqrmap[net_irq], port+SET_IRQ)
-#define enable_irq(port)	outb(SIRQ_en|irqrmap[net_irq], port+SET_IRQ)
+#define ee16_disable_irq(port)	outb(SIRQ_dis|irqrmap[net_irq], port+SET_IRQ)
+#define ee16_enable_irq(port)	outb(SIRQ_en|irqrmap[net_irq], port+SET_IRQ)
 
-#define scb_status(x)	(inw(x + 0xc008))
+static unsigned short scb_status(unsigned short ioaddr) {
+	return inw(ioaddr + 0xc008);
+}
 static unsigned short scb_rdcmd(unsigned short ioaddr) {
 	return inw(ioaddr + 0xc00a);
 }
 static void scb_command(unsigned short ioaddr, unsigned short cmd) {
 	outw(cmd, ioaddr + 0xc00a);
+ 	outb(0xff, ioaddr+SIGNAL_CA);
 }
 static void scb_wrcbl(unsigned short ioaddr, unsigned short val) {
 	outw(val, ioaddr + 0xc00c);
@@ -234,10 +250,12 @@ static void scb_wrrfa(unsigned short ioaddr, unsigned short val) {
 	outw(val, ioaddr + 0xc00e);
 }
 static void set_loopback(unsigned short ioaddr) {
-	outb(inb(ioaddr + Config) | 2, ioaddr + Config);
+	unsigned opt = Cfg_Loopback;
+	if (!pio_mode) opt |= Cfg_EnaMCS16;
+	outb(inb(ioaddr + Config) | opt, ioaddr + Config);
 }
 static void clear_loopback(unsigned short ioaddr) {
-	outb(inb(ioaddr + Config) & ~2, ioaddr + Config);
+	outb((inb(ioaddr + Config) & ~Cfg_Loopback)|(pio_mode?0:Cfg_EnaMCS16), ioaddr + Config);
 }
 static unsigned short SHADOW(unsigned short addr) {
 	addr &= 0x1f;
@@ -245,17 +263,79 @@ static unsigned short SHADOW(unsigned short addr) {
 	return addr + 0x4000;
 }
 
-/* Fast way to check for more data pending in NIC buffers */
-static unsigned short get_rx_status(unsigned int port) {
+/*
+ * When we send a command to the 586, then 'kick' it with SIGNAL_CA,
+ * it will read and accept the command, then zero it, which doesn't mean
+ * it has been processed, but that the CU is ready to accept the next cmd.
+ * NOTE:
+ * If the 586 is really busy, the 'original' wait (10 jiffies) is insufficient.
+ * Some sources claim we may have to wait up to 0.9 secs, a serious delay
+ * by any measure. Thus this loop may not be a good idea in the first 
+ * place. It may be smarter to check for zero before issuing the next command
+ * rather than wait just after issuing the command - unless the
+ * code depends on the command having been accepted and acted upon.
+ * 
+ * The NetBSD driver is smart about this, setting an async flag whenever possible.
+ * FIXME!!
+ */
+#define CMD_CLEAR_TIMEOUT 40	/* approx .8 seconds */
 
-	outw(rx_ptr & ~31, port + SM_PTR);
-	return(inw(port+SHADOW(rx_ptr)));
+static void ee16_cmd_clear(unsigned int ioaddr)
+{
+	unsigned long oldtime = jiffies;
+
+	while (scb_rdcmd(ioaddr) && time_before(jiffies, oldtime + CMD_CLEAR_TIMEOUT));
+	if (scb_rdcmd(ioaddr)) {
+		printk("%s: command didn't clear\n", dev_name);
+	}
+}
+
+static unsigned short peek_buffer(unsigned int addr) {
+	unsigned short ret, old_ptr;
+
+	if (pio_mode) {		/* This wrapping may be overprotective, but it works */
+		clr_irq();
+		old_ptr = inw(net_port + SM_PTR);
+		outw(addr&~31, net_port + SM_PTR);
+		ret = inw(net_port+SHADOW(addr));
+		outw(old_ptr, net_port + SM_PTR);
+		set_irq();
+	} else
+		ret = shmem[addr/2];
+	return ret;
+}
+
+#ifdef UNUSED
+static void poke_buffer(unsigned short addr, unsigned short val) {
+	unsigned short old_ptr;
+
+	clr_irq();
+	old_ptr = inw(net_port + SM_PTR);
+	outw(addr&~31, net_port + SM_PTR);
+	outw(val, net_port+SHADOW(addr));
+	outw(old_ptr, net_port + SM_PTR);
+	set_irq();
+	return;
+}
+#endif
+
+static void copyout(unsigned short off, unsigned short *src, unsigned seg, int byte_cnt)
+{
+
+	if (pio_mode) {
+		outw(off, net_port+WRITE_PTR);
+		ee16_outsw(net_port+DATAPORT, src, seg, byte_cnt);	
+	} else
+		fmemcpyw((void *)off, shmem_seg, src, (ramdesc_t)seg, (byte_cnt+1)>>1);
 }
 
 /*
- * Sanity check the suspected EtherExpress card - if it's there.
+ * Check for presence, then sanity check the suspected EtherExpress card.
  * Read hardware address, reset card, size memory and initialize buffer
- * memory pointers. 
+ * memory pointers. This is the only point at which the card itself gets
+ * reset. Resetting it after boot tgurns out to create havoc - in
+ * particular if running shmem. The i586 otoh is being stopped and started
+ * quite a bit.
  */
 static int INITPROC ee16_hw_probe(void)
 {
@@ -265,17 +345,27 @@ static int INITPROC ee16_hw_probe(void)
 	word_t *mac = (word_t *)&netif_stat.mac_addr;
 	byte_t *mac_addr = (byte_t *)mac;
 	unsigned int i;
-	unsigned short xsum = 0;
+	unsigned short mval, xsum = 0;
 
 	printk("eth: %s at 0x%x, irq %d", dev_name, ioaddr, net_irq);
 	outb(ASIC_RST, ioaddr+EEPROM_Ctrl);
 	outb(0, ioaddr+EEPROM_Ctrl);
-	udelay(500);
-	outb(i586_RST, ioaddr+EEPROM_Ctrl);
+	ee16_udelay(5000);
+
+	outb(inb(ioaddr + Config), ioaddr + Config); /* If we change from shmem to pio mode w/o
+						      * powercycling, the MCS16 bit in the config
+						      * register sticks and probe() will hang when
+						      * accessing memory via PIO.
+						      * This trick clears the MCS16 bit.
+						      */
+	/* The 586 is stopped in readeeprom() */
+	//outb(i586_RST, ioaddr+EEPROM_Ctrl);
 	hw_addr[0] = ee16_hw_readeeprom(ioaddr,2);
 	hw_addr[1] = ee16_hw_readeeprom(ioaddr,3);
 	hw_addr[2] = ee16_hw_readeeprom(ioaddr,4);
+	mval = ee16_hw_readeeprom(ioaddr,6) & 0xff;	/* shared mem config */
 
+#ifdef NOT_USEFUL
 	/* Address validity check - Standard Address or Compaq LTE Address */
 	if (!((hw_addr[2]==0x00aa && ((hw_addr[1] & 0xff00)==0x0000)) ||
 	      (hw_addr[2]==0x0080 && ((hw_addr[1] & 0xff00)==0x5F00)))) {
@@ -283,13 +373,24 @@ static int INITPROC ee16_hw_probe(void)
 			hw_addr[2],hw_addr[1],hw_addr[0]);
 		return -ENODEV;
 	}
-	//printk("|%04x%04x%04x|", hw_addr[2], hw_addr[1], hw_addr[0]);
+	printk("|%04x%04x%04x|", hw_addr[2], hw_addr[1], hw_addr[0]);
+#endif
 	/*
 	 * Calculate the EEPROM checksum.  Carry on anyway if it's bad,
 	 * though.
 	 */
+#ifdef DISPLAY_EEPROM
+	unsigned short x;
+	for (i = 0; i < 64; i++) {
+		x = ee16_hw_readeeprom(ioaddr, i);
+		xsum += x;
+		printk("%04x ", x);
+		if ((i+1)%16 == 0) printk("\n");
+	}
+#else
 	for (i = 0; i < 64; i++)
 		xsum += ee16_hw_readeeprom(ioaddr, i);
+#endif
 	if (xsum != 0xbaba)
 		printk(" (bad EEPROM xsum 0x%02x)", xsum);
 	for (i = 0; i < 6; i++)
@@ -303,17 +404,29 @@ static int INITPROC ee16_hw_probe(void)
 		/* Use the IRQ from EEPROM if none was given */
 		if (!net_irq)
 			net_irq = irq;
-		/* FIXME: should we just report the internal conn settings, or update the flags? */
 		conn = !(setupval & 0x1000) ? AUI :
 				ee16_hw_readeeprom(ioaddr,5) & 0x1 ? TPE : BNC;
-		buswidth = !((setupval & 0x400) >> 10);
+		buswidth = !(setupval & 0x400);			/* 8bit -> true */
+		if (buswidth || (net_flags&ETHF_8BIT_BUS))	/* 8bit bus may be set in the eeprom */
+			netif_stat.if_status |= ETHF_8BIT_BUS;	/* or forced via (bootopts) flags */
+								/* At this time there is no way to
+								 * force 16bit bus in case the eeprom
+								 * setting is wrong.
+								 */
 	}
- 	printk(" (HWconf: IRQ %d, %s connector, %d-bit bus", irq,
- 	       ee16_ifmap[conn], buswidth?8:16);
+#ifdef USE_EEPROM_SHM_CFG
+ 	if (verbose) printk(" (HWconf: IRQ %d, %s, %d-bit bus, shmem 0x%x)", irq,
+ 		ee16_ifmap[conn], (netif_stat.if_status&ETHF_8BIT_BUS)?8:16, mval);
+#else
+ 	if (verbose) printk(" (HWconf: IRQ %d, %s, %d-bit bus)", irq,
+ 		ee16_ifmap[conn], (netif_stat.if_status&ETHF_8BIT_BUS)?8:16);
+#endif
 
-	/* Find out how much RAM we have on the card */
+	/* Find out how much RAM we have on the card 
+	 * (don't trust the eeprom shared mem size for this).
+	 */
 	outw(0, ioaddr + WRITE_PTR);
-	for (i = 0; i < 32768; i++)
+	for (i = 0; i < 0x8000; i++)	/* 32k */
 		outw(0, ioaddr + DATAPORT);
         for (memory_size = 0; memory_size < 64; memory_size++) {
 		outw(memory_size<<10, ioaddr + READ_PTR);
@@ -328,35 +441,73 @@ static int INITPROC ee16_hw_probe(void)
 	/* Sort out the number of buffers.  We may have 16, 32, 48 or 64k
 	 * of RAM to play with.
 	 */
-	num_tx_bufs = 4;
-	rx_buf_end = 0x3ff6;
-	//netif_stat.if_status |= (memory_size/8)-1;	/* sets ETHF_32K_BUF etc., */
-							/* not used by this NIC */
-	if (buswidth || (net_flags&ETHF_8BIT_BUS))	/* 8bit bus may be set in the NIC */
-		netif_stat.if_status |= ETHF_8BIT_BUS;	/* or forced via (bootopts) flags */
-	switch (memory_size)
-	{
-	case 64:
-		rx_buf_end += 0x4000;
-	case 48:
-		num_tx_bufs += 4;
-		rx_buf_end += 0x4000;
-	case 32:
-		rx_buf_end += 0x4000;
-	case 16:
-		printk(", %dk RAM)\n", memory_size);
-		break;
-	default:
-		printk(") bad memory size (%dk).\n", memory_size);
-		return -ENODEV;
-		break;
+	real_mem_top = (memory_size << 10) - 0xa;
+	if (net_flags&ETHF_16K_BUF) {
+		memory_size = 16;
+		netif_stat.if_status |= ETHF_16K_BUF;
 	}
+
+	num_tx_bufs = memory_size >> 3;	/* must be >=3 for the restartCU regime to work */
+
+	if (memory_size < 16 || memory_size > 64) {
+		printk(", bad memory size (%dk).\n", memory_size);
+		return -ENODEV;
+	} else
+		printk(", %dk RAM\n", memory_size);
+	rx_buf_end = (memory_size<<10) - 0xa;
+
+	pio_mode = 1;
+
+	/* 
+	 * Shared memory configuration is black art, copied from driver to driver thru 
+	 * generations, with no documentation and a lot of assumptions.
+	 * 
+	 * For now, skip the EEprom shmem config and use the shared mem address from /bootopts.
+	 * If no shared memory setting in bootopts (or just 0), turn off shared memory.
+	 * Having only 16k buffer space should do the same, for now just emit a warning
+	 * (valuable for testing/debugging).
+	 */
+
+	if (!net_ram) {	/* forced pio mode */
+		if (verbose) printk("eth: no shared mem, using PIO mode\n");
+	} else {
+		unsigned short pg = 2;	/* 2 for c800, 4 for d000 */
+		unsigned short adjust, decode, edecode;
+
+		shmem_seg = net_ram;
+		if (shmem_seg != 0xc800) {
+			shmem_seg = 0xd000; /* insurance */
+			pg = 4;
+		}
+		shmem = _MK_FP(shmem_seg, 0);
+		if (verbose) printk("eth: using shared mem at 0x%x (%lx)\n", shmem_seg, (long) shmem);
+		pio_mode = 0;
+		if (memory_size < 32)
+			printk("eth: Warning - shmem mode may be unstable with memory < 32k!\n");
+		adjust = MEM_CTRL_FMCS16 | (pg &0x03) << 2;
+		decode = ((1 << (memory_size/16)) - 1) << pg;
+		edecode = ((~decode >> 4) & 0xF0) | (decode >> 8);
+
+		outb(decode & 0xFF, ioaddr + MEM_Dec);
+		outb(adjust, ioaddr + MEM_Ctrl);
+		outb((~decode & 0xFF), ioaddr + MEM_Page_Ctrl);
+		outb(edecode, ioaddr + MEM_ECtrl);	/* Clear 0xe0000 */
+
+#ifdef TEST_SHMEM
+		*shmem=0xa5a5;
+		shmem[1] = 0x5a5a;
+		shmem[0x80] = 0x5a5a;
+		unsigned short *k = 0x100;
+		fmemsetw(k, shmem_seg, 0xa000, (TX_BUF_SIZE*num_tx_bufs)/2);
+		printk("test shared memory: %x %x\n", *shmem, *(shmem+TX_BUF_SIZE-1));
+#endif
+	}
+
 	printk("eth: %s (%s) on MAC %02x", dev_name, model_name, (mac_addr[0]&0xff));
 	i = 1;  
 	while (i < 6) printk(":%02x", (mac_addr[i++]&0xff));
 	printk(", flags 0x%x\n", net_flags); 
 
-	rx_buf_start = tx_buf_start + (num_tx_bufs*TX_BUF_SIZE);
 	return 0;
 }
 
@@ -366,7 +517,7 @@ void INITPROC ee16_drv_init(void) {
 		printk("ee16: no port, ignored\n");
 		return;
 	}
-	verbose = (net_flags&ETHF_VERBOSE);
+	verbose = !!(net_flags&ETHF_VERBOSE);
 	if (ee16_hw_probe() == 0) {
 		found++;
 		eths[ETH_EE16].stats = &netif_stat;
@@ -375,12 +526,55 @@ void INITPROC ee16_drv_init(void) {
 
 }
 
+/* 
+ * Restart the (wedged) CU at the given block.
+ * When we detect that the CU stopped sending frames,
+ * this will restart it, starting at 'addr'.
+ */
+static void ee16_restartCU(unsigned short addr)
+{
+#if NET_DEBUG
+	printk("@%x|%x:", addr, peek_buffer(addr+0x0c));
+#endif
+	scb_wrcbl(net_port, addr);
+	ee16_cmd_clear(net_port);		/* change when we add an async flag */
+	scb_command(net_port, SCB_CUstart);
+}
+
+#ifdef SERIOUS_DEBUG
+static void dump_header(unsigned short ptr, int len)
+{
+	int i;
+
+	printk("\n%x: ", ptr);
+	for (i = 0; i < len; i += 2) {
+		printk("%04x ", peek_buffer(ptr+i));
+		if (!((i+2)%16)) printk("\n");
+	}
+	if (i%16) printk("\n");
+}
+
+static void dump_shmem(unsigned short off, int len)
+{
+	int i = 0;
+	printk("0x%lx(%04x)\n%04x: ", (long)shmem, shmem[0], off);
+	
+	while (i < len/2) {
+		printk("%04x ", *(shmem+(off/2)+i));
+		if (!(++i%16)) printk("\n%04x: ", off+(i<<1));
+	}
+	if (i%16) printk("\n");
+}
+#endif
+
+
+
 static size_t ee16_write(struct inode *inode, struct file *file, char *data, size_t len)
 {
 	int res;
 
 	while (1) {
-#if NET_DEBUG > 1
+#if NET_DEBUG > 2
 		//kputchar('T');
 		printk("\nT %d/%d|", len, tx_avail);
 #endif
@@ -408,37 +602,9 @@ static size_t ee16_write(struct inode *inode, struct file *file, char *data, siz
 	return res;
 }
 
-/*
- * When we send a command to the 586, then kicks it with SIGNAL_CA,
- * it will read the command, then zero it, which (apparently) indicate
- * some kind of readyness to continue (or at least to issue the next cmd).
- * NOTE:
- * If the 586 is really busy, the 'original' 10 jiffies are insufficient.
- * Some sources claim we may have to wait up to 0.9 secs, a serious delay
- * by any measure. Thus this loop may not be a good idea in the first 
- * place. It may be smarter to check for zero before issuing the next command
- * rather than wait just after issuing the command - of course unless the
- * code depends on the command having been accepted and acted upon.
- * 
- * The NetBSD driver is smart about this, setting an async flag whenever possible.
- * FIXME!!
- */
-#define CMD_CLEAR_TIMEOUT 40
-
-static void ee16_cmd_clear(unsigned int ioaddr)
-{
-	unsigned long oldtime = jiffies;
-	unsigned short s;
-
-	while (scb_rdcmd(ioaddr) && time_before(jiffies, oldtime + CMD_CLEAR_TIMEOUT));
-	if ((s = scb_rdcmd(ioaddr))) {
-		printk("%s: command (%x) didn't clear\n", dev_name, s);
-	}
-}
-
 
 /*
- * Handle an EtherExpress interrupt in the odd(!) case that the CU isn't running. 
+ * Handle an EtherExpress interrupt if the CU isn't running. 
  * If we've finished initializing, start the RU and CU up.
  * If we've already started, reap tx buffers, handle any received packets,
  * check to make sure we've not become wedged.
@@ -455,15 +621,13 @@ static unsigned short ee16_start_irq(unsigned int ioaddr, unsigned short status)
 		printk("%s: CU went non-active (status %04x)\n",
 		       dev_name, status);
 #endif
-		outw(CONF_DIAG_RESULT & ~31, ioaddr + SM_PTR);
-		diag_status = inw(ioaddr + SHADOW(CONF_DIAG_RESULT));
+		diag_status = peek_buffer(CONF_DIAG_RESULT);
 		if (diag_status & 1<<11) {
 			printk("%s: 82586 failed self-test\n", dev_name);
 		} else if (!(diag_status & 1<<13)) 
 			printk("%s: 82586 self-test failed to complete\n", dev_name);
 
-		outw(CONF_TDR_RESULT & ~31, ioaddr + SM_PTR);
-		tdr_status = inw(ioaddr + SHADOW(CONF_TDR_RESULT));
+		tdr_status = peek_buffer(CONF_TDR_RESULT);
 		if (tdr_status & (TDR_SHORT|TDR_OPEN)) {
 			printk("%s: TDR reports cable %s at %d tick%s\n", dev_name,
 				(tdr_status & TDR_SHORT)?"short":"broken", tdr_status & TDR_TIME,
@@ -488,7 +652,7 @@ static unsigned short ee16_start_irq(unsigned int ioaddr, unsigned short status)
 			rx_ptr = rx_buf_start;
 			dev_started |= STARTED_RU;
 		}
-		ack_cmd |= SCB_CUstart | 0x2000;
+		ack_cmd |= SCB_CUstart | ACK_CUstopped;
 	}
 	if (!(dev_started & STARTED_RU) && SCB_RUstat(status)==4)
 		dev_started |= STARTED_RU;
@@ -501,90 +665,89 @@ static unsigned short ee16_start_irq(unsigned int ioaddr, unsigned short status)
 static void ee16_int(int irq, struct pt_regs *regs)
 {
 	unsigned short ioaddr, status, ack_cmd;
-	unsigned short old_read_ptr, old_write_ptr;
 
 	ioaddr = net_port;
-	disable_irq(ioaddr);
-	old_read_ptr = inw(ioaddr+READ_PTR);	/* in case we interrupted something, */
-	old_write_ptr = inw(ioaddr+WRITE_PTR);  /* save the current pointers */
+	ee16_disable_irq(ioaddr);
+	ee16_cmd_clear(ioaddr);		/* Never read status until cmd has cleared */
 	status = scb_status(ioaddr);
 
-#if NET_DEBUG
+#if NET_DEBUG == 2
 	printk("ee0 int %x;", status);
-	//kputchar('I');
+#elif NET_DEBUG
+	kputchar('I');
 #endif
 	if (dev_started == (STARTED_CU | STARTED_RU)) {
+		kputchar('>');
 		do {
-#if 0	/* Experimental, moved down. The docs suggest this, but it's unclear why it would matter. */
-			ee16_cmd_clear(ioaddr);
-			ack_cmd = SCB_ack(status);
-			scb_command(ioaddr, ack_cmd);
-			outb(0, ioaddr+SIGNAL_CA);
-			//printk("nt %x;", status);
-			ee16_cmd_clear(ioaddr);
+#if NET_DEBUG > 1
+			printk("i %x;", status);
 #endif
-			if (SCB_complete(status)) {	/* TX interrupt */
-				if (!ee16_hw_lasttxstat(ioaddr))
-					printk("%s: tx interrupt but no status\n", dev_name);
-				else {
-					// moved to lasttxstat()
-					//tx_avail++;	/* One buffer freed (maybe skip if status 0?)  */
-					wake_up(&txwait);
-				}
-			}
-			if (SCB_rxdframe(status)) {	/* RX interrupt */
-				wake_up(&rxwait);
-				//ee16_hw_rx_pio(ioaddr);
-			}
-#if 1		/* check comment above */
-			ee16_cmd_clear(ioaddr);
-			ack_cmd = SCB_ack(status);
-			scb_command(ioaddr, ack_cmd);
-			outb(0, ioaddr+SIGNAL_CA);
-			//printk("nt %x;", status);
-			ee16_cmd_clear(ioaddr);
-#endif
-			status = scb_status(ioaddr);
-		} while (status & 0xc000);	/* we may have new (supressed) interrupts while 
-						 * processing, complete the loop or we 
-						 * risk losing some */
 
-		/* this part needs more testing */
-		if (SCB_RUdead(status)) {
-			printk("%s: RU stopped: status %04x\n", dev_name, status);
-#if 0
-			printk("%s: cur_rfd=%04x, cur_rbd=%04x\n", dev->name, lp->cur_rfd, lp->cur_rbd);
-			outw(lp->cur_rfd, ioaddr+READ_PTR);
-			printk("%s: [%04x]\n", dev->name, inw(ioaddr+DATAPORT));
-			outw(lp->cur_rfd+6, ioaddr+READ_PTR);
-			printk("%s: rbd is %04x\n", dev->name, rbd= inw(ioaddr+DATAPORT));
-			outw(rbd, ioaddr+READ_PTR);
-			printk("%s: [%04x %04x] ", dev->name, inw(ioaddr+DATAPORT), inw(ioaddr+DATAPORT));
-			outw(rbd+8, ioaddr+READ_PTR);
-			printk("[%04x]\n", inw(ioaddr+DATAPORT));
+			ack_cmd = 0;
+			if (!SCB_ack(status)) printk("*%x*", status);
+
+			if (SCB_rxdframe(status)) {	/* RX interrupt */
+				ack_cmd |= ACK_rxdframe;
+				kputchar('r');
+				wake_up(&rxwait);
+			}
+			if (SCB_complete(status)) {	/* TX interrupt */
+							/* may want to skip if CU stopped */
+				ack_cmd |= ACK_complete;
+				kputchar('t');
+				if (tx_head != tx_reap)	{
+				   if (!ee16_hw_lasttxstat(ioaddr))  {
+					/* if we get here, something might be seriously wrong */
+					printk("%s: tx-int, no status (%x)\n", dev_name, scb_status(ioaddr));
+				   } else {
+				   	wake_up(&txwait);
+				   }
+				}
+#if NET_DEBUG
+				else	/* If we process several tx packets in lasttxstat(), there
+					 * may be unacknowledged interrupts. They end up here
+					 * and eventually get acknowleged */
+					kputchar('+');
 #endif
-			netif_stat.rx_errors++;
-#if 1
-		        ee16_hw_rxinit(ioaddr);
-#else
-			cur_rfd = first_rfd;
-#endif
-			scb_wrrfa(ioaddr, rx_buf_start);
-			scb_command(ioaddr, SCB_RUstart);
-			outb(0, ioaddr+SIGNAL_CA);
-		}
-	} else {
+			}
+			/* Experimental */
+			if (SCB_RUstat(status) == 2) {
+				printk("%s: RX overrun, status 0x%x\n", dev_name, status);
+				/**** should not happen - receive buffers are 'looped'  */
+			}
+
+			/* FIXME: this part needs more testing */
+			if (SCB_RUdead(status)) {
+				ack_cmd |= ACK_RUstopped|SCB_RUstart;
+				printk("%s: RU stopped: status %04x\n", dev_name, status);
+				netif_stat.rx_errors++;
+		        	ee16_hw_rxinit(ioaddr);
+				scb_wrrfa(ioaddr, rx_buf_start);
+			}
+			if (SCB_CUdead(status)) {	/* UNTESTED */
+				/* happens all the time when using start/stop tx mode */
+				ack_cmd |= ACK_CUstopped|SCB_CUstart;
+				printk("%s: CU stopped: status %04x\n", dev_name, status);
+				netif_stat.tx_errors++;
+				scb_wrcbl(ioaddr, tx_reap);	/* the last tx probably failed, retry */
+			}
+			scb_command(ioaddr, ack_cmd);
+			ee16_cmd_clear(ioaddr);
+
+			status = scb_status(ioaddr);	/* check for new events */
+			//if (SCB_actioncmd(status)) kputchar('>');
+		} while (SCB_actioncmd(status));
+
+	} else {	/* NIC initialization only */
 		if (status & 0x8000)
 			ack_cmd = ee16_start_irq(ioaddr, status);
 		else
 			ack_cmd = SCB_ack(status);
 		scb_command(ioaddr, ack_cmd);
-		outb(0, ioaddr+SIGNAL_CA);
 	}
 	ee16_cmd_clear(ioaddr);
-	outw(old_read_ptr, ioaddr+READ_PTR);
-	outw(old_write_ptr, ioaddr+WRITE_PTR);
-	enable_irq(ioaddr);
+	ee16_enable_irq(ioaddr);
+	kputchar('<');
 
 	return;
 }
@@ -596,14 +759,12 @@ static void ee16_int(int irq, struct pt_regs *regs)
 static void ee16_release(struct inode *inode, struct file *file)
 {
 	if (--usecount == 0) {
-		disable_irq(net_port);
-		//outb(SIRQ_dis|irqrmap[net_irq], net_port+SET_IRQ);
+		ee16_disable_irq(net_port);
 		scb_command(net_port, SCB_CUsuspend|SCB_RUsuspend);
-		outb(0, net_port+SIGNAL_CA);
-		outb(i586_RST, net_port+EEPROM_Ctrl);
+		outb(i586_RST, net_port+EEPROM_Ctrl);	/* stop the NIC */
 		free_irq(net_irq);
 	}
-#if NET_DEBUG > 3
+#if NET_DEBUG > 2
 	printk("ee16: release\n");
 #endif
 }
@@ -616,10 +777,11 @@ static size_t ee16_read(struct inode *inode, struct file *filp, char *data, size
 
 	while(1) {
 		
-		rx_status = get_rx_status(net_port);
+		rx_status = peek_buffer(rx_ptr);
 #if NET_DEBUG > 1
-		//printk("R%04x", rx_status);		// DEBUG
-		kputchar('R');		// DEBUG
+		printk("R%04x", rx_status);
+#elif NET_DEBUG
+		kputchar('R');
 #endif
 		prepare_to_wait_interruptible(&rxwait);
 
@@ -628,6 +790,7 @@ static size_t ee16_read(struct inode *inode, struct file *filp, char *data, size
 				res = -EAGAIN;
 				break;
 			}
+			kputchar('!');
 			do_wait();
 			if (current->signal) {
 				res = -EINTR;
@@ -635,8 +798,9 @@ static size_t ee16_read(struct inode *inode, struct file *filp, char *data, size
 			}
 		}
 
+		kputchar('^');
 		if ((res = ee16_get_packet(data, len)) <= 0) {
-			printk("%d: Network read error (%d)\n", dev_name, res);
+			printk("%s: Network read error (%d)\n", dev_name, res);
 			res = -EIO;
 		}
 		break;
@@ -654,12 +818,11 @@ static size_t ee16_read(struct inode *inode, struct file *filp, char *data, size
 static int ee16_open(struct inode *inode, struct file *file)
 {
 	int err;
-	char *mac_addr = (char *)&netif_stat.mac_addr;
 
 	if (!found) 
 		return -ENODEV;
 
-	if (usecount++ != 0)
+	if (usecount != 0)
 		return 0;		// Already open, success
 
 	err = request_irq(net_irq, ee16_int, INT_GENERIC);
@@ -667,12 +830,13 @@ static int ee16_open(struct inode *inode, struct file *file)
 		printk(EMSG_IRQERR, model_name, net_irq, err);
 		return err;
 	}
-	ee16_hw_init586(net_port);	/* may fail, need return value, */
-					/* release IRQ if failure FIXME */
+	if ((err = ee16_hw_init586(net_port))) {
+		free_irq(net_irq);
+		printk("%s: initialization failed (%d)\n", dev_name, err);
+		return -ENODEV;
+	}
  	ee16_hw_set_interface();	/* set conn type from flags	*/
-#if NET_DEBUG > 3
-	printk("ee16 is now open\n");
-#endif
+	usecount++;
 	return 0;
 }
 
@@ -709,9 +873,10 @@ static int ee16_ioctl(struct inode *inode, struct file *file, unsigned int cmd, 
 int ee16_select(struct inode *inode, struct file *filp, int sel_type)
 {       
 	int res = 0;
+	unsigned rx_status;
 	
 #if NET_DEBUG > 1
-	printk("S%d/%d;", sel_type, tx_avail);
+	printk("S%d/%d/%x;", sel_type, tx_avail, tx_head-tx_reap);
 #endif
 	switch (sel_type) {
 		case SEL_OUT:
@@ -724,10 +889,15 @@ int ee16_select(struct inode *inode, struct file *filp, int sel_type)
 			break;
 		
 		case SEL_IN:
-			if (!FD_Done(get_rx_status(net_port))) {	// data in NIC buffer??
+
+			rx_status = peek_buffer(rx_ptr);	/* KLUDGE to speed up file transfers */
+			if (!FD_Done(rx_status)) ee16_udelay(700);
+
+			if (!FD_Done(peek_buffer(rx_ptr))) {	// data in NIC buffer??
 #if NET_DEBUG > 1
 				printk("SrxW;");
 #endif
+				kputchar('W');
 				select_wait(&rxwait);
 				break;
 			}
@@ -742,9 +912,9 @@ int ee16_select(struct inode *inode, struct file *filp, int sel_type)
 #endif
 	return res;
 }
+
 /*
  * Set the cable type to use.
- * Don't INITPROC this since we use it from _open.
  */
 static void ee16_hw_set_interface(void)
 {
@@ -757,18 +927,21 @@ static void ee16_hw_set_interface(void)
 	oldval &= ~0x82;
 	switch (net_flags & (ETHF_USE_AUI|ETHF_USE_BNC)) {
 	case 0:		/* TPE */
-		oldval |= 0x2;	/* OK to fall thru?? */
+		oldval |= 0x2;	/* fall thru */
 	case ETHF_USE_BNC:
-		oldval |= 0x80;
+		oldval |= 0x80;	/* TPE = 0xa0 */
 		break;
+	case ETHF_USE_AUI:
+ 		oldval &= ~0xa0;
 	}
 	outb(oldval, net_port+0x300e);
-	udelay(20000);
+	ee16_udelay(20000);
 }
 
 /*
  * Read a word from the EtherExpress on-board serial EEPROM.
- * The EEPROM contains 64 words of 16 bits.
+ * The EEPROM contains 64 words of 16 bits. Keep the i586 reset
+ * throughout.
  */
 static unsigned short INITPROC ee16_hw_readeeprom(unsigned short ioaddr,
 						    unsigned char location)
@@ -777,7 +950,7 @@ static unsigned short INITPROC ee16_hw_readeeprom(unsigned short ioaddr,
 	unsigned short rval = 0, wval = EC_CS|i586_RST;
 	unsigned int i;
 
-	outb(EC_CS|i586_RST, ioaddr+EEPROM_Ctrl);
+	outb(wval, ioaddr+EEPROM_Ctrl);
 	for (i = 0x100; i; i >>= 1 ) {
 		if (cmd&i)
 			wval |= EC_Wr;
@@ -807,10 +980,6 @@ static unsigned short INITPROC ee16_hw_readeeprom(unsigned short ioaddr,
 
 	return rval;
 }
-static void udelay(int usec)
-{
-	while (usec--)	outb_p(0, 0x80);
-}
 
 /*
  * Writes down the list of transmit buffers into card memory.  Each
@@ -819,64 +988,40 @@ static void udelay(int usec)
  * the data into the appropriate transmit buffer and then modify the
  * preceding jump to point at the new transmit command.  This means that
  * the 586 command unit is continuously active.
- *
- * NEW REGIME (HS): Place one NOP per TX buffer at the beginning of the
- * memory block, each pointing (link) to itself. Then, when a buffer is ready 
- * for transmission, it links to the next NOP and when change the link in
- * the currently executing NOP to point to us. That way we can fill up all
- * TX buffer, each pointing to its own NOP and ready to go. And when there
- * nothing to do, the CU loops in the last used NOP.
  */
 static void ee16_hw_txinit(unsigned int ioaddr)
 {
-	unsigned short tx_block = PROG_AREA_START;
+	unsigned short tx_block;
 	unsigned short curtbuf;
+	unsigned short txcmd[XMIT_CMD_SIZE/2];
 
-#ifdef NOP_REGIME
-	for (curtbuf = 0; curtbuf < num_tx_bufs; curtbuf++) {
-		outw(tx_block, ioaddr + WRITE_PTR);
-	        outw(0x0000, ioaddr + DATAPORT);	/* clear status */
-		outw(Cmd_Nop, ioaddr + DATAPORT);	/* enter command */
-		outw(tx_block, ioaddr + DATAPORT);	/* add link to self */
-		tx_block += NOP_CMD_SIZE;
-	}
-	tx_buf_start = tx_block;
-#else
-	tx_buf_start = PROG_AREA_START;
-#endif
+	tx_block = tx_buf_start;
+	memset((char *)txcmd, 0, XMIT_CMD_SIZE);
+	txcmd[0] = 0xa000;	/* fake initial status to keep the CU wedged mechanism happy */
+	txcmd[7] = 0x8000;
+	txcmd[8] = 0xffff;
 
-//---------------- this is pretty useless, we're doing the same every time we create a new xmit packet
 	for (curtbuf = 0; curtbuf < num_tx_bufs; curtbuf++) {
-		outw(tx_block, ioaddr + WRITE_PTR);
-	        outw(0x0000, ioaddr + DATAPORT);
-		outw(Cmd_INT|Cmd_Xmit, ioaddr + DATAPORT);
-#ifdef NOP_REGIME
-		outw(PROG_AREA_START + curtbuf*NOP_CMD_SIZE, ioaddr + DATAPORT);
-#else
-		outw(tx_block+0x08, ioaddr + DATAPORT);
-#endif
-		outw(tx_block+0x0e, ioaddr + DATAPORT);
-		outw(0x0000, ioaddr + DATAPORT);
-		outw(0x0000, ioaddr + DATAPORT);
-		outw(tx_block+0x08, ioaddr + DATAPORT);
-		outw(0x8000, ioaddr + DATAPORT);
-		outw(-1, ioaddr + DATAPORT);
-		outw(tx_block+0x16, ioaddr + DATAPORT);
-		outw(0x0000, ioaddr + DATAPORT);
+		txcmd[1] = Cmd_INT|Cmd_Xmit;
+		txcmd[2] = tx_block+0x08;
+		txcmd[3] = tx_block+0x0e;
+		txcmd[6] = tx_block+0x08;
+		txcmd[9] = tx_block+0x16;
+		copyout(tx_block, txcmd, kernel_ds, XMIT_CMD_SIZE);
 		tx_block += TX_BUF_SIZE;
 	}
-//----------------------------------
 
 	tx_head = tx_buf_start;
 	tx_reap = tx_buf_start;
-	tx_tail = tx_block - TX_BUF_SIZE;
-#ifdef NOP_REGIME
-	tx_link = tx_buf_start - NOP_CMD_SIZE;	/* last NOP command */
-#else
+	tx_tail = tx_last = tx_block - TX_BUF_SIZE;	/* last block */
 	tx_link = tx_tail + 0x08;
-#endif
 	rx_buf_start = tx_block;
 	tx_avail = num_tx_bufs;
+#ifdef SERIOUS_DEBUG
+	if (!pio_mode) dump_shmem(tx_head, XMIT_CMD_SIZE*2);
+	dump_header(tx_head, XMIT_CMD_SIZE);
+	dump_header(tx_tail, XMIT_CMD_SIZE);
+#endif
 }
 
 /*
@@ -884,48 +1029,58 @@ static void ee16_hw_txinit(unsigned int ioaddr)
  * The end of the list isn't marked, which means that the 82586 receive
  * unit will loop until buffers become available (this avoids it giving us
  * "out of resources" messages).
- * HS:That's why we never get overrun message, must FIX.
+ * HS-06/24: Smart - except it prevents us from knowing about overruns ...
  */
 static void ee16_hw_rxinit(unsigned int ioaddr)
 {
 	unsigned short rx_block = rx_buf_start;
+	unsigned short rxcmd[RX_CMD_SIZE/2];
+	int i;
+
 	num_rx_bufs = 0;
 	rx_first = rx_ptr = rx_block;
+	for (i = 4; i < 10; i++)
+		rxcmd[i] = 0xdead;
+	rxcmd[0] = rxcmd[1] = 0;
+	rxcmd[3] = 0xffff;
+	rxcmd[4] = 0;
+	rxcmd[11] = 0;
+	rxcmd[14] = 0;
+
 	do {
 		num_rx_bufs++;
-		outw(rx_block, ioaddr + WRITE_PTR);
-		outw(0, ioaddr + DATAPORT);  outw(0, ioaddr+DATAPORT);
-		outw(rx_block + RX_BUF_SIZE, ioaddr+DATAPORT);
-		outw(0xffff, ioaddr+DATAPORT);
-		outw(0x0000, ioaddr+DATAPORT);
-		outw(0xdead, ioaddr+DATAPORT);
-		outw(0xdead, ioaddr+DATAPORT);
-		outw(0xdead, ioaddr+DATAPORT);
-		outw(0xdead, ioaddr+DATAPORT);
-		outw(0xdead, ioaddr+DATAPORT);
-		outw(0xdead, ioaddr+DATAPORT);
-		outw(0x0000, ioaddr+DATAPORT);
-		outw(rx_block + RX_BUF_SIZE + 0x16, ioaddr+DATAPORT);
-		outw(rx_block + 0x20, ioaddr+DATAPORT);
-		outw(0, ioaddr+DATAPORT);
-		outw(RX_BUF_SIZE-0x20, ioaddr+DATAPORT);
+		rxcmd[2] = rx_block + RX_BUF_SIZE;
+		rxcmd[12] = rx_block + RX_BUF_SIZE + 0x16;
+		rxcmd[13] = rx_block + 0x20;
+		rxcmd[15] = RX_BUF_SIZE-0x20;
+		copyout(rx_block, rxcmd, kernel_ds, RX_CMD_SIZE);
+
 		rx_last = rx_block;
 		rx_block += RX_BUF_SIZE;
 	} while (rx_block <= rx_buf_end-RX_BUF_SIZE);
 
+	if (pio_mode) {
 	/* Make first Rx frame descriptor point to first Rx buffer descriptor */
-	outw(rx_first + 6, ioaddr+WRITE_PTR);
-	outw(rx_first + 0x16, ioaddr+DATAPORT);
+		outw(rx_first + 6, ioaddr+WRITE_PTR);
+		outw(rx_first + 0x16, ioaddr+DATAPORT);
 
 	/* Close Rx frame descriptor ring */
-  	outw(rx_last + 4, ioaddr+WRITE_PTR);
-  	outw(rx_first, ioaddr+DATAPORT);
+  		outw(rx_last + 4, ioaddr+WRITE_PTR);
+  		outw(rx_first, ioaddr+DATAPORT);
 
 	/* Close Rx buffer descriptor ring */
-	outw(rx_last + 0x16 + 2, ioaddr+WRITE_PTR);
-	outw(rx_first + 0x16, ioaddr+DATAPORT);
+		outw(rx_last + 0x16 + 2, ioaddr+WRITE_PTR);
+		outw(rx_first + 0x16, ioaddr+DATAPORT);
+	} else {
+		shmem[(rx_first + 6)/2] = rx_first + 0x16;
+		shmem[(rx_last + 4)/2] = rx_first;
+		shmem[(rx_last + 0x16 + 2)/2] = rx_first + 0x16;
+	}
+
 #if NET_DEBUG
-	printk("INIT: #rxbufs %d, #txbufs %d\n", num_rx_bufs, num_tx_bufs);
+	printk("%s: %d rxBuffers, %d txBuffers\n", dev_name, num_rx_bufs, num_tx_bufs);
+	printk("%s: rx start: %d (0x%x), rx end: %d (0x%x)\n", dev_name, rx_first, rx_first,
+					rx_last+RX_BUF_SIZE, rx_last+RX_BUF_SIZE);
 #endif
 }
 
@@ -934,9 +1089,21 @@ static void ee16_hw_rxinit(unsigned int ioaddr)
  * this to finish, but allow the interrupt handler to start the CU and RU for
  * us.  We can't start the receive/transmission system up before we know that
  * the hardware is configured correctly.
- * FIXME: need to return a value so the caller can exit if we fail !!
+ * Return non-zero on error.
+ *
+ * The 82586 coldboots from the upper 10 bytes of buffer ram (rx_buf_end), which
+ * among a few other things, points it where to continue. Conveniently, if everything
+ * is ZERO, it continues at address 0, which is where we put the
+ * setup/initialization code.
+ * Note in particular that a non-zero value at location top-10 means that the
+ * 586 will run in 8bit mode. This mode is not yet supported. 
+ * Also note that limiting available buffer space via configuration (like forced use
+ * of 16k even though physical is 32k) doesn't change the NIC perception of where RAM
+ * ends. It will still boot from location top-10.
+ * Note 2: The main IO-port is somehow not available unless the i82586 is running, thus the
+ * extended use of the shadow mechanism below (avoiding copyout() for pio_mode).
  */
-static void ee16_hw_init586(unsigned int ioaddr)
+static int ee16_hw_init586(unsigned int ioaddr)
 {
 	unsigned short *mac = (unsigned short *)&netif_stat.mac_addr;
 	unsigned int i;
@@ -944,27 +1111,44 @@ static void ee16_hw_init586(unsigned int ioaddr)
 #if NET_DEBUG
 	printk("%s: ee16_hw_init586()\n", dev_name);
 #endif
+#ifdef NOT_GOOD
+	outb(ASIC_RST, ioaddr+EEPROM_Ctrl);	/* reset card to known state */
+	outb(0, ioaddr+EEPROM_Ctrl);
+	ee16_udelay(5000);
+	outb(i586_RST, ioaddr+EEPROM_Ctrl);
+#endif
 	dev_started = 0;
-	set_loopback(ioaddr);
-	outb(SIRQ_dis|irqrmap[net_irq], ioaddr+SET_IRQ);
+	tx_buf_start = PROG_AREA_START;
+	rx_buf_start = tx_buf_start + (num_tx_bufs*TX_BUF_SIZE);
 
-	/* Download the startup code */
-	outw(rx_buf_end & ~31, ioaddr + SM_PTR);
-	outw((netif_stat.if_status|ETHF_8BIT_BUS)?0x0001:0x0000, ioaddr + 0x8006);
-	outw(0x0000, ioaddr + 0x8008);
-	outw(0x0000, ioaddr + 0x800a);
-	outw(0x0000, ioaddr + 0x800c);
-	outw(0x0000, ioaddr + 0x800e);
-	for (i = 0; i < ARRAY_SIZE(start_code) * 2; i+=32) {
-		unsigned int j;
-		outw(i, ioaddr + SM_PTR);
-		for (j = 0; j < 16 && (i+j)/2 < ARRAY_SIZE(start_code); j+=2)
-			outw(start_code[(i+j)/2],
-			     ioaddr+0x4000+j);
-		for (j = 0; j < 16 && (i+j+16)/2 < ARRAY_SIZE(start_code); j+=2)
-			outw(start_code[(i+j+16)/2],
-			     ioaddr+0x8000+j);
+	ee16_disable_irq(ioaddr);
+	set_loopback(ioaddr);
+
+	/* Download the startup code at the top of phys memory */	
+	if (pio_mode) {
+		outw(real_mem_top & ~31, ioaddr + SM_PTR);
+		outw((netif_stat.if_status&ETHF_8BIT_BUS)?0x0001:0x0000, ioaddr + 0x8006);
+		outw(0x0000, ioaddr + 0x8006);
+		outw(0x0000, ioaddr + 0x8008);
+		outw(0x0000, ioaddr + 0x800a);
+		outw(0x0000, ioaddr + 0x800c);
+		outw(0x0000, ioaddr + 0x800e);
+
+		for (i = 0; i < ARRAY_SIZE(start_code) * 2; i+=32) {
+			unsigned int j;
+			outw(i, ioaddr + SM_PTR);
+			for (j = 0; j < 16 && (i+j)/2 < ARRAY_SIZE(start_code); j+=2)
+				outw(start_code[(i+j)/2], ioaddr+0x4000+j);
+			for (j = 0; j < 16 && (i+j+16)/2 < ARRAY_SIZE(start_code); j+=2)
+				outw(start_code[(i+j+16)/2], ioaddr+0x8000+j);
+		}
+	} else {
+		fmemsetw((void *)real_mem_top, shmem_seg, 0, 5);
+		if (netif_stat.if_status&ETHF_8BIT_BUS)
+			shmem[real_mem_top/2] = 1;
+		copyout(0, start_code, kernel_ds, ARRAY_SIZE(start_code)*2);
 	}
+
 	/* Do we want promiscuous mode or multicast? */
 
 #if 0	/* TLVC: We don't do promisc or multicast yet */
@@ -975,41 +1159,37 @@ static void ee16_hw_init586(unsigned int ioaddr)
 	lp->was_promisc = dev->flags & IFF_PROMISC;
 	ee16_setup_filter(dev);
 #endif
-	/* Write our hardware address */
-#if NET_DEBUG
-	printk("set MAC: %04x%04x%04x;", mac[0], mac[1], mac[2]);
-#endif
-	outw(CONF_HWADDR & ~31, ioaddr+SM_PTR);
-	outw(mac[0], ioaddr+SHADOW(CONF_HWADDR));
-	outw(mac[1], ioaddr+SHADOW(CONF_HWADDR+2));
-	outw(mac[2], ioaddr+SHADOW(CONF_HWADDR+4));
+	/* Write our hardware address into the config program */
+	if (pio_mode) {
+		outw(CONF_HWADDR & ~31, ioaddr+SM_PTR);
+		outw(mac[0], ioaddr+SHADOW(CONF_HWADDR));
+		outw(mac[1], ioaddr+SHADOW(CONF_HWADDR+2));
+		outw(mac[2], ioaddr+SHADOW(CONF_HWADDR+4));
+	} else 
+		copyout(CONF_HWADDR, mac, kernel_ds, 6);
 	ee16_hw_txinit(ioaddr);
 	ee16_hw_rxinit(ioaddr);
-	outb(0, ioaddr+EEPROM_Ctrl);
-	udelay(5000);
-	scb_command(ioaddr, 0xf000);
-	outb(0, ioaddr+SIGNAL_CA);
-	outw(0, ioaddr+SM_PTR);
+	outb(0, ioaddr+EEPROM_Ctrl);	/* start i586 (stopped in hw_probe or _release)  */
+	ee16_udelay(5000);		/* ~5ms */
+	scb_command(ioaddr, 0xf000);	/* clear pending interrupts */
 	{
 		unsigned short rboguscount=50, rfailcount=5;
-		while (inw(ioaddr+0x4000)) {
+		while (peek_buffer(0)) {
 			if (!--rboguscount) {
 				printk("%s: i82586 reset timed out, kicking...\n",
 					dev_name);
 				scb_command(ioaddr, 0);
-				outb(0, ioaddr+SIGNAL_CA);
 				rboguscount = 100;
 				if (!--rfailcount) {
 					printk("%s: i82586 not responding, giving up.\n",
 						dev_name);
-					return;
+					return -1;
 				}
 			}
 		}
 	}
         scb_wrcbl(ioaddr, CONF_LINK);
 	scb_command(ioaddr, 0xf000|SCB_CUstart);
-	outb(0, ioaddr+SIGNAL_CA);
 	{
 		unsigned short iboguscount=50,ifailcount=5;
 		while (!scb_status(ioaddr)) {
@@ -1019,64 +1199,69 @@ static void ee16_hw_init586(unsigned int ioaddr)
 						dev_name, scb_status(ioaddr), scb_rdcmd(ioaddr));
 					scb_wrcbl(ioaddr, CONF_LINK);
 				        scb_command(ioaddr, 0xf000|SCB_CUstart);
-					outb(0, ioaddr+SIGNAL_CA);
 					iboguscount = 100;
 				} else {
 					printk("%s: Failed to initialize i82586, giving up.\n", dev_name);
-					return;
+					return -1;
 				}
 			}
 		}
 	}
 	clear_loopback(ioaddr);
-	outb(SIRQ_en|irqrmap[net_irq], ioaddr+SET_IRQ);
-	//init_time = jiffies;
+	ee16_enable_irq(ioaddr);
 #if NET_DEBUG
         printk("%s: leaving ee16_hw_init586()\n", dev_name);
 #endif
+	return 0;
 }
 
 /*
  * Called after each transfer-completed intr.
- * Reap tx buffers and return last transmit status.
+ * Reap tx-buffers and return last transmit status.
  * if ==0 then either:
  *    a) we're not transmitting anything, so why are we here?
  *    b) we've died.
  * otherwise, Stat_Busy(return) means we've still got some packets
  * to transmit, Stat_Done(return) means our buffers should be empty
  * again
- * NOTE: There is no Stat_Busy check, must fix.
  */
 static unsigned short ee16_hw_lasttxstat(unsigned int ioaddr)
 {
 	unsigned short tx_block = tx_reap;
 	unsigned short status;
 
-	if (tx_head == tx_reap)		/* Insurance really - return if empty */
-		return 0;
-
 	do {
+		//status = peek_buffer(tx_block);
+		/* fix this - peek_b is much better for shmem */
 		outw(tx_block & ~31, ioaddr + SM_PTR);
 		status = inw(ioaddr + SHADOW(tx_block));
-#if NET_DEBUG > 1
+#if NET_DEBUG  > 2
 		printk("|%x|", status);
 #endif
-		tx_avail++;		/* experimental, moved from _int proper */
-		if (!Stat_Done(status)) {	/* hmmmm, looks like this block hasn't been sent yet */
-			kputchar('X');		/* maybe the interrupt was all about the previous block, 
-						 * still, it may not make sense to try to restart this,
-						 * it should be automatically entered into the CU cmd chain */
-//#ifdef NOP_REGIME
-			//tx_link = PROG_AREA_START + NOP_CMD_SIZE*((tx_block - tx_buf_start)/TX_BUF_SIZE);
-//#else
+		if (Stat_Busy(status)) {	
+			/* the current packet is still in process, exit */
+			kputchar('B');
+			return(status);
+		}
+		if (!Stat_Done(status)) {
+#if NET_DEBUG > 1
+			unsigned short prev = 
+			    (tx_block == tx_buf_start ? tx_last:tx_block-TX_BUF_SIZE);
+			printk("X[%x/%x/%x]", tx_block, peek_buffer(tx_block/*prev+0xc*/), peek_buffer(prev+0x14));
+			//dump_header(tx_block, XMIT_CMD_SIZE);
+			//dump_header(prev, XMIT_CMD_SIZE);
+#else
+			kputchar('X');
+#endif
 			tx_link = tx_block;
-//#endif
 			return status;
 		} else {
-			//last_tx_restart = 0;
-			//netif_stat.tx_errors += Stat_NoColl(status);
 			if (!Stat_OK(status)) {
-				char *whatsup = NULL;
+				/*
+				 * Mostly untested, we don't get these kinds of errors 
+				 * easily on modern TP/switched networks */
+				const char *whatsup = NULL;
+				kputchar('E');
 				netif_stat.tx_errors++;
   				//if (Stat_Abort(status))
 					//dev->stats.tx_aborted_errors++;
@@ -1089,7 +1274,15 @@ static unsigned short ee16_hw_lasttxstat(unsigned int ioaddr)
 					//dev->stats.tx_carrier_errors++;
 				}
 				if (Stat_TNoDMA(status)) {
-					whatsup = "FIFO underran";
+					whatsup = "FIFO underrun, discarded";
+#ifdef TBD
+					if (underrun++ < 4) {
+						/* more testing needed */
+						printk("FIFO underrun\n");
+						ee16_restartCU(tx_block);
+						return status;
+					}
+#endif
 					//dev->stats.tx_fifo_errors++;
 				}
 				if (Stat_TXColl(status)) {
@@ -1099,57 +1292,55 @@ static unsigned short ee16_hw_lasttxstat(unsigned int ioaddr)
 				if (whatsup)
 					printk("%s: transmit %s\n", dev_name, whatsup);
 			}
-			//else
-				//dev->stats.tx_packets++;
 		}
-		if (tx_block == tx_buf_start+((num_tx_bufs-1)*TX_BUF_SIZE))
+		tx_avail++;
+		if (tx_block == tx_last)
 			tx_reap = tx_block = tx_buf_start;
 		else
 			tx_reap = tx_block += TX_BUF_SIZE;
-		//netif_wake_queue(dev);	/** FIXME ****/
 
 	} while (tx_reap != tx_head);
 
-#ifdef NOP_REGIME
-	tx_link = PROG_AREA_START + NOP_CMD_SIZE*((tx_tail - tx_buf_start)/TX_BUF_SIZE);
-#else
 	tx_link = tx_tail + 0x08;
-#endif
 	return status;
 }
-
 /*
- * Check all the receive buffers, and hand any received packets
- * to the upper levels. Basic sanity check on each frame
- * descriptor, though we don't bother trying to fix broken ones.
- * CORRECTION: Get exactly one receive buffer into the provided
+ * Retrieve one received backet into the provided
  * address, loop only on bad packets.
  */
-//static void ee16_hw_rx_pio(unsigned int ioaddr)
 static int ee16_get_packet(char *buffer, int len)
 {
 	unsigned short rx_block = rx_ptr;
 	unsigned short boguscount = num_rx_bufs;
 	unsigned short ioaddr = net_port;
 	unsigned short status, pkt_len = 0;
+ 	unsigned short rfd_cmd, rx_next, pbuf;
 
-#if NET_DEBUG > 1
+#if NET_DEBUG > 2
 	printk("get_packet (%x/%d)\n", rx_block, len);
 #endif
-	disable_irq(ioaddr);
  	do {
- 		unsigned short rfd_cmd, rx_next, pbuf;
+		if (pio_mode) {
+			outw(rx_block, ioaddr + READ_PTR);
+			status = inw(ioaddr + DATAPORT);
+		} else
+			status = shmem[rx_block/2];
 
-		outw(rx_block, ioaddr + READ_PTR);
-		status = inw(ioaddr + DATAPORT);
 		if (FD_Done(status)) {
-			rfd_cmd = inw(ioaddr + DATAPORT);
-			rx_next = inw(ioaddr + DATAPORT);
-			pbuf = inw(ioaddr + DATAPORT);	/* get ptr to data */
-			outw(pbuf, ioaddr + READ_PTR);	/* prepare to read it */
-			pkt_len = inw(ioaddr + DATAPORT);	/* 1st word is length+status */
+			if (pio_mode) {
+				rfd_cmd = inw(ioaddr + DATAPORT);
+				rx_next = inw(ioaddr + DATAPORT);
+				pbuf = inw(ioaddr + DATAPORT);	/* get ptr to data */
+				outw(pbuf, ioaddr + READ_PTR);	/* prepare to read it */
+				pkt_len = inw(ioaddr + DATAPORT);	/* 1st word is length+status */
+			} else {
+				rfd_cmd = (unsigned short)shmem[(rx_block+2)/2];
+				rx_next = (unsigned short)shmem[(rx_block+4)/2];
+				pbuf    = (unsigned short)shmem[(rx_block+6)/2];
+				pkt_len = (unsigned short)shmem[pbuf/2];
+			}
 #if NET_DEBUG > 1
-			printk("rx: len 0x%x(%d);", pkt_len, pkt_len&0x3fff);
+			printk("rx: len %d;", pkt_len&0x3fff);
 #endif
 			if (rfd_cmd != 0x0000) {
 				printk("%s: rfd_cmd not zero:0x%04x\n", dev_name, rfd_cmd);
@@ -1167,6 +1358,7 @@ static int ee16_get_packet(char *buffer, int len)
   			}
   			else if (!FD_OK(status)) {
 				netif_stat.rx_errors++;
+				printk("%s: Rcv error, status 0x%x, len %d\n", status, pkt_len&0x3fff);
 #if 0			/* keep for reference, we don't collect detailed error stats */
 				if (FD_CRC(status))
 					dev->stats.rx_crc_errors++;
@@ -1183,42 +1375,30 @@ static int ee16_get_packet(char *buffer, int len)
 				/* All good, get the data */
 				pkt_len &= 0x3fff;
 
-				outw(pbuf+10, ioaddr+READ_PTR);
-				//ignoring the len parameter, FIXME
-				// insw is words only FIXME
-			        ee16_insw(ioaddr+DATAPORT, (word_t *)buffer, (pkt_len+1)>>1);
-				boguscount = 0; /* for now, one at a time, break the loop */
+				/* do the actual data transfer, assuming there is always enough space */
+				if (pio_mode) {
+				    outw(pbuf+10, ioaddr+READ_PTR);
+			            ee16_insw(ioaddr+DATAPORT, (word_t *)buffer, pkt_len);
+				} else
+				    fmemcpyw(buffer, current->t_regs.ds, (void *)(pbuf+10),
+				    		shmem_seg, (pkt_len+1)>>1);
 			}
-			/* FIXME: don't think this is meaningful (HS) */
-			outw(rx_block, ioaddr+WRITE_PTR);
-			outw(0, ioaddr+DATAPORT);	/* clear status field */
-			outw(0, ioaddr+DATAPORT);	/* clear cmd field */
+			if (pio_mode) {
+				outw(rx_block, ioaddr+WRITE_PTR);
+				outw(0, ioaddr+DATAPORT);	/* clear status field */
+				outw(0, ioaddr+DATAPORT);	/* clear cmd field */
+			} else {
+				shmem[rx_block/2] = 0;
+				shmem[(rx_block+2)/2] = 0;
+			}
 			rx_block = rx_next;
+			boguscount = 0; 	/* we can handle only one pkt for now */
 		}
-		boguscount = 0;		/* We want only one (TLVC) */
 	} while (FD_Done(status) && boguscount--);
+
 	rx_ptr = rx_block;
-	enable_irq(ioaddr);
 	return pkt_len;
 }
-
-#if NET_DEBUG > 1
-static void dump_header(unsigned short ptr, int len)
-{
-	int i = 0;
-	unsigned short old_read_ptr = inw(net_port+READ_PTR);
-
-	printk("\n");
-	outw(ptr, net_port + READ_PTR);
-	while (i < len/2) {
-		printk("%04x ", inw(net_port+DATAPORT));
-		if (!(++i%16)) printk("\n");
-	}
-	if (i%16) printk("\n");
-	outw(old_read_ptr, net_port+READ_PTR);
-}
-#endif
-
 
 /*
  * Hand a packet to the card for transmission
@@ -1228,114 +1408,103 @@ static void dump_header(unsigned short ptr, int len)
  */
 static void ee16_put_packet(unsigned int ioaddr, char *buf, int len)
 {
-	unsigned short tail_stat;
+	unsigned short head = tx_head; 	/* concurrency protection */
+	unsigned short tail = tx_tail; 	/* concurrency protection */
+	unsigned short txcmd[XMIT_CMD_SIZE/2];
 
-#if NET_DEBUG  > 2
-	unsigned short old_read_ptr = inw(ioaddr+READ_PTR);
-
-	outw(tx_tail&~31, ioaddr+SM_PTR);
-	tail_stat = inw(ioaddr+SHADOW(tx_tail));
-	printk("put: %d/%x/%x/%x;", len, tx_head, tx_tail, tail_stat);
-	if (!tail_stat) dump_header(tx_tail, XMIT_CMD_SIZE);
+#if NET_DEBUG 
+	unsigned short tail_stat = peek_buffer(tx_tail);
+	//unsigned short __far *chks = _MK_FP(current->t_regs.ds, (unsigned)(buf+50));
+	//printk("put: %x/%x/%x/%x(%x)", tx_head, tx_reap, *chks, tail_stat, len);
+	printk("put: %x/%x/%x", tx_head, tx_reap, tail_stat);
 #endif
-	tx_avail--;						/* the CMD block */
-	tail_stat = 0;	/*DEBUG, toggle the CU stop/start regime */
-	//clr_irq();
-	disable_irq(ioaddr);
-#ifdef NOP_REGIME
-	unsigned short this_nop = PROG_AREA_START + NOP_CMD_SIZE*((tx_head - tx_buf_start)/TX_BUF_SIZE);
 
- 	outw(tx_head+XMIT_CMD_SIZE, ioaddr + WRITE_PTR);	/* dump data just after */
-	ee16_sendpk(ioaddr + DATAPORT, buf, len);
- 	outw(tx_head, ioaddr + WRITE_PTR);
-	outw(0x0000, ioaddr + DATAPORT);	/* clear status */
-        outw(Cmd_INT|Cmd_Xmit, ioaddr + DATAPORT);	/* add cmd */
-	outw(this_nop, ioaddr + DATAPORT);	/* Link to the next cmd (NOP) */
-	outw(tx_head+0x0e, ioaddr + DATAPORT);	/* Ptr to BD (next word) */
-	outw(0x0000, ioaddr + DATAPORT);	/* 6 byte address field */
-	outw(0x0000, ioaddr + DATAPORT);	/* not used */
-	outw(0x0000, ioaddr + DATAPORT);	
-						/* Buffer descriptor starts here (4w) */
-	outw(0x8000|len, ioaddr + DATAPORT);	/* Data length in bytes + END marker */
-	outw(-1, ioaddr + DATAPORT);		/* Next BD (none) */
-	outw(tx_head+0x16, ioaddr + DATAPORT);	/* Where the data is (2 bytes down) */
-	outw(0, ioaddr + DATAPORT);
+	/* Developer Notes [this may be deprecated, but kept until we have 8bit mode running]:
+	 * This is a remedy for the CU-Wedged problem which renders the CU idle
+	 * at random intervals during transmission - when the 586 is in 8bit mode. Happens only when
+	 * NIC buffersize is > 16k. There is no difference between PIO and SHMEM.
+	 * 
+	 * We check for zero status in the previous tx-block.
+	 * If true, that frame has not been transmitted, but transmission 
+	 * may still be in progress, so we check the time passed since we let it loose
+	 * (the Busy_bit does not seem to be reliable at this point). 
+	 * If more than one jiffie has passed, we assume the CU is wedged (even though the 
+	 * CU status says OK), and restart the CU at the first uncompleted 
+	 * block. Not a perfect solution, but it works and seems faster than the alternatives,
+	 * like using a regular timeout mechanism. Still, there is the risk that heavy outgoing 
+	 * traffic (packets piling up in the buffer), may cause false negatives.
+	 */ 
+	 /* If the CU suspend/resume mechanism (see below) is in operation, the recovery
+	  * mechanism must be disabled. */
 
-	/* TX cmd ready, link it into the command chain */
- 	outw(this_nop, ioaddr + WRITE_PTR);
-	outw(0x0000, ioaddr + DATAPORT);	/* clr status */
-	outw(Cmd_Nop, ioaddr + DATAPORT);	/* the nop command, already initialized */
-						/* but we need to move the pointer anyway */
-	outw(this_nop, ioaddr + DATAPORT);	/* the link, point to itself */
-
-	/* this_nop - the one executed when this tx is done, is ready */
-	/* At this point the CU is (probably) looping in the previous NOP cmd. */
-	/* Thus - change the prevoius NOP cmd to point to us so we can get going */
-	if (this_nop == PROG_AREA_START)
-		this_nop = PROG_AREA_START + (NOP_CMD_SIZE * (num_tx_bufs - 1));
-	else
-		this_nop -= NOP_CMD_SIZE;
-	outw(this_nop+4, ioaddr + WRITE_PTR);	/* point to the link field */
-	//outw(0x0000, ioaddr + DATAPORT);	/* clr status */
-	//outw(Cmd_Nop, ioaddr + DATAPORT);	/* incidentally just 0x0000 */
-	outw(tx_head, ioaddr + DATAPORT);	/* update link, here we go ... */
-	//trans_start = jiffies;
-#else
-	// EXPERIMENTAL: Avoid getting the CU wedged...
-	// Need to find out why it happens.
-	if (!tail_stat || netif_stat.if_status & ETHF_8BIT_BUS) {
-		/* Stop the CU so that there is no chance that it
-		   jumps off to a bogus address while we are writing the
-		   pointer to the next transmit packet in 8-bit mode --
-		   this eliminates the "CU wedged" errors in 8-bit mode.
-		   (Zoltan Szilagyi 10-12-96) */
-		/* FIXME: This needs to be throughly tested on TLVC,
-		   probably not required, or there is another way to fix it.
-		   HS Apr24 */
-		scb_command(ioaddr, SCB_CUsuspend);
-		outw(0xFFFF, ioaddr+SIGNAL_CA);
+#define USE_RESTART_CU 3
+#if USE_RESTART_CU == 2		/* recovery before new packet */
+				/* recovery after: See below, the jury is out on which is best */
+	if (tx_avail < num_tx_bufs && (jiffies - last_tx)) {
+		ee16_restartCU(tx_reap);
 	}
-	disable_irq(ioaddr);	/* doesn't seem to matter */
-	/* most of this is already in place (txinit()), we just have to add the variables */
- 	outw(tx_head, ioaddr + WRITE_PTR);
-	outw(0x0000, ioaddr + DATAPORT);
-        outw(Cmd_INT|Cmd_Xmit, ioaddr + DATAPORT);
-	outw(tx_head+0x08, ioaddr + DATAPORT);
-	outw(tx_head+0x0e, ioaddr + DATAPORT);
-	outw(0x0000, ioaddr + DATAPORT);
-	outw(0x0000, ioaddr + DATAPORT);
-	outw(tx_head+0x08, ioaddr + DATAPORT);
-	outw(0x8000|len, ioaddr + DATAPORT);
-	outw(-1, ioaddr + DATAPORT);
-	outw(tx_head+0x16, ioaddr + DATAPORT);
-	outw(0, ioaddr + DATAPORT);
-	ee16_sendpk(ioaddr + DATAPORT, buf, len);
-	outw(tx_tail+0xc, ioaddr + WRITE_PTR);
-	outw(tx_head, ioaddr + DATAPORT);
-	//trans_start = jiffies;
 #endif
-	//set_irq();
+
+	/* NOTE: If interrupts are allowed here, the xmit-complete interrupt will hit almost
+	 * immediately after we update the link (IOW, let the packet loose). At that point,
+	 * tx_head MUST be pointing to the next available frame, not this one.
+	 * Thus the need for head = tx_head above and the tx_head update just below -
+	 * which may happen here or after the new packet is ready - thus the '#if 0'.
+	 */
+	tx_avail--;					
+#if 0
 	tx_tail = tx_head;
-	if (tx_head == tx_buf_start+((num_tx_bufs-1)*TX_BUF_SIZE))
+	if (tx_head == tx_last)
 		tx_head = tx_buf_start;
 	else
 		tx_head += TX_BUF_SIZE;
-#if 0
-	if (tx_head != tx_reap) {
-		//netif_wake_queue(dev); /* FIXME!!!!! *********/
-		// May use this to avoid the tx_avail regime ??
-		wake_up(&txwait);
+	//set_irq();
+#endif
+
+	txcmd[0] = 0;
+	txcmd[1] = Cmd_INT|Cmd_Xmit;
+	txcmd[2] = head + 0x08;
+	txcmd[3] = head + 0x0e;
+	txcmd[4] = 0;
+	txcmd[5] = 0;
+	txcmd[6] = head + 0x08;
+	txcmd[7] = 0x8000|len;
+	txcmd[8] = 0xffff;
+	txcmd[9] = head + 0x16;
+	txcmd[10] = 0;
+	clr_irq();	/*EXPERIMENTAL*/
+	copyout(head, txcmd, kernel_ds, XMIT_CMD_SIZE);
+	copyout(head+XMIT_CMD_SIZE, (void *)buf, current->t_regs.ds, len);
+	set_irq();
+
+#if USE_RESTART_CU == 3
+	/* If this is placed before filling the buffer, we may get underrun errors,
+	 * seemingly from memory contention. TO BE VERIFIED */
+	if (tx_avail < (num_tx_bufs-1) && (jiffies - last_tx)) {
+		ee16_restartCU(tx_reap);
 	}
 #endif
-	enable_irq(ioaddr);
-	if (!tail_stat || netif_stat.if_status & ETHF_8BIT_BUS) {
-		/* Restart the CU so that the packet can actually
-		   be transmitted. (Zoltan Szilagyi 10-12-96) */
-		scb_command(ioaddr, SCB_CUresume);
-		outw(0xFFFF, ioaddr+SIGNAL_CA);
-	}
-	//dev->stats.tx_packets++;
-	//last_tx = jiffies;
-	//kputchar('P');
+
+	/* if we update tx_head early, we may cause a race condition in the int handler,
+	 * which compares tx_head and tx_reap. That said, we need to update them before
+	 * the txcomplete interrupt for this packet hits, otherwise we have a different race condition. */
+	tx_tail = tx_head;
+	if (tx_head == tx_last)
+		tx_head = tx_buf_start;
+	else
+		tx_head += TX_BUF_SIZE;
+
+	last_tx = jiffies;	/* may want to track last TX complete int instead */
+
+	/* Update the link in the previous block to point to this block.
+	 * This will allow the CU to process this frame and almost always trigger an immediate
+	 * TX complete interrupt. */
+	if (pio_mode) {
+		outw(tail+0xc, ioaddr + WRITE_PTR);
+		outw(head, ioaddr + DATAPORT);
+	} else
+		shmem[(tail+0x0c)/2] = head;
+		
+	kputchar('P');
 }
 

--- a/tlvc/arch/i86/drivers/net/ee16.c
+++ b/tlvc/arch/i86/drivers/net/ee16.c
@@ -345,7 +345,10 @@ static int INITPROC ee16_hw_probe(void)
 	word_t *mac = (word_t *)&netif_stat.mac_addr;
 	byte_t *mac_addr = (byte_t *)mac;
 	unsigned int i;
-	unsigned short mval, xsum = 0;
+	unsigned short xsum = 0;
+#ifdef USE_EEPROM_SHM_CFG  
+	unsigned short mval;
+#endif
 
 	printk("eth: %s at 0x%x, irq %d", dev_name, ioaddr, net_irq);
 	outb(ASIC_RST, ioaddr+EEPROM_Ctrl);
@@ -363,7 +366,9 @@ static int INITPROC ee16_hw_probe(void)
 	hw_addr[0] = ee16_hw_readeeprom(ioaddr,2);
 	hw_addr[1] = ee16_hw_readeeprom(ioaddr,3);
 	hw_addr[2] = ee16_hw_readeeprom(ioaddr,4);
+#ifdef USE_EEPROM_SHM_CFG
 	mval = ee16_hw_readeeprom(ioaddr,6) & 0xff;	/* shared mem config */
+#endif
 
 #ifdef NOT_USEFUL
 	/* Address validity check - Standard Address or Compaq LTE Address */
@@ -375,6 +380,8 @@ static int INITPROC ee16_hw_probe(void)
 	}
 	printk("|%04x%04x%04x|", hw_addr[2], hw_addr[1], hw_addr[0]);
 #endif
+	if (!(hw_addr[0]+hw_addr[1]+hw_addr[2]))
+		return -ENODEV;
 	/*
 	 * Calculate the EEPROM checksum.  Carry on anyway if it's bad,
 	 * though.
@@ -522,7 +529,7 @@ void INITPROC ee16_drv_init(void) {
 		found++;
 		eths[ETH_EE16].stats = &netif_stat;
 	} else
-		printk("ee16: not found\n");
+		printk(" not found\n");
 
 }
 

--- a/tlvc/include/arch/ports.h
+++ b/tlvc/include/arch/ports.h
@@ -111,6 +111,7 @@
 /* Intel EtherExpress 16, ee16.c */
 #define EE16_PORT	0x360
 #define EE16_IRQ	11
+#define EE16_RAM	0xC800		/* Beware: if present, shared mem will be activated */
 #define EE16_FLAGS	0x80
 
 /* bioshd.c*/

--- a/tlvc/include/linuxmt/netstat.h
+++ b/tlvc/include/linuxmt/netstat.h
@@ -56,6 +56,7 @@ struct netif_stat {
 #define ETHF_16K_BUF	0x02	/* Force 16k NIC buffer */
 #define ETHF_32K_BUF	0x03	/* Force 32k NIC buffer */
 #define ETHF_4K_BUF	0x04	/* Force  4k NIC buffer */
+#define ETHF_BUF_MASK	0x07	/* mask for all buffer sizes */
 #define ETHF_8BIT_BUS	0x10	/* Force  8 bit bus */
 #define ETHF_16BIT_BUS 	0x20	/* Force 16 bit bus */
 #define ETHF_USE_BNC	0x08	/* Use BNC connection */


### PR DESCRIPTION
With this PR the EtherExpress16 driver enters a completed state. Several serious bugs have been weeded out, shared memory support has been added and the code has been significantly cleaned up. The new version is fast, reliable and supports important `bootopts` configuration flags. 8bit bus support is still missing - a relatively easy addition when/if the need arises because the scaffolding is already in place.

Summary of key enhancements since the previous PR:
- Full shared memory and pio support. If a valid (not zero) shared memory address is provided in `/bootopts`, shared memory is used, otherwise pio. With more practical experience it may be desirable to force pio-mode when the buffer is 16k, like other drivers do. However, at this point there is little evidence to the claim of instability of the 16k/shmem combination.
- The performance difference between shmem/pio is minimal on fast machines, shmem has a 4% advantage on my 40MHz 386sx. Probably more on slower machines - shared memory becoming increasingly better.
- The io address in /bootopts MUST match the card setting, other parameters are taken from `bootopts` if available, regardless of card settings. In verbose mode, the card settings are reported at boottime. The card's shared memory settings are read but currently ignored.
- The card/driver runs at approx. 80k bytes per second (ftp), `ktcp` permitting. A real kludge, a 600ms delay, has been added to the readselect routine in the driver. The delay speeds up outgoing file transfers by 300% average by avoiding a read select_wait call. A similar method may speed up other drivers as well. Looking into whether ktcp may be adjusted to avoid this kludge is on the list. See discussion below.
- Bootopts flags supported are (forced) 16k buffer size, verbose mode, cable type selection. 
- The driver allocates transmit buffers like this: `((bufsize in k)>>3)&7`, which means 2@16k, 4@32/64k. The current implementation of ktcp does not enable practical use of more than 2 tx-buffers, so the latter case is a waste - for now. Total number of NIC packet buffers is 10/20/40 @ 16/32/64k. 

The driver is (still) happily and silently overwrite unprocessed packets in the rx-queue under heavy load. Changing the code to handle this differently has been deemed not worthwhile this far - possibly because most testing has been done on a 32k buffer NIC (iow ample buffer space). The only case in which this issue may (!) become visible is when launching a flood ping with significant size packets while running a listing in an outgoing telnet connection. Flood pings and ftp transfers work well. AAMOF - ftp transfers into TLVC are just barely affected by a running flood ping, indicating that there is more performance to be gained from tuning/optimizing ktcp.

Which brings us back to the
### TCP speed kludge
This 'trick' was accidentally discovered when removing `printk`s (actually `kputchars`) turned out to kill the performance of outgoing FTPs completely, from 70+k to ~25k. Keeping the `kputchar`s in `lasttxstatus()`, which is part of tx interrupt processing, brought the performance back. The `kputchar`s were eventually replaced by `udelay()` calls and moved to the `_select` function where quite a bit of experimenting lead to what seems to be a reasonable delay value.

This value will be different on a different speed machine, so - while in use - it should be calculated using a speed index, like the machine's BOGOMIPS value - which currently does not exist, but may be coming.

As to why this delay helps: What seems to be the case is that in the course of pushing packets and ticking off incoming ACKs, the delay is just enough to avoid a `select_wait()/wake_up()` cycle when receiving the ACK immediately following a transmitted data packet. The delay optimizes the rhythm of the exchange so to speak. It is not obvious that there is an easy fix for this in `ktcp`, but given the size of the improvement, it seems worth a discussion.
