### PR TITLE
[ktcp] New fix for minimizing retransmits to slow peers

### DIFF
--- a/tlvccmd/ktcp/tcp.c
+++ b/tlvccmd/ktcp/tcp.c
@@ -240,8 +240,10 @@ static void tcp_established(struct iptcp_s *iptcp, struct tcpcb_s *cb)
 
     if (h->flags & TF_RST) {
 	/* TODO: Check seqnum for security */
+#if VERBOSE
 	printf("tcp: RST from %s:%u->%u\n",
 	    in_ntoa(cb->remaddr), ntohs(h->sport), ntohs(h->dport));
+#endif
 	rmv_all_retrans_cb(cb);
 
 	if (cb->state == TS_CLOSE_WAIT) {

--- a/tlvccmd/ktcp/tcp.h
+++ b/tlvccmd/ktcp/tcp.h
@@ -39,7 +39,7 @@
 /* timeout values in 1/16 seconds, or (seconds << 4). Half second = 8 */
 #define TIMEOUT_ENTER_WAIT	(4<<4)	/* TIME_WAIT state (was 30, then 10) */
 #define TIMEOUT_CLOSE_WAIT	(10<<4)	/* CLOSING/LAST_ACK/FIN_WAIT states (was 240) */
-#define TIMEOUT_INITIAL_RTT	4	/* initial RTT before retransmit (was 4, then 1<<4) */
+#define TIMEOUT_INITIAL_RTT	(1<<4)	/* initial RTT before retransmit (was 4, then 1<<4) */
 #define TCP_RETRANS_MAXWAIT	(4<<4)	/* max retransmit wait (4 secs) */
 #define TCP_RETRANS_MINWAIT_SLIP 8	/* min retrans timeout for slip/cslip (1/2 sec) */
 #define TCP_RETRANS_MINWAIT_ETH	4	/* min retrans timeout for ethernet (1/4 sec) */
@@ -49,6 +49,8 @@
 #define TCP_RTT_ALPHA			90
 #define TCP_RETRANS_MAXMEM		5120	/* max retransmit total memory (was 4096) */
 #define TCP_RETRANS_MAXTRIES		6	/* max # retransmits (~12 secs total) */
+#define TCP_PEER_INDEX_MAX		20	/* don't let the retrans slowdown get out
+						 *  of hand, use 200 for debugging */
 
 #define SEQ_LT(a,b)	((long)((a)-(b)) < 0)
 #define SEQ_LEQ(a,b)	((long)((a)-(b)) <= 0)
@@ -123,10 +125,10 @@ struct tcpcb_s {
 
 	__u8	state;
 	__u8	unaccepted;		/* boolean */
-	__u8	sndwin_loop;		/* loop count waiting for space in retrans buffer */
+	__u8	sndwin_loop;		/* consecutive loops while waiting for retrans buffer */
 	__u8	peer_speed;		/* peer speed index, for throttling retrans */
 	timeq_t	rtt;			/* in 1/16 secs*/
-	//__u16	retrns_cnt;		/* # of packets in retrans buffer */
+	__u16	retranscnt;		/* # of retranmits for this connection */
 
 	__u32	time_wait_exp;
 	//__u16	wait_data;

--- a/tlvccmd/ktcp/tcp.h
+++ b/tlvccmd/ktcp/tcp.h
@@ -31,7 +31,7 @@
 
 /* max outstanding send window size*/
 #define TCP_SEND_WINDOW_MAX	1536	/* should be less than TCP_RETRANS_MAXMEM*/
-					/* was 1024 */
+					/* was 1024, then 1536 which works fine */
 
 /* threshold to wait before pushing data to application (turned off for now) */
 //#define PUSH_THRESHOLD	512
@@ -39,10 +39,11 @@
 /* timeout values in 1/16 seconds, or (seconds << 4). Half second = 8 */
 #define TIMEOUT_ENTER_WAIT	(4<<4)	/* TIME_WAIT state (was 30, then 10) */
 #define TIMEOUT_CLOSE_WAIT	(10<<4)	/* CLOSING/LAST_ACK/FIN_WAIT states (was 240) */
-#define TIMEOUT_INITIAL_RTT	(1<<4)	/* initial RTT before retransmit (was 4) */
+#define TIMEOUT_INITIAL_RTT	4	/* initial RTT before retransmit (was 4, then 1<<4) */
 #define TCP_RETRANS_MAXWAIT	(4<<4)	/* max retransmit wait (4 secs) */
 #define TCP_RETRANS_MINWAIT_SLIP 8	/* min retrans timeout for slip/cslip (1/2 sec) */
 #define TCP_RETRANS_MINWAIT_ETH	4	/* min retrans timeout for ethernet (1/4 sec) */
+#define TCP_RETRANS_ADJUST	2	/* retrans timeout multiplicator for slow peers */
 
 /* retransmit settings*/
 #define TCP_RTT_ALPHA			90
@@ -122,7 +123,10 @@ struct tcpcb_s {
 
 	__u8	state;
 	__u8	unaccepted;		/* boolean */
+	__u8	sndwin_loop;		/* loop count waiting for space in retrans buffer */
+	__u8	peer_speed;		/* peer speed index, for throttling retrans */
 	timeq_t	rtt;			/* in 1/16 secs*/
+	//__u16	retrns_cnt;		/* # of packets in retrans buffer */
 
 	__u32	time_wait_exp;
 	//__u16	wait_data;

--- a/tlvccmd/ktcp/tcp_output.c
+++ b/tlvccmd/ktcp/tcp_output.c
@@ -278,6 +278,7 @@ void tcp_reoutput(struct tcp_retrans_list_s *n)
 
     ip_sendpacket((unsigned char *)n->tcphdr, n->len, &n->apair, n->cb);
     netstats.tcpretranscnt++;
+    n->cb->retranscnt++;
 }
 
 /* called every ktcp cycle when tcp_timeruse nonzero - check for expired retrans*/
@@ -332,7 +333,7 @@ void tcp_retrans_retransmit(void)
     while (n != NULL) {
 	/* check for retrans time up*/
 	if (TIME_GEQ(Now, n->next_retrans + (long)(n->cb->peer_speed * TCP_RETRANS_ADJUST))) {
-    	    printf("retrans (%d)\n", tcp_timeruse);	/* DEBUG ONLY */
+    	    //printf("retrans (%d,%d)\n", tcp_timeruse, n->len - TCP_DATAOFF(&n->tcphdr[0]));	/* DEBUG */
 	    tcp_reoutput(n);
 	    if (n->retrans_num >= TCP_RETRANS_MAXTRIES) {
 		printf("tcp retrans: max retries exceeded seq %lu unack %lu time %ld\n",
@@ -423,7 +424,7 @@ void tcp_output(struct tcpcb_s *cb)
     apair.daddr = cb->remaddr;
     apair.protocol = PROTO_TCP;
 
-    add_for_retrans(cb, th, len, &apair);
     ip_sendpacket((unsigned char *)th, len, &apair, cb);
+    add_for_retrans(cb, th, len, &apair);
     netstats.tcpsndcnt++;
 }

--- a/tlvccmd/ktcp/tcp_output.c
+++ b/tlvccmd/ktcp/tcp_output.c
@@ -127,61 +127,14 @@ __u16 tcp_chksumraw(struct tcphdr_s *h, __u32 saddr, __u32 daddr, __u16 len)
     return ~(__u16)sum;
 }
 
-/*** __u16 tcp_chksumraw(struct tcphdr_s *h, __u32 saddr, __u32 daddr, __u16 len)
-	.text
-	.globl _tcp_chksumraw
-_tcp_chksumraw:
-	push	bp
-	mov	bp, sp
-	push	di
-	push	si
-
-	mov	si, 4[bp]	! h
-	mov	ax, $E[bp]	! len
-	mov	cx, ax
-	xchg	al, ah
-	mov	bx, cx
-	sar	cx, #$1
-
-	mov	dx, bx
-	and	bx, #$1
-	jz	loop2
-
-	mov	bx, dx
-	dec	bx
-	mov	dl, [si + bx]
-	xor	dh, dh
-	add	ax, dx
-
-loop2:
-	adc	ax, [si]
-        inc si
-        inc si
-        loop	loop2
-
-	adc	ax, 6[bp]
-	adc	ax, 8[bp]
-	adc	ax, $A[bp]
-	adc	ax, $C[bp]
-	adc	ax, #$600
-        adc     ax, 0
-
-        not	ax
-
-	pop	si
-	pop	di
-	pop	bp
-	ret
-***/
-
 struct tcp_retrans_list_s *
 rmv_from_retrans(struct tcp_retrans_list_s *n)
 {
     struct tcp_retrans_list_s *next = n->next;
 
     tcp_timeruse--;
+    //n->cb->retrns_cnt--;
     tcp_retrans_memory -= n->len;
-    //n->cb->rtrns--;	// EXPERIMENTAL
     debug_mem("retrans free: (cnt %d mem %u)\n", tcp_timeruse, tcp_retrans_memory);
 
 #ifdef REVERSE_LIST
@@ -282,7 +235,8 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
 #endif
 
     /* start timeout blocking in main loop*/
-    tcp_timeruse++;
+    tcp_timeruse++;	/* actually counts the # of packets in the retransmit buffer */
+    //cb->retrns_cnt++;
 
     tcp_retrans_memory += len;
     debug_mem("retrans alloc: (cnt %d, mem %u)\n", tcp_timeruse, tcp_retrans_memory);
@@ -292,9 +246,6 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
     n->retrans_num = 0;
 
     n->rto = cb->rtt << 1;			/* set retrans timeout to twice RTT*/
-    if (cb->rtt > 2) n->rto <<= 1;		/* if the peer is very slow or heavily loaded,
-						 * give it a break instead of pouring out
-						 * retransmits. (hs) */
     if (linkprotocol == LINK_ETHER) {
 	if (n->rto < TCP_RETRANS_MINWAIT_ETH)
 	    n->rto = TCP_RETRANS_MINWAIT_ETH;	/* 1/4 sec min retrans timeout on ethernet*/
@@ -304,7 +255,7 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
     }
     n->first_trans = Now;
     n->next_retrans = Now + n->rto;
-    //cb->rtrns++;		// count # of outstanding pkts per cb
+    //fprintf(stderr, "rtt/rto/tu: %ld/%ld/%d\n", cb->rtt, n->rto, tcp_timeruse);
 }
 
 void tcp_reoutput(struct tcp_retrans_list_s *n)
@@ -318,10 +269,12 @@ void tcp_reoutput(struct tcp_retrans_list_s *n)
 	n->rto = TCP_RETRANS_MAXWAIT;
     n->next_retrans = Now + n->rto;
 
+#ifdef VERBOSE
     printf("tcp retrans: seq %lu+%u size %d rcvwnd %u unack %lu rto %ld rtt %ld state %d (RETRY %d cnt %d mem %u)\n",
 	ntohl(n->tcphdr[0].seqnum) - n->cb->iss, datalen,
 	n->len - TCP_DATAOFF(&n->tcphdr[0]), n->cb->rcv_wnd, n->cb->send_una - n->cb->iss,
 	n->rto, n->cb->rtt, n->cb->state, n->retrans_num, tcp_timeruse, tcp_retrans_memory);
+#endif
 
     ip_sendpacket((unsigned char *)n->tcphdr, n->len, &n->apair, n->cb);
     netstats.tcpretranscnt++;
@@ -378,7 +331,8 @@ void tcp_retrans_retransmit(void)
     
     while (n != NULL) {
 	/* check for retrans time up*/
-	if (TIME_GEQ(Now, n->next_retrans)) {
+	if (TIME_GEQ(Now, n->next_retrans + (long)(n->cb->peer_speed * TCP_RETRANS_ADJUST))) {
+    	    printf("retrans (%d)\n", tcp_timeruse);	/* DEBUG ONLY */
 	    tcp_reoutput(n);
 	    if (n->retrans_num >= TCP_RETRANS_MAXTRIES) {
 		printf("tcp retrans: max retries exceeded seq %lu unack %lu time %ld\n",

--- a/tlvccmd/ktcp/tcpdev.c
+++ b/tlvccmd/ktcp/tcpdev.c
@@ -337,7 +337,7 @@ static void tcpdev_write(void)
     struct tdb_write *db = (struct tdb_write *)sbuf; /* read from sbuf*/
     struct tcpcb_list_s *n;
     struct tcpcb_s *cb;
-    void *  sock = db->sock;
+    void *sock = db->sock;
     unsigned int size, maxwindow;
 
     sock = db->sock;
@@ -384,11 +384,18 @@ static void tcpdev_write(void)
     if (maxwindow > TCP_SEND_WINDOW_MAX)	/* limit retrans memory usage*/
 	maxwindow = TCP_SEND_WINDOW_MAX;
     if (cb->send_nxt - cb->send_una + size > maxwindow) {
+	cb->sndwin_loop++;
 	debug_tcp("tcp limit: seq %lu size %d maxwnd %u unack %lu rcvwnd %u\n",
 	    cb->send_nxt - cb->iss, size, maxwindow, cb->send_nxt - cb->send_una, cb->rcv_wnd);
-	retval_to_sock(sock, -ERESTARTSYS);	/* kernel will retry 100ms later*/
+	retval_to_sock(sock, -ERESTARTSYS);	/* source will wait for 100ms, then retry */
 	return;
     }
+
+    if (cb->sndwin_loop > cb->peer_speed) {    /* Adjust the 'peer performance index' */
+	cb->peer_speed = cb->sndwin_loop;
+	fprintf(stderr, "spd ind %d\n", cb->sndwin_loop);
+    }
+    cb->sndwin_loop = 0;
 
     debug_tcp("tcp write: seq %lu size %d rcvwnd %u unack %lu (cnt %d, mem %u)\n",
 	cb->send_nxt - cb->iss, size, cb->rcv_wnd, cb->send_nxt - cb->send_una,


### PR DESCRIPTION
A new fix for the `ktcp` problem discussed at length in #68: excessive retransmits when talking to very slow systems (like TLVC talking to TLVC or ELKS).

The scenario is this: A very slow system, say an XT or a 286 AT, `telnet`s to another TLVC/ELKS host and does something that creates a lot of output, like `hd /bin/ps` for example. The server will deliver reliably but slow because the `ktcp` retransmit timeouts don't work with such slow clients. A similar pattern may be observed when sending files to such as slow system (`ftp`).

After understanding the details of the problem (again, see #68), and testing several fixes that worked but have drawbacks, such as not being able to adapt to the degree of slowness on the client side, here's a solution that seem to satisfy reasonable demands, including not breaking anything(!).

The primary challenge was to find a reliable metric for the (network) performance of the client. The solution turned out to be hiding right under my nose: When the send window closes (the retransmit buffer is full), `ktcp` will 'loop' that particular connection until the window opens up again. Counting the number of times it loops turns out to be the metric we're looking for. 

The fix monitors the loop and establishes a performance index for the client using the max # of consecutive loops recorded. It usually takes 2-3 attempts to get there and a few retransmits will be sent in the meantime, but the cost seems acceptable given the dynamics the solution brings to the table. Like - a 286AT will get an index of 6 give or take 1, and XT (4.7MHz) will end up between 13 and 15 - for example. Most systems will have a speed index of 0 - or, if on a long or slow connection, 1, which does not affect normal operation. The speed-factor is then used to increase the retransmit timeout for the connection without touching the regular RTT and RTO values.

The price for the fix is 2 additional bytes in the `CB struct` and a little bit of code.