### PR TITLE
[net, ktcp] Enhancements: Speed, retransmits

### DIFF
--- a/tlvc/arch/i86/drivers/net/el3-asm.S
+++ b/tlvc/arch/i86/drivers/net/el3-asm.S
@@ -1,5 +1,5 @@
 //
-// Low level routines for ELKS EtherLink III ethernet driver (3c509)
+// Low level routines for ELKS/TLVC EtherLink III ethernet driver (3c509)
 //
 // Helge Skrivervik (@mellvik) june 2022
 //
@@ -17,7 +17,7 @@
 	.text
 
 //-----------------------------------------------------------------------------
-// Read data from port
+// Read data from port to buffer in user-task data segment
 //-----------------------------------------------------------------------------
 // void el3_insw(int port, char *data, int count)
 //
@@ -51,7 +51,7 @@ word_loop:
 
 
 //-----------------------------------------------------------------------------
-// Write data to port
+// Write data from buffer in user data segment to port 
 //-----------------------------------------------------------------------------
 // void el3_sendpk(int port, char *data, int count)
 //

--- a/tlvc/arch/i86/drivers/net/el3.c
+++ b/tlvc/arch/i86/drivers/net/el3.c
@@ -12,7 +12,6 @@
 */
 
 #include <arch/io.h>
-#include <arch/ports.h>
 #include <arch/segment.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/major.h>
@@ -112,9 +111,9 @@ static int max_interrupt_work = 5;
 /* runtime configuration set in /bootopts or defaults in ports.h */
 #define net_irq     (netif_parms[ETH_EL3].irq)
 #define net_port    (netif_parms[ETH_EL3].port)
-#define net_ram     (netif_parms[ETH_EL3].ram)
 #define net_flags   (netif_parms[ETH_EL3].flags)
-static int ioaddr;	// FIXME  remove later
+
+static int ioaddr;
 static word_t el3_id_port;
 static unsigned char found;
 
@@ -139,10 +138,11 @@ struct file_operations el3_fops =
     el3_release
 };
 
