### PR TITLE
[kernel] Precision timer code, printk updates from ghaerr, cleanups

### DIFF
--- a/tlvc/arch/i86/drivers/block/ll_rw_blk.c
+++ b/tlvc/arch/i86/drivers/block/ll_rw_blk.c
@@ -391,13 +391,9 @@ void ll_rw_blk(int rw, register struct buffer_head *bh)
     dev = NULL;
     if ((major = MAJOR(buffer_dev(bh))) < MAX_BLKDEV)
 	dev = blk_dev + major;
-    if (!dev || !dev->request_fn) {
-	printk("ll_rw_blk: Trying to read nonexistent block-device %s (%lu)\n",
-	       kdevname(buffer_dev(bh)), buffer_blocknr(bh));
-	mark_buffer_clean(bh);
-	mark_buffer_uptodate(bh, 0);
-    } else
-	make_request(major, rw, bh);
+    if (!dev || !dev->request_fn)
+	panic("ll_rw_blk: unknown device %D", buffer_dev(bh));
+    make_request(major, rw, bh);
 }
 
 void INITPROC blk_dev_init(void)

--- a/tlvc/arch/i86/drivers/char/mem.c
+++ b/tlvc/arch/i86/drivers/char/mem.c
@@ -259,6 +259,9 @@ int kmem_ioctl(struct inode *inode, struct file *file, int cmd, char *arg)
     case MEM_GETTASK:
 	retword = (unsigned short)task;
 	break;
+    case MEM_GETMAXTASKS:
+	retword = max_tasks;
+	break;
     case MEM_GETCS:
 	retword = kernel_cs;
 	break;
@@ -283,6 +286,9 @@ int kmem_ioctl(struct inode *inode, struct file *file, int cmd, char *arg)
 	retword = (unsigned short) &uptime;
 	break;
 #endif
+    case MEM_GETJIFFADDR:
+	retword = (unsigned) &jiffies;
+	break;
     default:
 	return -EINVAL;
     }

--- a/tlvc/arch/i86/kernel/irqtab.S
+++ b/tlvc/arch/i86/kernel/irqtab.S
@@ -405,12 +405,29 @@ idle_halt:
 	hlt
 	ret
 
+#ifdef CONFIG_PREC_TIMER
+        .global test_udelay
+
+test_udelay:
+
+        push    %bp
+        mov     %sp,%bp
+        mov     4(%bp),%cx      // count
+1:
+        outb    $0x80
+        loop    1b
+
+        pop     %bp
+        ret
+#endif
+
 	.data
 	.global	intr_count
 	.global endistack
 	.global	istack
 	.extern	current
 	.extern	previous
+
 
 #ifdef CONFIG_BLK_DEV_BIOS
 bios_call_cnt:                  // call BIOS IRQ 0 handler every 5th interrupt

--- a/tlvc/arch/i86/kernel/irqtab.S
+++ b/tlvc/arch/i86/kernel/irqtab.S
@@ -405,22 +405,6 @@ idle_halt:
 	hlt
 	ret
 
-#ifdef CONFIG_PREC_TIMER
-        .global test_udelay
-
-test_udelay:
-
-        push    %bp
-        mov     %sp,%bp
-        mov     4(%bp),%cx      // count
-1:
-        outb    $0x80
-        loop    1b
-
-        pop     %bp
-        ret
-#endif
-
 	.data
 	.global	intr_count
 	.global endistack

--- a/tlvc/arch/i86/kernel/system.c
+++ b/tlvc/arch/i86/kernel/system.c
@@ -31,7 +31,7 @@ void INITPROC setup_arch(seg_t *start, seg_t *end)
 	 * If ramdisk configured, subtract space for it from end of memory.
 	 */
 
-	/* Heap allocations at even addresses, helps debugging*/
+	/* Heap allocations at even addresses, important for performance */
 	unsigned int endbss = (unsigned int)(_endbss + 1) & ~1;
 
 	/*

--- a/tlvc/arch/i86/lib/Makefile
+++ b/tlvc/arch/i86/lib/Makefile
@@ -59,6 +59,10 @@ SRCS3 = \
 	bitops.c \
 	# end of list
 
+ifeq ($(CONFIG_ARCH_IBMPC), y)
+SRCS3 += prectimer.c
+endif
+
 OBJS3 = $(SRCS3:.c=.o)
 
 OBJS		= $(OBJS1) $(OBJS2) $(OBJS3)

--- a/tlvc/arch/i86/lib/prectimer.c
+++ b/tlvc/arch/i86/lib/prectimer.c
@@ -49,7 +49,7 @@ unsigned int get_time_10ms(void)
     static unsigned int lastcount;
 
     outb(0, TIMER_CMDS_PORT);       /* latch timer value */
-    lo = inb(TIMER_DATA_PORT);
+    lo = inb(TIMER_DATA_PORT)&0xff;
     hi = inb(TIMER_DATA_PORT) << 8;
     count = lo | hi;
     pdiff = lastcount - count;
@@ -68,7 +68,6 @@ unsigned int get_time_50ms(void)
     clr_irq();
     jdiff = (unsigned)jiffies - (unsigned)lastjiffies;
     lastjiffies = jiffies;          /* 32 bit save required after ~10.9 mins */
