### PR TITLE
[net] Fix probe error in ee16 driver

### DIFF
--- a/tlvc/arch/i86/drivers/net/ee16.c
+++ b/tlvc/arch/i86/drivers/net/ee16.c
@@ -371,9 +371,9 @@ static int INITPROC ee16_hw_probe(void)
 			hw_addr[2],hw_addr[1],hw_addr[0]);
 		return -ENODEV;
 	}
-	printk("|%04x%04x%04x|", hw_addr[2], hw_addr[1], hw_addr[0]);
 #endif
-	if (!(hw_addr[0]+hw_addr[1]+hw_addr[2]))
+	//printk("|%04x%04x%04x|", hw_addr[2], hw_addr[1], hw_addr[0]);
+	if (!hw_addr[0] || hw_addr[0] == 0xffff)
 		return -ENODEV;
 	/*
 	 * Calculate the EEPROM checksum.  Carry on anyway if it's bad,

--- a/tlvc/arch/i86/drivers/net/ee16.c
+++ b/tlvc/arch/i86/drivers/net/ee16.c
@@ -373,6 +373,10 @@ static int INITPROC ee16_hw_probe(void)
 	}
 #endif
 	//printk("|%04x%04x%04x|", hw_addr[2], hw_addr[1], hw_addr[0]);
+	/* When there is nothing there, the address returned is typically all zeroes or all ones.
+	 * Thus checking the address is a safe test-for-presence. MAC addresses starting
+	 * with 00:00 are perfectly legal, but extremely unlikely to be an ee16 (not from Intel
+	 * or HP or any other OEM I could find). */
 	if (!hw_addr[0] || hw_addr[0] == 0xffff)
 		return -ENODEV;
 	/*

--- a/tlvccmd/inet/telnet/telnet.c
+++ b/tlvccmd/inet/telnet/telnet.c
@@ -51,7 +51,7 @@ static void keybd(void)
 	int count;
 	char buffer[BUFSIZE];
 
-		count= read (0, buffer, sizeof(buffer));
+		count= read(0, buffer, sizeof(buffer));
 		if (count <= 0) {
 			finish();
 			return;
@@ -73,7 +73,7 @@ static void scrn(void)
 	int count, optsize;
 	char buffer[BUFSIZE];
 
-		count = read (tcp_fd, buffer, sizeof(buffer));
+		count = read(tcp_fd, buffer, sizeof(buffer));
 #if DEBUG
  { where(); fprintf(stderr, "read %d bytes\r\n", count); }
 #endif
@@ -81,8 +81,7 @@ static void scrn(void)
 			printf("\r\nTELNET BUFFER OVERFLOW\r\n");
 			finish();
 		}
-		if (count <= 0)
-		{
+		if (count <= 0) {
 			if (count < 0)
 				perror("Read socket");
 			printf("\r\nConnection closed\r\n");
@@ -95,14 +94,12 @@ static void scrn(void)
 		do
 		{
 			iacptr= memchr (bp, IAC, count);
-			if (!iacptr)
-			{
+			if (!iacptr) {
 				write(1, bp, count);
 				count= 0;
 				return;
 			}
-			if (iacptr && iacptr>bp)
-			{
+			if (iacptr && iacptr>bp) {
 #if DEBUG
  { where(); fprintf(stderr, " ptr-bp= %d\r\n", iacptr-bp); }
 #endif
@@ -111,8 +108,7 @@ static void scrn(void)
 				bp= iacptr;
 				continue;
 			}
-			if (iacptr)
-			{
+			if (iacptr) {
 				optsize= process_opt(bp, count);
 #if DEBUG
  { where(); fprintf(stderr, "process_opt(...)= %d\r\n", optsize); }
@@ -217,7 +213,7 @@ int main(int argc, char **argv)
 
 #ifndef RAWTELNET
 #define next_char(var) \
-	if (offset<count) { (var) = bp[offset++]; } \
+	if (offset < count) { (var) = bp[offset++]; } \
 	else { if (read(tcp_fd, (char *)&(var), 1) != 1) printf("TELNET BAD READ2\n"); exit(1); }
 
 static void do_option (int optsrt)
@@ -230,14 +226,11 @@ static void do_option (int optsrt)
 	case OPT_TERMTYPE:
 		if (WILL_terminal_type)
 			return;
-		if (!WILL_terminal_type_allowed)
-		{
+		if (!WILL_terminal_type_allowed) {
 			reply[0]= IAC;
 			reply[1]= IAC_WONT;
 			reply[2]= optsrt;
-		}
-		else
-		{
+		} else {
 			WILL_terminal_type= TRUE;
 			term_env= getenv("TERM");
 			if (!term_env)
@@ -274,14 +267,11 @@ static void will_option (int optsrt)
 	case OPT_ECHO:
 		if (DO_echo)
 			break;
-		if (!DO_echo_allowed)
-		{
+		if (!DO_echo_allowed) {
 			reply[0]= IAC;
 			reply[1]= IAC_DONT;
 			reply[2]= optsrt;
-		}
-		else
-		{
+		} else {
 			struct termios termios;
 			tcgetattr(0, &termios);
 			termios.c_iflag &= ~(ICRNL|IGNCR|INLCR|IXON|IXOFF);
@@ -295,30 +285,29 @@ static void will_option (int optsrt)
 			reply[1]= IAC_DO;
 			reply[2]= optsrt;
 		}
-		result= writeall(tcp_fd, (char *)reply, 3);
-		if (result<0)
+		result = writeall(tcp_fd, (char *)reply, 3);
+		if (result < 0)
 			perror("write");
 		break;
+
 	case OPT_SUPP_GA:
 		if (DO_suppress_go_ahead)
 			break;
-		if (!DO_suppress_go_ahead_allowed)
-		{
+		if (!DO_suppress_go_ahead_allowed) {
 			reply[0]= IAC;
 			reply[1]= IAC_DONT;
 			reply[2]= optsrt;
-		}
-		else
-		{
+		} else {
 			DO_suppress_go_ahead= TRUE;
 			reply[0]= IAC;
 			reply[1]= IAC_DO;
 			reply[2]= optsrt;
 		}
-		result= writeall(tcp_fd, (char *)reply, 3);
-		if (result<0)
+		result = writeall(tcp_fd, (char *)reply, 3);
+		if (result < 0)
 			perror("write");
 		break;
+
 	default:
 #if DEBUG
  { where(); fprintf(stderr, "got a WILL (%d)\r\n", optsrt); }


### PR DESCRIPTION
The first 'probe for existence' test in the driver I a sanity check of the MAC address read from EEPROM. Previously a 00:00:00:00:00:00 address would signal non.existence. Not good enough for QEMU, which returns ff:ff:ff:ff:ff:ff.

The fix is to test the first word for 00:00 then ff:ff, since both are unallowed in legal MAC addresses.

Also in this PR, some formatting adjustments in the `telnet` source file.