### PR TITLE
[net, ne2k] Bugfixes and enhancements in buffer management

### DIFF
--- a/tlvc/arch/i86/drivers/net/ne2k-asm.S
+++ b/tlvc/arch/i86/drivers/net/ne2k-asm.S
@@ -1003,7 +1003,7 @@ ne2k_get_hw_addr:
 	mov     4(%bp),%di
 
 	// Effectively a soft reset of the NIC, required in order to get access to the
-	// address PROM. The PROM is 16 or 32 bytes depending on the bus widths. We read
+	// address PROM. The PROM is 16 or 32 bytes depending on the bus width. We read
 	// it in word mode and always get 32 back.
 	// The MAC address is in the first 6 bytes.
 	// The remaining 10 bytes sometimes identify the card type. The PROM content from 
@@ -1032,7 +1032,8 @@ w_reset:
 	mov	$32,%cx		// bytes to read
 	xor	%bx,%bx		// read from 0:0
 	xor	%al,%al		// AL = 0 : local xfer
-	call	dma_read
+	call	dma_read	// read is always word mode at this point,
+				// ne2k_flags has not been set yet
 
 	mov	net_port,%dx
 	add	$io_ne2k_tx_conf,%dx	// set tx back to normal


### PR DESCRIPTION
This update to the ne2k driver makes its use of buffers more functional - in fact, more useful since the old code would never take advantage of more than at most 2 buffers, most of the time only one. The main change is that the interrupt routine now move as many received packets as possible from the NIC to the buffers - not only after a RX interrupt but on any interrupt.

Debug instrumentation shows that all receive buffers (there is no change to tx buffer code and the recommendation is to turn them off via bootopts) are used when needed  - tested with 4 rx buffers.

Some observations from the testing:
- For all but the slowest systems, testing needs to be done through a router (or with other traffic going in parallel) in order to break the simple send-ack-send-ack sequence which will never use more than one buffer regardless. Also, when sending files to the system under test, the destination is always `/dev/null`.
- NIC level receive buffers have minimal impact on performance (as in transfer speed) regardless of how many are allocated. The very slow V20/XT system delivers the same speed with 4 buffers and 0 buffers indicating that this is not a bottleneck. On a faster system (capable of processing packets faster) this will likely be different.
- Also, since TCP does flow control, more than 2 buffers in use during a single file transfer is rare, occasionally 3 and never 4. This changes when several connections are active: Now buffer usage fluctuates 'naturally', 4 are used at times and more would likely be used if available.
- No performance gain doesn't mean the buffers are without value. Their presence changes the responsiveness of the system significantly, as evidenced by running a `ping -I 0.2 -s 1400 10.0.2.x` alongside a file transfer: There is no effect on the file transfer speed at all. Likewise I'm seeing interactive `telnet` response minimally affected by parallel file transfers.
- A flood ping with large packets will still effectively choke (but not kill) any tcp connection because of NIC overruns  requiring retransmissions - which have a hard time getting through. Up until the first overrun though, `telnet` is OK even when a big (1400 bytes) flood ping is running. Kill ping and the tcp connections recover nicely.
- The testing confirms - as discussed elsewhere - that the performance bottlenecks are located further up the chain.

The monitoring 'instrumentation' has been left in (commented out) the code for upcoming work on buffers.
Also, the compile config option (in `netbufs.h`) providing a choice between heap buffers or statically allocated buffers will be removed, leaving heap as the only option.  

Optional no-buffer support will be kept for now even though `netbufs=0,0` in `/bootopts` has the same effect, as it saves some code.