-    outb(0, TIMER_CMDS_PORT);       /* latch timer value */
     set_irq();
 
     pticks = get_time_10ms();

--- a/tlvc/arch/i86/lib/prectimer.c
+++ b/tlvc/arch/i86/lib/prectimer.c
@@ -71,10 +71,10 @@ unsigned int get_time_50ms(void)
 
     save_flags(flags);
     clr_irq();
+    outb(0, TIMER_CMDS_PORT);       /* latch timer value */
     /* ia16-elf-gcc won't generate 32-bit subtract so use 16-bit and check wrap */
     jdiff = (unsigned)jiffies - (unsigned)lastjiffies;
     lastjiffies = jiffies;          /* 32 bit save required after ~10.9 mins */
-    outb(0, TIMER_CMDS_PORT);       /* latch timer value */
     restore_flags(flags);
 
     lo = inb(TIMER_DATA_PORT);

--- a/tlvc/arch/i86/lib/prectimer.c
+++ b/tlvc/arch/i86/lib/prectimer.c
@@ -1,0 +1,163 @@
+#include <linuxmt/prectimer.h>
+#include <linuxmt/sched.h>
+#include <linuxmt/kernel.h>
+#include <arch/param.h>
+#include <arch/ports.h>
+#include <arch/irq.h>
+#include <arch/io.h>
+
+/*
+ * Precision timer routines
+ * 2 Aug 2024 Greg Haerr
+ */
+
+/*
+ * Each ptick corresponds to the elapsed time for a countdown in the 8254 PIT.
+ * The PC master oscillator frequency is 14.31818 MHz, and is divided
+ * by 12 for the PIT input frequency: 14.31818/12 = 1.1931818 Mhz. Divide
+ * that by 1000 and you get 11932 for the PIT countdown start value;
+ * 1/11932 = 0.8381 usecs per PIT 'ptick'.
+ */
+#define MAX_PTICK        11932      /* PIT reload value for 10ms (100 HZ) */
+
+/* error check with master PIT frequency */
+#define PITFREQ         11931818L   /* PIT input frequency * 10 */
+#define PITTICK         ((5+(PITFREQ/(HZ)))/10)
+#if PITTICK != MAX_PTICK
+#error Incorrect MAX_PTICK!
+#endif
+
+static unsigned long lastjiffies;
+
+/*
+ * Each PIT count (ptick) is 0.8381 usecs each for 10ms jiffies timer (= 1/11932)
+ *
+ * To display a ptick in usecs use ptick * 838 / 1000U (= 1 mul, 1 div )
+ *
+ * Return type   Name           Resolution  Max
+ * unsigned int  get_time_10ms  pticks      10ms  (< 11932 pticks)
+ * unsigned int  get_time_50ms  pticks      50ms  (< 5 jiffies = 59660 pticks)
+ * unsigned long get_time       pticks      1 hr  (< 359953 jiffies = 2^32 / 11932)
+ * unsigned long jiffies        jiffies   497 days(< 2^32 jiffies)
+ */
+
+/* read PIT diff count, returns < 11932 pticks (10ms), no overflow checking */
+unsigned int get_time_10ms(void)
+{
+    unsigned int lo, hi, count;
+    int pdiff;
+    static unsigned int lastcount;
+
+    outb(0, TIMER_CMDS_PORT);       /* latch timer value */
+    lo = inb(TIMER_DATA_PORT);
+    hi = inb(TIMER_DATA_PORT) << 8;
+    count = lo | hi;
+    pdiff = lastcount - count;
+    if (pdiff < 0)                  /* wrapped */
+        pdiff += MAX_PTICK;         /* = MAX_PTICK - count + lastcount */
+    lastcount = count;
+    return pdiff;
+}
+
+/* count up to 5 jiffies in pticks, returns < 59660 pticks (50ms), w/overflow check */
+unsigned int get_time_50ms(void)
+{
+    int jdiff;
+    unsigned int pticks;
+
+    clr_irq();
+    jdiff = (unsigned)jiffies - (unsigned)lastjiffies;
+    lastjiffies = jiffies;          /* 32 bit save required after ~10.9 mins */
+    outb(0, TIMER_CMDS_PORT);       /* latch timer value */
+    set_irq();
+
+    pticks = get_time_10ms();
+    if (jdiff < 0)                  /* lower half wrapped */
+        jdiff = -jdiff;             /* = 0x10000000 - lastjiffies + jiffies */
+    if (jdiff >= 2) {
+        if (jdiff >= 6)
+            return 0;               /* overflow displays 0s */
+        return (jdiff - 1) * 11932U + pticks;
+    }
+    return pticks;
+}
+
+/* return unknown elapsed time in pticks, precision < 50ms then ~10ms accuracy */
+unsigned long get_time(void)
+{
+    unsigned int pticks;
+    static unsigned long lasttime;
+
+    clr_irq();                  /* for saving lasttime below */
+    lasttime = lastjiffies;
+    pticks = get_time_50ms();
+    if (pticks != 0)
+        return pticks;          /* < 50ms */
+    /* current jiffies is in lastjiffies, last jiffies is in lasttime */
+    return (lastjiffies - lasttime) * MAX_PTICK;
+}
+
+#if TIMER_TEST
+/* sample timer routines */
+void timer_10ms(void)
+{
+    unsigned int pticks;
+
+    pticks = get_time_10ms();
+    printk("%u %u = %k\n", pticks, (unsigned)jiffies, pticks);
+}
+
+void timer_50ms(void)
+{
+    static int v;
+    unsigned long timeout = jiffies + v;            /* > 5 will fail */
+    unsigned int pticks = get_time_50ms();
+    unsigned int usecs = pticks * 838UL / 1000;     /* use unsigned _udivsi3 for speed */
+    printk("%u %u = %u usecs = %k\n", pticks, (unsigned)lastjiffies, usecs, pticks);
+    if (++v > 5) v = 0;
+    while (jiffies < timeout)
+        ;
+}
+
+void timer_4s(void)
+{
+    unsigned long timeout = jiffies + 400;
+    unsigned long pticks = get_time();
+    printk("%lu %u = %lk\n", pticks, (unsigned)lastjiffies, pticks);
+    while (jiffies < timeout)
+        ;
+}
+
+void timer_test(void)
+{
+    printk("1 = %k\n", 1);
+    printk("2 = %k\n", 2);
+    printk("3 = %k\n", 3);
+    printk("100 = %k\n", 100);
+    printk("500 = %k\n", 500);
+    printk("1000 = %k\n", 1000);
+    printk("1192 = %k\n", 1192);
+    printk("1193 = %k\n", 1193);
+    printk("1194 = %k\n", 1194);
+    printk("10000 = %k\n", 10000);
+    printk("59659 = %k\n", 59659U);
+    printk("59660 = %k\n", 59660U);
+    printk("59661 = %k\n", 59661U);
+    printk("100000 = %lk\n", 100000L);
+    printk("5*59660 = %lk\n", 5*59660L);
+    printk("359953 = %lk\n", 359953L);
+    printk("19*59660 = %lk\n", 19*59660L);
+    printk("20*59660 = %lk\n", 20*59660L);
+    printk("21*59660 = %lk\n", 21*59660L);
+    printk("60*59660 = %lk\n", 60*59660L);
+    printk("84*59660 = %lk\n", 84*59660L);
+    printk("600*59660 = %lk\n", 600*59660L);
+    printk("3000000 = %lk\n", 3000000L);
+    printk("30000000 = %lk\n", 30000000UL);
+    printk("35995300 = %lk\n", 35995300UL);
+    printk("36000000 = %lk\n", 36000000UL);
+    printk("51000000 = %lk\n", 51000000UL);
+    printk("51130563 = %lk\n", 51130563UL);
+    printk("51130564 = %lk\n", 51130564UL);
+}
+#endif