-void INITPROC el3_drv_init(void) {
+void INITPROC el3_drv_init(void)
+{
 
 	ioaddr = net_port;
-	if (!net_port) {
+	if (!ioaddr) {
 		printk("el3: ignored\n");
 		return;
 	}
@@ -159,11 +159,11 @@ void INITPROC el3_drv_init(void) {
 
 }
 
-static int INITPROC el3_find_id_port (void) {
-
-	for ( el3_id_port = EP_ID_PORT_START ;
-	      el3_id_port < EP_ID_PORT_END ;
-	      el3_id_port += EP_ID_PORT_INC ) {
+static int INITPROC el3_find_id_port(void)
+{
+	for (el3_id_port = EP_ID_PORT_START;
+	     el3_id_port < EP_ID_PORT_END;
+	     el3_id_port += EP_ID_PORT_INC) {
 		outb(0, el3_id_port);
 		/* See if anything's listening */
 		outb(0xff, el3_id_port);
@@ -328,9 +328,9 @@ static size_t el3_write(struct inode *inode, struct file *file, char *data, size
 	A note about TLVC, EL3 and Interrupts
 	TLVC does not service network interrupts as they arrive. Instead, when the application calls the
 	driver, the status is checked and a read initiated if data is ready - or a write is initiated if 
-	the interface is ready. Otherwise the application is but to sleep, to be awakened by the wake_up
+	the interface is ready. Otherwise the application is put to sleep, to be awakened by the wake_up
 	calls from the driver. A more traditional approach is to act on the cause of an interrupt 
-	- e.g. transfer an arrived packet into a buffer, immediately.
+	- e.g. transfer received packets into a buffer immediately.
 	The 3Com 3C509 family of NICs expect the latter, and the RxComplete and RxEarly interrupt status
 	bits can only be reset by emptying the NIC's FIFO.
 	In order to get this scheme to work with TLVC, we mask off the RxComplete interrupt immediately 
@@ -793,11 +793,7 @@ int el3_select(struct inode *inode, struct file *filp, int sel_type)
 		
 		case SEL_IN:
 
-			el3_udelay(300);	/* experimental delay to increase speed of */
-						/* outward ftp transfers. May need different
-						 * values on different machines */ 
-						/* '300' quadruples the speed on a 40MHz 386SX system */
-			// Don't use RxComplete for this test, it has been masked out!
+			/* Don't use the RxComplete intr for this test, it has been masked out! */
 			if (inw(ioaddr+RX_STATUS) & 0x8000) {
 				//printk("s%x", inw(ioaddr+RX_STATUS));
 				select_wait(&rxwait);

--- a/tlvc/net/ipv4/af_inet.c
+++ b/tlvc/net/ipv4/af_inet.c
@@ -368,14 +368,14 @@ static int inet_write(register struct socket *sock, char *ubuf, int size,
 
 	if (ret < 0) {
             if (ret == -ERESTARTSYS) {
-		/* delay process 100ms*/
+		/* delay process 100ms - shortening this */
+		/* may cause deadlock on fast systems (hs) */
 		current->state = TASK_INTERRUPTIBLE;
 		current->timeout = jiffies + (HZ / 10); /* 1/10 sec = 100ms*/
                 schedule();
             } else
                 return ret;
-        }
-        else {
+        } else {
 	    count -= usize;
 	    ubuf += usize;
 	}

--- a/tlvccmd/ktcp/Makefile
+++ b/tlvccmd/ktcp/Makefile
@@ -14,7 +14,7 @@ OBJS		= $(CFILES:.c=.o)
 all:	ktcp
 
 ktcp:	$(OBJS)
-	$(LD) $(LDFLAGS) -maout-heap=32768 -maout-stack=3072  -o ktcp $(OBJS) $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=33772 -maout-stack=3072  -o ktcp $(OBJS) $(LDLIBS)
 
 lint:
 	@for FILE in *.c ; do \

--- a/tlvccmd/ktcp/tcp.c
+++ b/tlvccmd/ktcp/tcp.c
@@ -457,7 +457,7 @@ void tcp_reject(struct iphdr_s *iph) {
 
 	tcph = (struct tcphdr_s *)(((char *)iph) + 4 * IP_HLEN(iph));
 	seqno = ntohl(tcph->seqnum);
-	printf("tcp: refusing packet from %s:%u to :%u fl 0x%02x\n", in_ntoa(iph->saddr),
+	debug_tcp("tcp: refusing packet from %s:%u to :%u fl 0x%02x\n", in_ntoa(iph->saddr),
 		ntohs(tcph->sport), ntohs(tcph->dport), tcph->flags);
 
 	/* Dummy up a new control block and send RST to shutdown sender */

--- a/tlvccmd/ktcp/tcp.h
+++ b/tlvccmd/ktcp/tcp.h
@@ -30,23 +30,24 @@
 #define USE_SWS			0	/* =1 to use silly window algorithm */
 
 /* max outstanding send window size*/
-#define TCP_SEND_WINDOW_MAX	1024	/* should be less than TCP_RETRANS_MAXMEM*/
+#define TCP_SEND_WINDOW_MAX	1536	/* should be less than TCP_RETRANS_MAXMEM*/
+					/* was 1024 */
 
 /* threshold to wait before pushing data to application (turned off for now) */
 //#define PUSH_THRESHOLD	512
 
-/* timeout values in 1/16 seconds, or (seconds << 4). Half second = 8*/
-#define TIMEOUT_ENTER_WAIT	(4<<4)	/* TIME_WAIT state (was 30, then 10)*/
-#define TIMEOUT_CLOSE_WAIT	(10<<4)	/* CLOSING/LAST_ACK/FIN_WAIT states (was 240)*/
-#define TIMEOUT_INITIAL_RTT	(1<<4)	/* initial RTT before retransmit (was 4)*/
-#define TCP_RETRANS_MAXWAIT	(4<<4)	/* max retransmit wait (4 secs)*/
-#define TCP_RETRANS_MINWAIT_SLIP 8	/* min retrans timeout for slip/cslip (1/2 sec)*/
-#define TCP_RETRANS_MINWAIT_ETH	4	/* min retrans timeout for ethernet (1/4 sec)*/
+/* timeout values in 1/16 seconds, or (seconds << 4). Half second = 8 */
+#define TIMEOUT_ENTER_WAIT	(4<<4)	/* TIME_WAIT state (was 30, then 10) */
+#define TIMEOUT_CLOSE_WAIT	(10<<4)	/* CLOSING/LAST_ACK/FIN_WAIT states (was 240) */
+#define TIMEOUT_INITIAL_RTT	(1<<4)	/* initial RTT before retransmit (was 4) */
+#define TCP_RETRANS_MAXWAIT	(4<<4)	/* max retransmit wait (4 secs) */
+#define TCP_RETRANS_MINWAIT_SLIP 8	/* min retrans timeout for slip/cslip (1/2 sec) */
+#define TCP_RETRANS_MINWAIT_ETH	4	/* min retrans timeout for ethernet (1/4 sec) */
 
 /* retransmit settings*/
 #define TCP_RTT_ALPHA			90
-#define TCP_RETRANS_MAXMEM		4096	/* max retransmit total memory*/
-#define TCP_RETRANS_MAXTRIES		6	/* max # retransmits (~12 secs total)*/
+#define TCP_RETRANS_MAXMEM		5120	/* max retransmit total memory (was 4096) */
+#define TCP_RETRANS_MAXTRIES		6	/* max # retransmits (~12 secs total) */
 
 #define SEQ_LT(a,b)	((long)((a)-(b)) < 0)
 #define SEQ_LEQ(a,b)	((long)((a)-(b)) <= 0)

--- a/tlvccmd/ktcp/tcp_output.c
+++ b/tlvccmd/ktcp/tcp_output.c
@@ -290,9 +290,11 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
     memcpy(n->tcphdr, th, len);
     memcpy(&n->apair, apair, sizeof(struct addr_pair));
     n->retrans_num = 0;
-    n->first_trans = Now;
 
     n->rto = cb->rtt << 1;			/* set retrans timeout to twice RTT*/
+    if (cb->rtt > 2) n->rto <<= 1;		/* if the peer is very slow or heavily loaded,
+						 * give it a break instead of pouring out
+						 * retransmits. (hs) */
     if (linkprotocol == LINK_ETHER) {
 	if (n->rto < TCP_RETRANS_MINWAIT_ETH)
 	    n->rto = TCP_RETRANS_MINWAIT_ETH;	/* 1/4 sec min retrans timeout on ethernet*/
@@ -300,6 +302,7 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
 	if (n->rto < TCP_RETRANS_MINWAIT_SLIP)
 	    n->rto = TCP_RETRANS_MINWAIT_SLIP;	/* 1/2 sec min retrans timeout on slip/cslip*/
     }
+    n->first_trans = Now;
     n->next_retrans = Now + n->rto;
     //cb->rtrns++;		// count # of outstanding pkts per cb
 }


### PR DESCRIPTION
This PR fixes the `ktcp` performance problem described in #67 by increasing the allowed max send window. The problem popped up only on relatively fast systems and only if there was a router between the TLVC system and the peer. The fix eliminates a wait/wakeup cycle and allows the TLVC sender to send packets more or less continuously, reaching the same level of performance as if the hosts were on the same network segment.

Also fixed is an old `ktcp` problem which caused lots of unneccessary retransmissions when sending to slow host. The retransmit timeout calculation simply didn't work in such settings. The fix is to check the roundtrip time before setting the first retransmit timeout. If the peer system is found to be very slow or heavily loaded, double the initial timeout.

Included:
- The delay kludge previously added to the ee16 and the el3 drivers to get around the slow-send problem has been removed.
- Shortening the read_select wait timeout from 100ms to 50ms  did speed things up, but not as much as the selected solution, increasing the allowed retransmit window. Also, the shortened wait timeout seems to create deadlocks in certain situations. A comment about this has been added to the `af_inet.c` file.
