### PR TITLE
[blockio] bugfix in idequery

### DIFF
--- a/tlvc/arch/i86/drivers/block/directhd.c
+++ b/tlvc/arch/i86/drivers/block/directhd.c
@@ -81,7 +81,7 @@ __asm__("cld;rep;outsw"::"d" (port),"S" (buf),"c" (nr))
 //#define USE_INTERRUPTS		/* EXPERIMENTAL - test interrupts */
 				/* cannot work with XT/IDE, XT/CF */
 #define OLD_IDE_DELAY 1000	/* delay required for old drives, system dependent */
-#define DEBUG
+//#define DEBUG
 
 //#define USE_LOCALBUF		/* For debugging: use local bounce buffer instead of */
 				/* direct buffer io via far pointers.
@@ -207,7 +207,7 @@ void insw(unsigned int port, word_t *buffer, int count)
     byte_t *buf = (byte_t *)buffer;
 #else
     word_t *buf = buffer;
-    count >>= 1;
+    count = (count+1)>>1;
 #endif
     //printk("insw %x,%x,%d;", port, buf, count);
     do {
@@ -250,12 +250,12 @@ void outsw(unsigned int port, word_t *buffer, int count)
     byte_t *buf = (byte_t *)buffer;
 #else
     word_t *buf = buffer;
-    count >>= 1;
+    count = (count+1) >> 1;
 #endif
     //printk("%04x:", buffer);
-    for (i = 0; i < count; i++) {
-	OUTBW(buffer[i], port);
-    }
+    for (i = 0; i < count; i++)
+	OUTBW(buf[i], port);
+
     return;
 }
 #endif
@@ -270,13 +270,12 @@ void write_data(unsigned int port, ramdesc_t seg, word_t *buffer, int count, int
     } else 
 #endif
     {
-
 	//printk("%x,%x,%x,%lx,%d;", port, buffer, seg, locbuf, count);
 #ifdef CONFIG_HW_PCXT
 	byte_t __far *locbuf = _MK_FP(seg, (unsigned)buffer);
 #else
 	word_t __far *locbuf = _MK_FP(seg, (unsigned)buffer);
-	count >>= 1;
+	count = (count+1) >> 1;
 #endif
 	do {
 	    OUTBW(*locbuf++, port);

--- a/tlvc/arch/i86/drivers/block/idequery.c
+++ b/tlvc/arch/i86/drivers/block/idequery.c
@@ -72,15 +72,15 @@ static void INITPROC dump_ide(word_t *buffer, int size) {
 int INITPROC get_ide_data(int drive, struct drive_infot *drive_info) {
 
 	word_t port = io_ports[drive >> 1];
-	int retval = 0, i;
+	int retval = 0, i, timeout = 10000;
 
 	word_t *ide_buffer = (word_t *)heap_alloc(512, 0);
 
 	out_hd(drive, IDE_DRIVE_ID);
-    	while (WAITING(port));
+    	while (WAITING(port) && timeout--);
 
 	i = STATUS(port);
-	if (!i || (i & 1) == 1) {
+	if (!timeout || !i || (i & 1) == 1) {
 		/* Error - drive not found or non-IDE.
 		 * NOTE: If drive # is 2 (i.e. 2nd controller), there may be a drive 3
 		 * (slave) even if drive 2 (the master) is missing. 


### PR DESCRIPTION
Some minor adjustments in `directhd.c` and fix for a bug in `idequery.c` (applies to BIOSHD, not directhd) : 
If the BIOS indicates that a HD is present but the drive (usually a CF or other flash card) is missing, `idequery` would hang waiting for a response. The fix adds a counter to prevent such hangs.