--- a/tlvc/config.in
+++ b/tlvc/config.in
@@ -17,6 +17,7 @@ mainmenu_option next_comment
 		bool 'Compaq DeskPro Hardware (fast mode)' CONFIG_HW_COMPAQFAST n
 		bool 'MK-88 Hardware (IRQ 3 keyboard)' CONFIG_HW_MK88 n
 		bool 'IBM PC/XT or compatible (8bit ISA)' CONFIG_HW_PCXT n
+		bool 'Add Precision timer (for debugging)' CONFIG_PREC_TIMER n
 
 		comment 'Devices'
 

--- a/tlvc/fs/devices.c
+++ b/tlvc/fs/devices.c
@@ -192,37 +192,3 @@ struct inode_operations chrdev_inode_operations = {
     NULL			/* truncate */
 };
 
-/*
- * Print device name (in decimal, hexadecimal or symbolic) -
- * at present hexadecimal only.
- * Note: returns pointer to static data!
- */
-
-extern char *hex_string;	/* It lives in kernel/printk.c. */
-
-char *kdevname(kdev_t dev)
-{
-#if (MINORBITS == 8) && (MINORMASK == 255)
-    static char buffer[5];
-    register char *bp = buffer + 4;
-    *bp = 0;
-    do {
-	*--bp = hex_string[dev & 0xf];
-	dev >>= 4;
-    } while (bp > buffer);
-#else
-    static char buffer[16];
-/*      register char *hexof = "0123456789ABCDEF"; */
-    register char *hexof = hex_string;
-    register char *bp = buffer;
-    kdev_t b = MAJOR(dev);
-
-    *bp++ = hexof[b >> 4];
-    *bp++ = hexof[b & 15];
-    b = MINOR(dev);
-    *bp++ = hexof[b >> 4];
-    *bp++ = hexof[b & 15];
-    *bp = 0;
-#endif
-    return buffer;
-}

