### PR TITLE
[directhd] Fixes and updates

### DIFF
--- a/tlvc/arch/i86/drivers/block/bioshd.c
+++ b/tlvc/arch/i86/drivers/block/bioshd.c
@@ -974,7 +974,7 @@ static int do_bios_readwrite(struct drive_infot *drivep, sector_t start, unsigne
 	return this_pass;
 }
 
-#ifdef CONFIG_TRACK_CACHE_NOTUSED		/* use track-sized sector cache */
+#ifdef CONFIG_TRACK_CACHE		/* use track-sized sector cache */
 
 static sector_t cache_startsector;
 static sector_t cache_endsector;
@@ -1100,7 +1100,7 @@ static void do_bioshd_request(void)
 	    buf = req->rq_buffer;
 	    while (count > 0) {
 		int num_sectors;
-#ifdef CONFIG_TRACK_CACHE_NOTUSED
+#ifdef CONFIG_TRACK_CACHE
 		/* first try reading track cache*/
 		num_sectors = do_cache_read(drivep, start, buf, req->rq_seg, req->rq_cmd);
 		if (!num_sectors)

--- a/tlvc/arch/i86/drivers/block/directhd.c
+++ b/tlvc/arch/i86/drivers/block/directhd.c
@@ -666,9 +666,10 @@ int directhd_open(struct inode *inode, struct file *filp)
 	return -ENXIO;
 
 #if defined(USE_LOCALBUF) || defined(CONFIG_FS_XMS_BUFFER)
-    if (!(localbuf = heap_alloc(BLOCK_SIZE, HEAP_TAG_DRVR))) {
+    if (!open_drv_count)
+	if (!(localbuf = heap_alloc(BLOCK_SIZE, HEAP_TAG_DRVR))) {
 	printk("athd: cannot allocate bounce buffer\n");
-            return -EBUSY;
+            return -ENOMEM;
     }
 #endif
     if (!S_ISCHR(inode->i_mode)) { 	/* Don't count raw opens */

--- a/tlvc/arch/i86/drivers/block/genhd.c
+++ b/tlvc/arch/i86/drivers/block/genhd.c
@@ -24,7 +24,7 @@
 #include <linuxmt/major.h>
 #include <linuxmt/string.h>
 #include <linuxmt/memory.h>
-#include <linuxmt/directhd.h>
+#include <arch/directhd.h>
 
 #include <arch/system.h>
 

--- a/tlvc/arch/i86/drivers/block/idequery.c
+++ b/tlvc/arch/i86/drivers/block/idequery.c
@@ -16,13 +16,11 @@
 
 #define IDE_DRIVE_ID	0xec	/* IDE command to get access to drive data */
 #define IDE_STATUS	7	/* get drive status */
-#define IDE_ERROR	1
 
 #define IDE_DEBUG	0	/* IDE probe debugging */
 
 /* For IDE/ATA access */
 #define STATUS(port)	inb_p(port + IDE_STATUS)
-#define ERROR(port)	inb_p(port + IDE_ERROR)
 #define WAITING(port)	(STATUS(port) & 0x80) == 0x80
 
 #if IDE_DEBUG
@@ -72,48 +70,50 @@ static void INITPROC dump_ide(word_t *buffer, int size) {
 int INITPROC get_ide_data(int drive, struct drive_infot *drive_info) {
 
 	word_t port = io_ports[drive >> 1];
-	int retval = 0, i, timeout = 10000;
+	int retval = -1, i, timeout = 10000;
 
 	word_t *ide_buffer = (word_t *)heap_alloc(512, HEAP_TAG_DRVR);
+	if (!ide_buffer) return -1;
 
-	out_hd(drive, IDE_DRIVE_ID);
-    	while (WAITING(port) && timeout--);
+	while (1) {
+            out_hd(drive, IDE_DRIVE_ID);
+	    while (WAITING(port) && timeout--);
+	    if (!timeout) break;
 
-	i = STATUS(port);
-	if (!timeout || !i || (i & 1) == 1) {
+	    i = STATUS(port);
+	    if (!i || (i & 1) == 1) {
 		/* Error - drive not found or non-IDE.
-		 * NOTE: If drive # is 2 (i.e. 2nd controller), there may be a drive 3
-		 * (slave) even if drive 2 (the master) is missing. 
+		 * NOTE: If drive # is 2 (i.e. 2nd controller) is missing,
+		 * there may be a 3rd (slave) drive.
 		 */
 		ide_debug("hd%c: drive at port 0x%x not found\n", 'a'+drive, port);
-		return -1;
-	}
+		break;
+	    }
+	    insw(port, ide_buffer, 512/2);	/* read - word size */
+	    /*
+	     * Sanity check: Head, cyl and sector values must be other than
+	     * 0 and buffer has to contain valid data (first entry in buffer
+	     * must be != 0).
+	     *
+	     * Using 'actual' CHS values from the ID data (words 54, 55 & 56), 
+	     * considered more reliable than 'default' CHS values (words 1, 3 & 6).
+	     * The difference is that some devices have selectable translation modes,
+	     * which is reflected in 'actual' values. ELKS does not use translation 
+	     * modes, so they are always the same.
+	     * Check for large # of cyls to detect (and skip) ATAPI CDROMs. 
+	     * 							HS sep2020
+	     */
 
-	insw(port, ide_buffer, 512/2);	/* read - word size */
-
-	/*
-	 * Sanity check: Head, cyl and sector values must be other than
-	 * 0 and buffer has to contain valid data (first entry in buffer
-	 * must be != 0).
-	 *
-	 * Using 'actual' CHS values from the ID data (words 54, 55 & 56), 
-	 * considered more reliable than 'default' CHS values (words 1, 3 & 6).
-	 * The difference is that some devices have selectable translation modes,
-	 * which is reflected in 'actual' values. ELKS does not use translation 
-	 * modes, so they are always the same.
-	 * Check for large # of cyls to detect (and skip) ATAPI CDROMs. 
-	 * 							HS sep2020
-	 */
-
-	if ((ide_buffer[1] < 34096) && (*ide_buffer != 0)	/* this is the real sanity check */
+	    if ((ide_buffer[1] < 34096) && (*ide_buffer != 0)	/* this is the real sanity check */
 	    	&& (ide_buffer[1] != 0) && (ide_buffer[3] != 0) && (ide_buffer[3] < 256)
 	    	&& (ide_buffer[6] != 0) && (ide_buffer[6] < 64)) {
 #if IDE_DEBUG
 	    	ide_buffer[20] = 0; /* String termination */
-	    	printk("IDE default CHS: %d/%d/%d serial %s\n", ide_buffer[1], ide_buffer[3],
+	    	printk(" IDE default CHS: %d/%d/%d serial %s\n", ide_buffer[1], ide_buffer[3],
 			ide_buffer[6], &ide_buffer[10]);
 #endif
 		if (ide_buffer[53]&1) {	/* if set, the 'actual' data are valid */
+					/* Old IDE drives don't support 'actual data' */
 	    	    drive_info->cylinders = ide_buffer[54];
 	    	    drive_info->heads = ide_buffer[55];
 	    	    drive_info->sectors = ide_buffer[56];
@@ -123,13 +123,16 @@ int INITPROC get_ide_data(int drive, struct drive_infot *drive_info) {
 	    	    drive_info->sectors = ide_buffer[6];
 		}
 		ide_debug("hd%c: %d heads, %d cylinders, %d sectors\n", 'a'+drive,
-			drive_info->heads, drive_info->cylinders, drive_info->sectors);
-	} else {
+		    drive_info->heads, drive_info->cylinders, drive_info->sectors);
+		retval = 0;
+	    } else {
 		retval = -2;
 		ide_debug("hd%c: Error in IDE device data.\n", 'a'+drive);
+	    }
+	    break;
 	}
 #if IDE_DEBUG
-	dump_ide(ide_buffer, 128);
+	if (retval != -1) dump_ide(ide_buffer, 128);
 #endif
 	heap_free(ide_buffer);
 

--- a/tlvc/arch/i86/drivers/block/idequery.c
+++ b/tlvc/arch/i86/drivers/block/idequery.c
@@ -74,7 +74,7 @@ int INITPROC get_ide_data(int drive, struct drive_infot *drive_info) {
 	word_t port = io_ports[drive >> 1];
 	int retval = 0, i, timeout = 10000;
 
-	word_t *ide_buffer = (word_t *)heap_alloc(512, 0);
+	word_t *ide_buffer = (word_t *)heap_alloc(512, HEAP_TAG_DRVR);
 
 	out_hd(drive, IDE_DRIVE_ID);
     	while (WAITING(port) && timeout--);

--- a/tlvc/arch/i86/drivers/char/rfd.c
+++ b/tlvc/arch/i86/drivers/char/rfd.c
@@ -39,7 +39,7 @@ size_t block_wr(struct inode *, struct file *, char *, size_t);
 size_t block_rd(struct inode *, struct file *, char *, size_t);
 
 /*
- * Let the blocK device open function do whatever is required - it will
+ * Let the block device open function do whatever is required - it will
  * recognize char device access and act accordingly.
  * There is (currently) no keeping track of opens/closes when doing raw access.
  */

--- a/tlvc/include/arch/directhd.h
+++ b/tlvc/include/arch/directhd.h
@@ -70,4 +70,20 @@
 /* other definitions */
 #define MAX_ATA_DRIVES 4		/* 2 per i/o channel and 2 i/o channels */
 
+struct hd_geometry {
+    unsigned char heads;
+    unsigned char sectors;
+    unsigned short cylinders;
+    unsigned long start;
+};
+
+/* hd/ide ctl's that pass (arg) ptrs to user space are numbered 0x030n/0x031n */
+#define HDIO_GETGEO             0x0301  /* get device geometry */
+#define HDIO_GET_UNMASKINTR     0x0302  /* get current unmask setting */
+#define HDIO_GET_NOWERR         0x030a  /* get ignore-write-error flag */
+
+/* hd/ide ctl's that pass (arg) non-ptr values are numbered 0x032n/0x033n */
+#define HDIO_SET_UNMASKINTR     0x0322  /* permit other irqs during I/O */
+#define HDIO_SET_NOWERR         0x0325  /* change ignore-write-error flag */
+
 #endif


### PR DESCRIPTION
A number of updates to the `directhd` driver:
- probe enhancement
- cleaned, consistent and fewer boot messages
- improved XTIDE support
- moved driver specific header file from `linuxmt` to `arch`
- changed bounce buffer allocation from static to heap
- removed zero initializers from static variables 