### PR TITLE
[kernel] Add 'precision' delay for drivers

### DIFF
--- a/tlvc/arch/i86/lib/Makefile
+++ b/tlvc/arch/i86/lib/Makefile
@@ -42,7 +42,7 @@ SRCS1 = \
 ifeq ($(CONFIG_ARCH_PC98), y)
 SRCS1 += bios1B.S bios-xms-pc98.S
 else
-SRCS1 += bios13.S bios15.S unreal.S
+SRCS1 += bios13.S bios15.S unreal.S udelay.S
 endif
 
 OBJS1 = $(SRCS1:.S=.o)
@@ -60,7 +60,7 @@ SRCS3 = \
 	# end of list
 
 ifeq ($(CONFIG_ARCH_IBMPC), y)
-SRCS3 += prectimer.c
+SRCS3 += prectimer.c delay.c
 endif
 
 OBJS3 = $(SRCS3:.c=.o)

--- a/tlvc/arch/i86/lib/delay.c
+++ b/tlvc/arch/i86/lib/delay.c
@@ -1,0 +1,163 @@
+#include <linuxmt/config.h>
+#include <linuxmt/prectimer.h>
+#include <arch/irq.h>
+
+#ifdef CONFIG_CALIBRATE_DELAY
+unsigned sys_dly_index; /* indicating the speed of the system - for delay loops */
+unsigned sys_dly_base;
+
+void u10delay(unsigned);
+void printk(const char *, ...);
+
+#define TEST_DELAY 0
+/* Create calibration constants for a system independent delay loop.
+ * NOTE: The calibration does not work with BIOS IO!
+ * The delay function (arch/i86/lib/udelay.S) has 3 parts to be accounted for
+ * when scaling:
+ * 1) the call (entry/exit), which should be insignificant but isn't on slow
+ *    systems
+ * 2) the outer loop, which becomes significant for short delays on slow systems.
+ *    the outer loop may take 30ms (8MHz 8088) to 55ms (4.77MHz 8088) and thus
+ *    becomes an important damage-limiter for short loops on such systems. 
+ * 3) the inner loop, which is timed separately and when run 4 times and
+ *    averaged, becomes a pretty good indication of the speed of the system (keep in
+ *    mind that the # of clock cycles required for this simple loop is varying
+ *    wildly between systems). Also, on a 386 (and later) instruction caching speeds
+ *    up this loop significantly.
+ *
+ * Important notes:
+ * - On fast QEMU systems, the collected timings vary wildly and are useless
+ *   for any calibration, so we set some basic numbers manually and skip the 
+ *   calculations. Delays don't matter on QEMU anyway. If QEMU is run with the
+ *   -singlestep option, the delay values are 'reasonable'.
+ *
+ * The items used in the calibration are
+ * adj - the time consumed by the precision timer routine, to be subtracted from
+ *       all measurements
+ * d0 - the delay routine call time, just call and return, no loops.
+ * d1 - call time + one outer loop, no inner loop
+ * d2 - the difference between d1 and d0, the cost of the outer loop
+ * l  - the loop time for the inner loop, which used to be run 1000 times, now 125
+ *	which makes the numbmers more predictable (less susceptible to system
+ *	interrupt disturbance).
+ * p  - the scale, 1 ptick, 0.838 us
+ * The chosen unit of measure is 10us, too small for the slowest systems, too big for 
+ * the fast ones, IOW a reasonable compromise.
+ * In order to avoid MULs and DIVs, we calculate (in sys_dly_ind) the # of
+ * inner loops to take, including one outer loop, to spend 10us.
+ * On very slow systems, the 'cost' of the call itself becomes significant, and 
+ * must be deducted from the loop count. This is the purpose of the sys_dly_base.
+ * For the XT@4.77MHz even this is useless as the call to the delay routine 
+ * takes close to 50us and the outer loop almost 10us. In this case the closest
+ * possible approximation is to set the _base to 5 and the index to 0.
+ * turn in the outer loop may exceed 70 pticks, or 59us.
+ *
+ * Again, in order to avoid conversions (MUL/DIV) at all cost, we use pticks
+ * all the way and approximate 10us = 12 pticks.
+ *
+ * The inner loop formula then becomes
+ * X = (12p - d2)/l where X is the number of loops per 10us. 
+ * Obviously, if d2 becomes larger than 12p, which happens on a PC/XT, this won't
+ * work and the speed index is set to 0 - see comments in the code.
+ */
+
+void calibrate_delay(void)
+{
+	unsigned d0, d1, adj, i, l;
+	unsigned long temp = 0;
+
+	//sys_dly_base = 1;
+	//sys_dly_index = 0;
+
+	/* find processing time for the get_ptime tool, average over 4 runs */
+	i = 0;
+	get_ptime();
+	for (d0 = 0; d0 < 4; d0++) {
+		get_ptime();
+		//asm volatile ("nop");
+		i += (unsigned)get_ptime();
+	}
+	adj = i >> 2;
+
+	/* time the inner loop. This - compensated for (d1-d0) - 
+	 * becomes the machine speed index. 
+	 * l = # of pticks to loop 125 times. longer loops
+	 * get disturbed by interrupts.
+	 */
+	d0 = d1 = l = 0;
+	for (i = 0; i < 4; i++) {
+		get_ptime();
+		clr_irq();
+		asm volatile ("mov $125,%cx");
+		//asm volatile ("1: nop; loop 1b");
+		asm volatile ("1:sub $1,%cx;ja 1b");
+		set_irq();
+		l += (unsigned)get_ptime();
+		//get_ptime();		/* time the outer loop */
+		u10delay(0);
+		d0 += (unsigned)get_ptime();
+		u10delay(2);
+		d1 += (unsigned)get_ptime();
+	}
+	l >>= 2;
+	d0 >>= 2;
+	d1 >>= 2;
+	printk("adj %u, l=%u (%k)", adj, l, l);
+	if (l <= adj) {	/* If running QEMU w/HW accel, results are nonsensical */
+		adj = l>>1;
+
+	}
+	l -= adj;
+	d0 -= adj;
+	d1 -= adj;
+	printk(" d0=%u (%k)", d0, d0);
+	printk(" d1=%u (%k)\n", d1, d1);
+	if (d1 < d0) d1 = d0;	/* for QEMU */
+	if (d0 >= 12) {		/* on systems running at <10MHz XT, the call itself 
+				 * takes more than 10us
+				 * and the best we can do is to set the index to
+				 * 0 and increase the base somewhat. Rough
+				 * approximation anyway */
+		sys_dly_index = 0;
+		sys_dly_base = d0/10;
+	} else {
+		d1 -= d0; 	/* d1 is (net) outer loop cost */
+		sys_dly_index = (unsigned)((12UL-d1)*125/(unsigned long)l);
+		//sys_dly_index = (unsigned)((12UL-d1)*1000UL/(unsigned long)l);
+					/* 12 is # of pticks per 10us */
+					/* subtract ptick cost of 1 outer loop */
+		sys_dly_base = d0*838/10000;	/* tare, the 'weight' of u10delay()
+					   * sans the inner loop. Notice the 
+					   * extra 0 to scale to 10us */
+		printk("%u, %u, %u, %u, ", l, adj, d0, d1);
+	}
+
+	printk("Delay calibration index: %d, skew: %d\n", sys_dly_index, sys_dly_base);
+
+#if TEST_DELAY
+	/* verify */
+	d1 = 5;				/* start off with 5*10us */
+	for (d0 = 0; d0 < 4; d0++) {
+		int diff, d;
+		unsigned t;
+
+		get_ptime();
+		u10delay(d1);
+		temp = get_ptime();
+		if (temp >= adj) 
+			temp -= adj;	/* QEMU weirdness */
+		else
+			temp -= 2;
+		printk("temp=%lu; ", temp);
+		t = (temp*838UL)/1000UL;	/* convert to microseconds */
+		d1 *= 10;	/* scale to 10us - and increment for next loop */
+		diff = t - d1;	/* diff in us */
+		printk("\n%lk (%u) diff %d, d1=%ld;", temp, t, diff, (long)d1);
+		d = -diff * 100/d1;
+		//if (d < 0) d = -d;
+		printk("\n%lk (%u) diff %d (%d%%);", temp, t, diff, d);
+	}
+#endif
+	printk("\n");
+}
+#endif