--- a/tlvc/fs/minix/inode.c
+++ b/tlvc/fs/minix/inode.c
@@ -145,7 +145,7 @@ struct super_block *minix_read_super(register struct super_block *s, char *data,
 	ms = (struct minix_super_block *) bh->b_data;
 	if (ms->s_magic != MINIX_SUPER_MAGIC) {
 	    if (!silent)
-		printk("VFS: dev %s is not minixfs.\n", kdevname(dev));
+		printk("VFS: dev %D is not minixfs.\n", dev);
 	    msgerr = err0;
 	    goto err_read_super_1;
 	}
@@ -354,8 +354,8 @@ static struct buffer_head *minix_get_inode(register struct inode *inode,
     ino = inode->i_ino;
     //printk("get_inode %d/%x;", ino, ino);
     if (!ino || ino > inode->i_sb->u.minix_sb.s_ninodes) {
-	printk("Bad inode number on dev %s: %d is out of range\n",
-		kdevname(inode->i_dev), ino);
+	printk("Bad inode number on dev %D: %d is out of range\n",
+		inode->i_dev, ino);
     } else {
 	block = inode->i_sb->u.minix_sb.s_imap_blocks + 2 +
 	    inode->i_sb->u.minix_sb.s_zmap_blocks + (ino - 1) / MINIX_INODES_PER_BLOCK;
@@ -434,8 +434,8 @@ int minix_sync_inode(register struct inode *inode)
 	ll_rw_blk(WRITE, bh);
 	wait_on_buffer(bh);
 	if (!buffer_uptodate(bh)) {
-	    printk("IO error syncing minix inode [%s:%08lx]\n",
-		   kdevname(inode->i_dev), inode->i_ino);
+	    printk("IO error syncing minix inode [%D:%08lx]\n",
+		   inode->i_dev, inode->i_ino);
 	    err = -1;
 	}
     } else if (!bh)

--- a/tlvc/fs/minix/namei.c
+++ b/tlvc/fs/minix/namei.c
@@ -373,7 +373,7 @@ static int empty_dir(register struct inode *inode)
     goto empt_dir;
   bad_dir:
     unmap_brelse(bh);
-    printk("Bad directory on device %s\n", kdevname(inode->i_dev));
+    printk("Bad directory on device %D\n", inode->i_dev);
   empt_dir:
     return 1;
 }
@@ -460,8 +460,8 @@ int minix_unlink(register struct inode *dir, char *name, size_t len)
 	current->euid != inode->i_uid && current->euid != dir->i_uid)
 	goto end_unlink;
     if (!inode->i_nlink) {
-	printk("Deleting nonexistent file (%s:%lu), %u\n",
-	       kdevname(inode->i_dev), inode->i_ino, inode->i_nlink);
+	printk("Deleting nonexistent file (%D:%lu), %u\n",
+	       inode->i_dev, inode->i_ino, inode->i_nlink);
 	inode->i_nlink = 1;
     }
     de->inode = 0;

--- a/tlvc/fs/super.c
+++ b/tlvc/fs/super.c
@@ -131,7 +131,7 @@ void put_super(kdev_t dev)
 
     if (!(sb = get_super(dev))) return;
     if (sb->s_covered)
-	printk("VFS: Mounted device %s - tssk, tssk\n", kdevname(dev));
+	printk("VFS: Mounted device %D - tssk, tssk\n", dev);
     else {
 	sop = sb->s_op;
 	if (sop && sop->put_super) sop->put_super(sb);
@@ -178,7 +178,7 @@ static struct super_block *read_super(kdev_t dev, int t, int flags,
 
 #if CONFIG_FULL_VFS
     if (!(type = get_fs_type(t))) {
-	printk("VFS: device %s unknown fs type %d\n", kdevname(dev), t);
+	printk("VFS: device %D unknown fs type %d\n", dev, t);
 	return NULL;
     }
 #else
@@ -471,7 +471,7 @@ void mount_root(void)
 	retval = open_filp(0, d_inode, &filp);
     }
     if (retval) {
-	printk("VFS: Unable to open root device %s\n", kdevname(ROOT_DEV));
+	printk("VFS: Unable to open root device %D\n", ROOT_DEV);
 	halt();
     }
 
@@ -509,6 +509,6 @@ void mount_root(void)
     }
 #endif
 
-    printk("VFS: Unable to mount root fs on %s\n", kdevname(ROOT_DEV));
+    printk("VFS: Unable to mount root fs on %D\n", ROOT_DEV);
     halt();
 }

--- a/tlvc/include/linuxmt/kdev_t.h
+++ b/tlvc/include/linuxmt/kdev_t.h
@@ -16,8 +16,6 @@
 
 typedef __u16 kdev_t;
 
-extern char *kdevname(kdev_t);	  /* note: returns pointer to static data! */
-
 /* As long as device numbers in the outside world have 16 bits only,
  * we use these conversions.
  */

--- a/tlvc/include/linuxmt/mem.h
+++ b/tlvc/include/linuxmt/mem.h
@@ -9,6 +9,8 @@
 #define MEM_GETHEAP	7
 #define MEM_GETUPTIME	8
 #define MEM_GETFARTEXT  9
+#define MEM_GETMAXTASKS 10
+#define MEM_GETJIFFADDR 11
 
 struct mem_usage {
 	unsigned int free_memory;

--- a/tlvc/include/linuxmt/prectimer.h
+++ b/tlvc/include/linuxmt/prectimer.h
@@ -3,7 +3,7 @@
  * 2 Aug 2024 Greg Haerr
  */
 
-#define TIMER_TEST	1	/* =1 to include timer_*() test routines */
+#define TIMER_TEST	0	/* =1 to include timer_*() test routines */
 
 /* all routines return pticks = 0.8381 usecs */
 unsigned int get_time_10ms(void);   /* < 10ms measurements */

--- a/tlvc/include/linuxmt/prectimer.h
+++ b/tlvc/include/linuxmt/prectimer.h
@@ -1,0 +1,17 @@
+/*
+ * Precision timer routines
+ * 2 Aug 2024 Greg Haerr
+ */
+
+#define TIMER_TEST	1	/* =1 to include timer_*() test routines */
+
+/* all routines return pticks = 0.8381 usecs */
+unsigned int get_time_10ms(void);   /* < 10ms measurements */
+unsigned int get_time_50ms(void);   /* < 50ms measurements */
+unsigned long get_time(void);       /* < 1 hr measurements */
+
+/* timer test routines */
+void timer_10ms(void);
+void timer_50ms(void);
+void timer_4s(void);
+void timer_test(void);

--- a/tlvc/init/main.c
+++ b/tlvc/init/main.c
@@ -15,15 +15,17 @@
 #include <linuxmt/debug.h>
 #include <linuxmt/devnum.h>
 #include <linuxmt/heap.h>
+#include <linuxmt/prectimer.h>
 #include <arch/system.h>
 #include <arch/segment.h>
 #include <arch/ports.h>
+#include <arch/io.h>
 
 /*
  *	System variable setups
  */
-#define ENV		1		/* allow environ variables as bootopts*/
-#define DEBUG		0		/* display parsing at boot*/
+#define ENV		1		/* allow environ variables as bootopts */
+#define DEBUG		0		/* display parsing at boot */
 
 #define MAX_INIT_ARGS	8
 #define MAX_INIT_ENVS	8
@@ -44,6 +46,12 @@ struct netif_parms netif_parms[MAX_ETHS] = {
 __u16 kernel_cs, kernel_ds;
 int tracing;
 int nr_mapbufs;
+
+#ifdef CONFIG_PREC_TIMER
+unsigned int hptimer;
+void testloop(unsigned);
+void test_udelay(unsigned);	/* in irqtab.S */
+#endif
 
 #define CHS_DRIVES 2	/* # of drives to config in bootopts */
 #define CHS_ARR_SIZE	CHS_DRIVES * 4
@@ -68,7 +76,7 @@ static char opts;
 static int args = 2;	/* room for argc and av[0] */
 static int envs;
 static int argv_slen;
-/* argv_init doubles as sptr data for sys_execv later*/
+/* argv_init doubles as sptr data for sys_execv later */
 static char *argv_init[80] = { NULL, bininit, NULL };
 #if ENV
 static char *envp_init[MAX_INIT_ENVS+1];
@@ -99,7 +107,7 @@ void start_kernel(void)
     setsp(&task->t_regs.ax);    /* change to idle task stack */
     kernel_init();              /* continue init running on idle task stack */
 
-    /* fork and run procedure init_task() as task #1*/
+    /* fork and run procedure init_task() as task #1 */
     kfork_proc(init_task);
     wake_up_process(&task[1]);
 
@@ -132,14 +140,14 @@ static void INITPROC early_kernel_init(void)
 
 void INITPROC kernel_init(void)
 {
-    /* set us (the current stack) to be idle task #0*/
+    /* set us (the current stack) to be idle task #0 */
     sched_init();
     irq_init();
 
-    /* set console from /bootopts console= or 0=default*/
+    /* set console from /bootopts console= or 0=default */
     set_console(boot_console);
 
-    /* init direct, bios or headless console*/
+    /* init direct, bios or headless console */
     console_init();
 
 #ifdef CONFIG_CHAR_DEV_RS
@@ -147,7 +155,7 @@ void INITPROC kernel_init(void)
 #endif
 
     inode_init();
-    if (buffer_init())	/* also enables xms and unreal mode if configured and possible*/
+    if (buffer_init())	/* also enables xms and unreal mode if configured and possible */
 	panic("No buf mem");
 
     device_init();
@@ -175,6 +183,12 @@ void INITPROC kernel_init(void)
 #endif
 
     kernel_banner(membase, memend, s, e - s);
+#ifdef CONFIG_PREC_TIMER
+    //timer_test();
+    testloop(hptimer ? hptimer:10000);
+    testloop(3000);
+    testloop(500);
+#endif
 }
 
 static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t extra)
@@ -525,6 +539,11 @@ static int INITPROC parse_options(void)
 			parse_parms(2, line+8, netbufs, 10);
 			continue;
 		}
+#ifdef CONFIG_PREC_TIMER
+		if (!strncmp(line,"hptimer=",8)) {
+			hptimer = (unsigned int)simple_strtol(line+8, 10);
+		}
+#endif
 		if (!strncmp(line,"TZ=",3)) {
 			tz_init(line+3);
 			/* fall through and add line to environment */
@@ -622,3 +641,16 @@ static char * INITPROC option(char *s)
 	return s;
 }
 #endif /* CONFIG_BOOTOPTS*/