--- a/tlvc/arch/i86/lib/prectimer.c
+++ b/tlvc/arch/i86/lib/prectimer.c
@@ -55,10 +55,10 @@ unsigned long get_ptime(void)
     /* 16-bit subtract handles low word wrap automatically */
     jdiff = (unsigned)jiffies - (unsigned)lastjiffies;
     lastjiffies = (unsigned)jiffies; /* 16 bit save works for ~10.9 mins */
-    restore_flags(flags);
 
     lo = inb(TIMER_DATA_PORT);
     hi = inb(TIMER_DATA_PORT) << 8;
+    restore_flags(flags);
     count = lo | hi;
     pticks = lastcount - count;
     if ((int)pticks < 0)            /* wrapped */

--- a/tlvc/arch/i86/lib/udelay.S
+++ b/tlvc/arch/i86/lib/udelay.S
@@ -1,0 +1,45 @@
+//
+// (void) u10delay(int wait) - calibrated delay loop, returns in 'wait' * 10 microseconds
+//		which is the best resolution possible on a PC/XT.
+//		The inner loop and the cost of the call itself are calibrated
+//		at boot time and stored in the globals sys_dly_index and
+//		sys_dly_base. See init/main.c for details about the calibration.
+//
+//		Delays are never exact. Short delays suffer from approximation in 
+//		calibration, in particular on slow (XT) machines. Long delays
+//		will be disturbed by clock interrupts and other interrupts.
+//		In general, delays tend to be longer on slow machines, shorter on
+//		fast iron, just abnout right on 286 systems.
+//
+// hs [@mellvik] August 2024
+//
+        .arch   i8086, nojumps
+        .code16
+        .text
+
+	.global u10delay
+
+u10delay:
+	//push	%bx
+	mov	%sp,%bx
+	mov	2(%bx),%ax
+	mov	sys_dly_index,%bx	// must be positive or zero
+	//push	%cx
+	sub	sys_dly_base,%ax // correct for 'tare', the cost of the call
+				// itself
+	jbe	1f
+3:	sub	$1,%ax		// sub works if ax=0, dec does not
+	jbe	1f
+	mov	%bx,%cx
+2:
+//	nop
+//	loop	2b		// fails if CX is zero
+	sub	$1,%cx		// now starting on zero is OK
+	ja	2b
+	jmp	3b
+1:	//pop	%bx
+	ret
+
+	.data
+	.extern sys_dly_index
+	.extern sys_dly_base


### PR DESCRIPTION
The `u10delay()`  delay routine loops for close to the given number of 10 microseconds regardless of platform. The accuracy is good across machines, but not great, established through thorough testing on 8088, V20, 286 and 386 systems plus QEMU. The latter doesn't need any accuracy in any delay so wide inaccuracies are acceptable. That said, id the `-singlestep` option is used, the results are reasonable even on QEMU.

The complicated part part of this addition is the calibration routine, now moved to its own file instead of residing in `init/main.c` where it has been hiding during development.

The calibration routine is called from `init/main.c` during system initialization. It may be enabled/disabled via `menuconfig`. No driver is using it yet. The source code has detailed explanations of the calibration 'mechanism', which in effect establishes a performance metric for the system which may possibly be used in other contexts too.

Also in this PR a few fixes and changes in `init/main.c` - including a temporary mechanism to set the size of the floppy sector cache - implemented in an upcoming PR for the `directfd` driver.