+
+#ifdef TIMER_TEST
+void testloop(unsigned timer) 
+{
+	unsigned pticks, x = timer;
+
+	get_time_10ms();
+	//while (x--) outb(x, 0x80);
+	test_udelay(timer);
+	pticks = get_time_10ms();
+	printk("hptimer %u: %k (%u)\n", timer, pticks, pticks);
+}
+#endif

--- a/tlvc/kernel/printk.c
+++ b/tlvc/kernel/printk.c
@@ -1,33 +1,34 @@
 /*
- *	This is NOT stunningly portable, but works for pretty dumb non-ANSI
- *	compilers and is tight. Adjust the sizes to taste.
+ *      This is NOT stunningly portable, but works for pretty dumb non-ANSI
+ *      compilers and is tight. Adjust the sizes to taste.
  *
- *	Illegal format strings will break it. Only the following simple
- *	printf() subset is supported:
+ *      Illegal format strings will break it. Only the following simple
+ *      printf() subset is supported:
  *
- *		%%	literal % sign
- *		%c	char
- *		%d/%i	signed decimal
- *		%u	unsigned decimal
- *		%o	octal
- *		%s	string in kernel space
- *		%t	string in user space
- *		%T	string w/specified segment
- *		%x/%X	hexadecimal with lower/upper case letters
- *		%#x/%#X	hexadecimal using 0x alt prefix
- *		%p/%P	pointer - same as %04x/%04X respectively
- *		%D      device name as %#04x
+ *              %%      literal % sign
+ *              %c      char
+ *              %d/%i   signed decimal
+ *              %u      unsigned decimal
+ *              %o      octal
+ *              %s      string in kernel space
+ *              %t      string in user space
+ *              %T      string w/specified segment
+ *              %x/%X   hexadecimal with lower/upper case letters
+ *              %#x/%#X hexadecimal using 0x alt prefix
+ *              %p      pointer - same as %04x
+ *              %D      device name as %04x
+ *              %P      process ID
+ *              %k      pticks (0.838usec intervals auto displayed as us, ms or s)
  *
- *	All except %% can be followed by a width specifier 1 -> 31 only
- *	and the h/l length specifiers also work where appropriate.
+ *      All except %% can be followed by a width specifier 1 -> 31 only
+ *      and the h/l length specifiers also work where appropriate.
  *
- *		Alan Cox.
+ *              Alan Cox.
  *
- *	MTK:	Sep 97 - Misc hacks to shrink generated code
+ *      MTK:    Sep 97 - Misc hacks to shrink generated code
  */
 
 #include <linuxmt/config.h>
-#include <arch/segment.h>
 #include <linuxmt/mm.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/sched.h>
@@ -36,102 +37,141 @@
 #include <linuxmt/ntty.h>
 #include <linuxmt/debug.h>
 #include <linuxmt/signal.h>
+#include <linuxmt/prectimer.h>
+#include <arch/segment.h>
+#include <arch/irq.h>
 #include <stdarg.h>
 
 dev_t dev_console;
 
 #ifdef CONFIG_CONSOLE_SERIAL
-#define DEVCONSOLE  MKDEV(TTY_MAJOR,RS_MINOR_OFFSET)	/* /dev/ttyS0*/
+#define DEVCONSOLE  MKDEV(TTY_MAJOR,RS_MINOR_OFFSET)    /* /dev/ttyS0*/
 #else
-#define DEVCONSOLE  MKDEV(TTY_MAJOR,TTY_MINOR_OFFSET)	/* /dev/tty1*/
+#define DEVCONSOLE  MKDEV(TTY_MAJOR,TTY_MINOR_OFFSET)   /* /dev/tty1*/
 #endif
 static void (*kputc)(dev_t, int) = 0;
 
 
 void set_console(dev_t dev)
 {
-	register struct tty *ttyp;
+    register struct tty *ttyp;
 
-	if (dev == 0)
-		dev = DEVCONSOLE;
-	if ((ttyp = determine_tty(dev))) {
-		kputc = ttyp->ops->conout;
-		dev_console = dev;
-	}
+    if (dev == 0)
+            dev = DEVCONSOLE;
+    if ((ttyp = determine_tty(dev))) {
+            kputc = ttyp->ops->conout;
+            dev_console = dev;
+    }
 }
 
 void kputchar(int ch)
 {
-	if (ch == '\n')
-		kputchar('\r');
-	if (kputc)
-		(*kputc)(dev_console, ch);
-	else early_putchar(ch);
+    if (ch == '\n')
+            kputchar('\r');
+    if (kputc)
+            (*kputc)(dev_console, ch);
+    else early_putchar(ch);
 }
 
 static void kputs(const char *buf)
 {
     while (*buf)
-	kputchar(*buf++);
+        kputchar(*buf++);
 }
 
 /************************************************************************
  *
- *	Output a number
+ *      Output a number
  */
 
-char hex_string[] = "0123456789ABCDEF 0123456789abcdef ";
+static char hex_string[] = "0123456789ABCDEF 0123456789abcdef ";
 
-static void numout(__u32 v, int width, int base, int useSign, int Lower, int Zero, int alt)
+static void numout(unsigned long v, int width, unsigned int base, int type,
+    int Zero, int alt)
 {
-    __u32 dvr;
+    unsigned long dvr;
     int c, vch, i;
+    int useSign, Lower, Decimal;
 
     i = 10;
     dvr = 1000000000L;
     if (base > 10) {
-	i = 8;
-	dvr = 0x10000000L;
+        i = 8;
+        dvr = 0x10000000L;
     }
     if (base < 10) {
-	i = 11;
-	dvr = 0x40000000L;
+        i = 11;
+        dvr = 0x40000000L;
     }
 
-    if (useSign && ((long)v < 0L))
-	v = (-(long)v);
-    else
-	useSign = 0;
+    Decimal = 0;
+#if CONFIG_PREC_TIMER
+    int Msecs = 0;
+    /* display 1/1193182s get_time*() pticks in range 0.838usec through 42.94sec */
+    if (type == 'k') {                  /* format works w/limited ranges only */
+        Decimal = 3;
+        if (v > 51130563UL)             /* = 2^32 / 84 high max range ~42.94s */
+            v = 0;                      /* ... displays 0us */
+        if (v > 5125259UL) {            /* = 2^32 / 838 */
+            v = v * 84UL;
+            Decimal = 2;                /* display xx.xx secs */
+        } else
+            v = v * 838UL;              /* convert to nanosecs w/o 32-bit overflow */
+        if (v > 1000000000UL) {         /* display x.xxx secs */
+            v /= 1000000UL;             /* divide using _udivsi3 for speed */
+        } else if (v > 1000000UL) {
+            v /= 1000UL;                /* display xx.xxx msecs */
+            Msecs = 1;
+        } else {
+            Msecs = 2;                  /* display xx.xxx usecs */
+        }
+    }
+#endif
 
+    useSign = (type == 'd');
+    if (useSign && ((long)v < 0L))
+        v = (-(long)v);
+    else
+        useSign = 0;
+
+    Lower = (type != 'X');
     if (Lower)
-	Lower = 17;
+        Lower = 17;
     vch = 0;
     if (alt && base == 16) {
         kputchar('0');
         kputchar('x');
     }
     do {
-	c = (int)(v / dvr);
-	v %= dvr;
-	dvr /= (unsigned int)base;
-	if (c || (i <= width) || (i < 2)) {
-	    if (i > width)
-		width = (int)i;
-	    if (!Zero && !c && (i > 1))
-		c = 16;
-	    else {
-		Zero = 1;
-		if (useSign) {
-		    useSign = 0;
-		    vch = '-';
-		}
-	    }
-	    if (vch)
-		kputchar(vch);
-	    vch = *(hex_string + Lower + c);
-	}
+        c = (int)(v / dvr);
+        v %= dvr;
+        dvr /= base;
+        if (c || (i <= width) || (i < 2)) {
+            if (i > width)
+                width = i;
+            if (!Zero && !c && (i > 1))
+                c = 16;
+            else {
+                Zero = 1;
+                if (useSign) {
+                    useSign = 0;
+                    vch = '-';
+                }
+            }
+            if (vch)
+                kputchar(vch);
+            vch = *(hex_string + Lower + c);
+            if (type == 'k' && i == Decimal) kputchar('.');
+        }
     } while (--i);
     kputchar(vch);
+#if CONFIG_PREC_TIMER
+    if (type == 'k') {
+        if (Msecs)
+            kputchar(Msecs == 1? 'm': 'u');
+        kputchar('s');
+    }
+#endif
 }
 
 static void vprintk(const char *fmt, va_list p)
@@ -141,87 +181,92 @@ static void vprintk(const char *fmt, va_list p)
     char *str;
 
     while ((c = *fmt++)) {
-	if (c != '%')
-	    kputchar(c);
-	else {
-	    c = *fmt++;
+        if (c != '%')
+            kputchar(c);
+        else {
+            c = *fmt++;
 
-	    if (c == '%') {
-		kputchar(c);
-		continue;
-	    }
+            if (c == '%') {
+                kputchar(c);
+                continue;
+            }
 
-	    ptrfmt = alt = width = 0;
+            ptrfmt = alt = width = 0;
             if (c == '#') {
                 alt = 1;
                 c = *fmt++;
             }
-	    zero = (c == '0');
-	    while ((n = (c - '0')) <= 9) {
-		width = width*10 + n;
-		c = *fmt++;
-	    }
+            zero = (c == '0');
+            while ((n = (c - '0')) <= 9) {
+                width = width*10 + n;
+                c = *fmt++;
+            }
 
-	    if ((c == 'h') || (c == 'l'))
-		c = *fmt++;
-	    n = 16;
-	    switch (c) {
-	    case 'i':
-	    case 'd':
-		c = 'd';
-		n = 18;
-	    case 'o':
-		n -= 2;
-	    case 'u':
-		n -= 6;
-	    case 'X':
-	    case 'x':
+            if ((c == 'h') || (c == 'l'))
+                c = *fmt++;
+            n = 16;
+            switch (c) {
+            case 'i':
+            case 'd':
+                c = 'd';
+                n = 18;
+            case 'o':
+                n -= 2;
+            case 'u':
+            case 'k':
+                n -= 6;
+            case 'X':
+            case 'x':
             hex:
-		if (*(fmt-2) == 'l') {
+                if (*(fmt-2) == 'l') {
                     if (ptrfmt) width = 8;
-		    v = va_arg(p, unsigned long);
-		} else {
-		    if (c == 'd')
-			v = (long)(va_arg(p, int));
-		    else
-			v = (unsigned long)(va_arg(p, unsigned int));
-		}
-		numout(v, width, n, (c == 'd'), (c != 'X'), zero, alt);
-		break;
+                    v = va_arg(p, unsigned long);
+                } else {
+                    if (c == 'd')
+                        v = (long)(va_arg(p, int));
+                    else
+                        v = (unsigned long)(va_arg(p, unsigned int));
+                }
+            out:
+                numout(v, width, n, c, zero, alt);
+                break;
+            case 'P':
+                v = current->pid;
+                c = 'd';
+                n = 10;
+                goto out;
             case 'D':
                 c += 'X' - 'D';
-                alt = 1;
-	    case 'P':
-	    case 'p':
+            case 'p':
                 c += 'X' - 'P';
                 ptrfmt = 1;
                 zero = 1;
                 width = 4;
                 goto hex;
-	    case 'T':
-		n = va_arg(p, unsigned int);
-		goto str;
-	    case 't':
-		n = current->t_regs.ds;
-		goto str;
-	    case 's':
-		n = kernel_ds;
-	    str:
-		str = va_arg(p, char *);
-		while ((zero = peekb((word_t)str++, n))) {
-		    kputchar(zero);
-		    width--;
-		}
-	    case 'c':
-		while (--width >= 0)
-		    kputchar(' ');
-		if (c == 'c')
-		    kputchar(va_arg(p, int));
-		break;
-	    default:
-		kputchar('?');
-	    }
-	}
+            case 'T':
+                n = va_arg(p, unsigned int);
+                goto str;
+            case 't':
+                n = current->t_regs.ds;
+                goto str;
+            case 's':
+                n = kernel_ds;
+            str:
+                str = va_arg(p, char *);
+                while ((zero = peekb((word_t)str++, n))) {
+                    kputchar(zero);
+                    width--;
+                }
+            case 'c':
+                while (--width >= 0)
+                    kputchar(' ');
+                if (c == 'c')
+                    kputchar(va_arg(p, int));
+                break;
+            default:
+                kputchar('?');
+            }
+        }
     }
 }
 
@@ -240,7 +285,7 @@ void halt(void)
     kputs("\nSYSTEM HALTED - Press CTRL-ALT-DEL to reboot:");
 
     while (1)
-	idle_halt();
+        idle_halt();
 }
 
 void panic(const char *error, ...)
@@ -252,28 +297,28 @@ void panic(const char *error, ...)
     vprintk(error, p);
     va_end(p);
 
-#if 0
+#if UNUSED      // FIXME rewrite for ia16 call stack
     int *bp = (int *) &error - 2;
     char *j;
     int i = 0;
     kputs("\napparent call stack:\n"
-	  "Line: Addr    Parameters\n"
-	  "~~~~: ~~~~    ~~~~~~~~~~");
+          "Line: Addr    Parameters\n"
+          "~~~~: ~~~~    ~~~~~~~~~~");
 
     do {
-	printk("\n%4u: %04P =>", i, bp[1]);
-	bp = (int *) bp[0];
-	j = (char *)2;
-	do {
-	    printk(" %04X", bp[(int)j]);
-	} while ((int)(++j) <= 8);
+        printk("\n%4u: %04P =>", i, bp[1]);
+        bp = (int *) bp[0];
+        j = (char *)2;
+        do {
+            printk(" %04X", bp[(int)j]);
+        } while ((int)(++j) <= 8);
     } while (++i < 9);
 #endif
 
     halt();
 }
 
-int dprintk_on = DEBUG_STARTDEF;	/* toggled by debug events*/
+int dprintk_on = DEBUG_STARTDEF;        /* toggled by debug events*/
 #if DEBUG_EVENT
 static void (*debug_cbfuncs[3])();  /* debug event callback function*/
 
@@ -290,7 +335,7 @@ void debug_event(int evnum)
         kill_all(SIGURG);
     }
     if (debug_cbfuncs[evnum])
-	debug_cbfuncs[evnum]();
+        debug_cbfuncs[evnum]();
 }
 
 void dprintk(const char *fmt, ...)
@@ -298,7 +343,7 @@ void dprintk(const char *fmt, ...)
     va_list p;
 
     if (!dprintk_on)
-	return;
+        return;
     va_start(p, fmt);
     vprintk(fmt, p);
     va_end(p);


### PR DESCRIPTION
Add @ghaerr's precision timer code (from ELKS #1953) as discussed in #71 and an expanded `printk` also from @ghaerr, which - among other things - eliminates the need for the `kdevname()` call.

Also, some cleanups.

As to how to use the timer routines, take a look at the examples in the `testloop()` routine at the end of `tlvc/init/main.c`.