### PR TITLE
[kernel, directfd] Redesigned sector buffer for the directfd driver

### DIFF
--- a/tlvc/arch/i86/drivers/block/config.in
+++ b/tlvc/arch/i86/drivers/block/config.in
@@ -3,68 +3,40 @@
 #
 mainmenu_option next_comment
     comment 'Block device drivers'
+    comment 'Choose either BIOS devices or Direct devices.'
+    Comment 'To choose one, deselect the other!'
 
-	bool 'BIOS block device support'	CONFIG_BLK_DEV_BIOS	n
-	if [ "$CONFIG_BLK_DEV_BIOS" == "y" ]; then
-	    bool '  BIOS hard drive support'	CONFIG_BLK_DEV_BHD	y
-	    bool '  IDE hard drive CHS probe'	CONFIG_IDE_PROBE	y
-	    bool '  BIOS floppy drive support'	CONFIG_BLK_DEV_BFD	y
-	    if [ "$CONFIG_BLK_DEV_BFD" == "y" ]; then
-		bool '    Pre-set floppy types'	CONFIG_BLK_DEV_BFD_HARD n
-		if [ "$CONFIG_BLK_DEV_BFD_HARD" == "y" ]; then
-		    comment 'Currently ignored and assumed to be 2880k for both drives.'
-		    choice '      Primary floppy drive type'	  \
-			   "None	CONFIG_BLK_DEV_BFD0_NONE  \
-			    360k	CONFIG_BLK_DEV_BFD0_360   \
-			    720k	CONFIG_BLK_DEV_BFD0_720   \
-			    1200k	CONFIG_BLK_DEV_BFD0_1200  \
-			    1440k	CONFIG_BLK_DEV_BFD0_1440  \
-			    2880k	CONFIG_BLK_DEV_BFD0_2880"	2880K
-		    choice '      Secondary floppy drive type'	  \
-			   "None	CONFIG_BLK_DEV_BFD1_NONE  \
-			    360k	CONFIG_BLK_DEV_BFD1_360   \
-			    720k	CONFIG_BLK_DEV_BFD1_720   \
-			    1200k	CONFIG_BLK_DEV_BFD1_1200  \
-			    1440k	CONFIG_BLK_DEV_BFD1_1440  \
-			    2880k	CONFIG_BLK_DEV_BFD1_2880"	None
-		fi
-	    else
-	    	bool '  DIRECT floppy disk support'	CONFIG_BLK_DEV_FD	n
-	    fi
-	else
-	    comment 'Direct/native block devices, choose one HD type'
-	    bool '  DIRECT floppy disk support'	CONFIG_BLK_DEV_FD	y
-	    if [ "$CONFIG_HW_PCXT" == "y" ]; then
-	    	bool '  DIRECT IDE hardisk support'	CONFIG_BLK_DEV_HD	n
-		if [ "$CONFIG_BLK_DEV_HD" == "y" ]; then
-		    bool '  XT/CF-lite is primary HD @0x300' CONFIG_HW_CFIDE0	n
-		else
-	    	    bool '  DIRECT XT/MFM disk support'	CONFIG_BLK_DEV_XD	n
-		fi
-		#if [ "$CONFIG_HW_CFIDE0" == "y" ]; then
-		#	define_bool CONFIG_HW_BLK_XD n
-		#fi
-		#if [ "$CONFIG_BLK_DEV_XD" == "y" ]; then
-		#	define_bool CONFIG_HW_BLK_CFIDE0 n
-		#fi
-	    else
-	    	bool '  DIRECT IDE hardisk support'	CONFIG_BLK_DEV_HD	y
+    bool 'DIRECT drivers' CONFIG_BLK_DEV_DIRECT y
+    if [ "$CONFIG_BLK_DEV_DIRECT" == "y" ]; then
+	define_bool CONFIG_BLK_DEV_BIOS n
+	define_bool CONFIG_BLK_DEV_BFD n
+	define_bool CONFIG_BLK_DEV_BHD n
+	bool '  DIRECT floppy support'		CONFIG_BLK_DEV_FD	y
+	bool '  DIRECT IDE hardisk support'	CONFIG_BLK_DEV_HD	y
+	if [ "$CONFIG_HW_PCXT" == "y" ]; then
+	    if [ "$CONFIG_BLK_DEV_HD" == "y" ]; then
+		bool '  XT/CF-lite is primary HD @0x300' CONFIG_HW_CFIDE0	n
 	    fi
 	    if [ "$CONFIG_HW_CFIDE0" == "y" ]; then
 		define_bool CONFIG_BLK_DEV_HD y
 	    fi
+	    bool '  DIRECT XT/MFM disk support'	CONFIG_BLK_DEV_XD	n
 	fi
-	if [ "$CONFIG_BLK_DEV_HD" == "y" -a "$CONFIG_BLK_DEV_XD" == "y" ]; then
-	   define_bool CONFIG_BLK_HD n
-	fi
+    fi
+    bool 'BIOS based drivers' CONFIG_BLK_DEV_BIOS n
+    if [ "$CONFIG_BLK_DEV_BIOS" == "y" ]; then
+	bool '  BIOS floppy support'	CONFIG_BLK_DEV_BFD	y
+	bool '  BIOS harddisk support'	CONFIG_BLK_DEV_BHD	n
+	bool '  IDE harddisk CHS probe'	CONFIG_IDE_PROBE	n
+    fi
+    if [ "$CONFIG_BLK_DEV_FD" == "y" -o "$CONFIG_BLK_DEV_XD" == "y" -o "$CONFIG_ETH_LANCE" == "y" ]; then
+	define_bool CONFIG_DMA y
+    else
+	define_bool CONFIG_DMA n
+    fi
+    bool 'Floppy drive track cache'	CONFIG_TRACK_CACHE	y
 
-	if [ "$CONFIG_BLK_DEV_FD" == "y" -o "$CONFIG_BLK_DEV_XD" == "y" ]; then
-	    define_bool CONFIG_DMA y
-	else
-	    define_bool CONFIG_DMA n
-	fi
-
-	comment 'Additional block devices'
+    comment 'Additional block devices'
 	bool 'RAM disk support'			CONFIG_BLK_DEV_RAM	y
 	if [ "$CONFIG_BLK_DEV_RAM" == "y" ]; then
 		hex 'Preload RAM disk segment address' CONFIG_RAMDISK_SEGMENT 0

--- a/tlvc/arch/i86/drivers/block/config.in
+++ b/tlvc/arch/i86/drivers/block/config.in
@@ -34,11 +34,8 @@ mainmenu_option next_comment
     else
 	define_bool CONFIG_DMA n
     fi
-    bool 'Floppy drive sector cache'	CONFIG_TRACK_CACHE	y
-    if [ "$CONFIG_TRACK_CACHE" == "y" ]; then
-	int 'Size of sector cache (1-9)(KB)' \
-	    CONFIG_TRACK_CACHE_SZ 5
-    fi
+    int 'Floppy drive sector cache (1-9)(KB), 0 to disable' \
+	    CONFIG_FLOPPY_CACHE 5
 
     comment 'Additional block devices'
 	bool 'RAM disk support'			CONFIG_BLK_DEV_RAM	y

--- a/tlvc/arch/i86/drivers/block/config.in
+++ b/tlvc/arch/i86/drivers/block/config.in
@@ -34,7 +34,11 @@ mainmenu_option next_comment
     else
 	define_bool CONFIG_DMA n
     fi
-    bool 'Floppy drive track cache'	CONFIG_TRACK_CACHE	y
+    bool 'Floppy drive sector cache'	CONFIG_TRACK_CACHE	y
+    if [ "$CONFIG_TRACK_CACHE" == "y" ]; then
+	int 'Size of sector cache (1-9)(KB)' \
+	    CONFIG_TRACK_CACHE_SZ 5
+    fi
 
     comment 'Additional block devices'
 	bool 'RAM disk support'			CONFIG_BLK_DEV_RAM	y

--- a/tlvc/arch/i86/drivers/block/directfd.c
+++ b/tlvc/arch/i86/drivers/block/directfd.c
@@ -119,13 +119,13 @@ void (*DEVICE_INTR) () = NULL;
 
 /* Driver configuration */
 
-#define dfd_debug	/* lots of debug output */
+//#define dfd_debug	/* lots of debug output */
 //#define INCLUDE_FD_FORMATTING	/* Formatting code untested, don't waste the space */
 
 #ifndef CONFIG_HW_PCXT	/* some options are not meaningful on pre-AT systems */
 #define ENABLE_FDC_82077	/* Enable 82077 extras if present, REQUIRED to use 360k media */
 			/* in 1.2M drive on QEMU!! */
-#define USE_DIR_REG	/* Use the DIR register if available for media change detection */
+//#define USE_DIR_REG	/* Use the DIR register if available for media change detection */
 			/* Default is on, off is experimental */
 			/* Use off for PC/XT/8086/8088 8bit ISA systems (save RAM), 
 			 * on otherwise - to let the driver make wise (!) choices -
@@ -153,20 +153,6 @@ void (*DEVICE_INTR) () = NULL;
 #endif
 
 
-static int initial_reset_flag;
-static int need_configure = 1;	/* for 82077 */
-static int reset;		/* something went wrong, reset FDC, start over */
-static int recalibrate;		/* less dramatic than reset, like changed drive
-				 * parameters or seek errors. Will (eventually)
-				 * trigger a call to recalibrate_floppy() */
-static int recover;		/* signal that we're recovering from a hang,
-				 * awakened by the watchdog timer */
-static int seek;		/* set if the current operation needs a track
-				 * change (seek) */
-static int nr_sectors;		/* # of sectors to r/w, 2 if block IO */
-static unsigned char raw;	/* set if raw/char IO	*/
-static unsigned char use_bounce;/* set if this transaction needs bounce buffer */
-
 static unsigned char current_DOR = 0x0C; /* default: DMA on, RESET off */
 
 static unsigned char running = 0; /* keep track of motors already running */
@@ -186,12 +172,6 @@ static unsigned char running = 0; /* keep track of motors already running */
  * current disk size is unknown.
  */
 #define MAX_DISK_SIZE 1440	/* change to add support for 2880K */
-
-/*
- * Maximum number of sectors in a track cache. Track caching is disabled
- * if tracks are bigger.
- */
-#define MAX_BUFFER_SECTORS 18
 
 /*
  * All floppy drives have 2 heads!
@@ -354,17 +334,33 @@ static void recal_interrupt(void);
 static void floppy_shutdown(void);
 static void motor_off_callback(int);
 
+#define NO_TRACK 255
+
 /*
  * These are global variables, as that's the easiest way to give
  * information to interrupts. They are the data used for the current
  * request.
  */
-#define NO_TRACK 255
 
-static int read_track;		/* set to read entire track 
-				 * (or cylinder, cache space allowing) */
-static int cache_track = -1;
+static int initial_reset_flag;
+static int need_configure = 1;	/* for 82077 */
+static int reset;		/* something went wrong, reset FDC, start over */
+static int recalibrate;		/* less dramatic than reset, like changed drive
+				 * parameters or seek errors. Will (eventually)
+				 * trigger a call to recalibrate_floppy() */
+static int recover;		/* signal that we're recovering from a hang,
+				 * awakened by the watchdog timer */
+static int seek;		/* set if the current operation needs a cylinder
+				 * change (seek) */
+static int nr_sectors;		/* # of sectors to r/w, 2 if block IO */
+static unsigned char raw;	/* set if raw/char IO	*/
+static unsigned char use_bounce;/* this transaction must use the  bounce buffer */
+static unsigned char use_cache;	
 static int cache_drive = -1;
+static int cache_start;		/* first cached sector */
+static int cache_len;		/* valid length of cache in sectors */
+static int cache_size;		/* # of sectors - min=2, max=DMASEGSZ>>9 */
+static unsigned int cache_hits;	/* For stats */
 static int cur_spec1 = -1;	/* HUT | SRT */
 static int cur_rate = -1;	/* datarate */
 static struct floppy_struct *floppy = floppy_type;
@@ -681,15 +677,24 @@ static void setup_DMA(void)
     count = nr_sectors<<9;
     if (use_xms || (physaddr + (unsigned int)count) < physaddr) { /* 64k phys wrap ? */
 	use_bounce++;
-	if (raw) {	/* raw access: must use track buffer as bounce buffer, split
-			 * transfer if too big */
-	    if (nr_sectors > MAX_BUFFER_SECTORS) {
-		nr_sectors = MAX_BUFFER_SECTORS;
-		count = nr_sectors<<9;
+	if (raw) {	/* The application buffer spans a 64k boundary, split it into
+			 * 2 or three parts, using the first k of the sector cache
+			 * as a bounce buffer */
+	    int sec_cnt = (0xffff - physaddr) >> 9;
+	    if (sec_cnt <= 1)	/* the single block with wrap problem */
+		nr_sectors = BLOCK_SIZE >> 9;	
+	    else {		/* get the sectors before the wrap */
+		nr_sectors = sec_cnt-1;
+	        dma_addr = _MK_LINADDR(req->rq_seg, req->rq_buffer);
+		use_bounce--;
 	    }
+	    count = nr_sectors<<9;
 	}
     } else
-	if (!read_track) dma_addr = _MK_LINADDR(req->rq_seg, req->rq_buffer);
+#ifdef CONFIG_TRACK_CACHE
+	if (!use_cache) 
+#endif
+	    dma_addr = _MK_LINADDR(req->rq_seg, req->rq_buffer);
 
     DEBUG("setupDMA:");
     DEBUG("-%x:%x-", req->rq_seg, req->rq_buffer);
@@ -697,18 +702,19 @@ static void setup_DMA(void)
 #ifdef INCLUDE_FD_FORMATTING
     if (command == FD_FORMAT) {
 	dma_addr = _MK_LINADDR(DMASEG, 0);
-	count = floppy->sect * 4;	/* formatting data, 4 bytes per sector */
+	count = floppy->sect << 2;	/* formatting data, 4 bytes per sector */
     }
 #endif
-    if (read_track) {	/* mark track cache bad, in case all this fails.. */
-	cache_drive = cache_track = -1;
-	if (floppy->sect <= MAX_BUFFER_SECTORS) {
-		count = floppy->sect << 9;	/* sects/trk (one side) times 512 */
-		if (floppy->sect & 1 && !head)
-	    		count += 512; /* add one if head=0 && sector count is odd */
-	}
-    } else if (use_bounce && command == FD_WRITE)
-	    xms_fmemcpyw(0, DMASEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
+#ifdef CONFIG_TRACK_CACHE
+    if (use_cache) {
+	cache_drive = -1;	/* mark track cache bad, in case all this fails.. */
+	cache_len = (floppy->sect<<1) - (sector + head*floppy->sect);
+	if (cache_len > cache_size) cache_len = cache_size;
+	count = cache_len << 9;
+    } else
+#endif
+    if (use_bounce && command == FD_WRITE)
+	xms_fmemcpyw(0, DMASEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
 
     DEBUG("%d/%lx/%x;", count, dma_addr, physaddr);
     clr_irq();
@@ -896,13 +902,10 @@ static void tell_sector(int nr)
  */
 static void rw_interrupt(void)
 {
-    unsigned char *buffer_area;
     int nr;
     char bad;
 
     nr = result();
-    /* NOTE: If read_track is active and sector count is uneven, ST0 will
-     * always show HD1 as selected at this point. */
     DEBUG("rwI%x|%x|%x-",ST0,ST1,ST2);
 
     /* check IC to find cause of interrupt */
@@ -985,14 +988,14 @@ static void rw_interrupt(void)
 	xms_fmemcpyw(req->rq_buffer, req->rq_seg, NULL, DMASEG, nr_sectors << (9-1));
 									/* words ^ */
     } else {
-	if (read_track) {
+	if (use_cache) {
+	    int start = CURRENT->rq_blocknr;
+
 	    cache_drive = current_drive;
-	    buffer_area = (unsigned char *)(sector << 9);
-	    cache_track = (seek_track << 1) + head; /* track cache */
-	    DEBUG("rd:%04x:%04x->%04lx:%04x;", DMASEG, buffer_area,
+	    cache_start = start;
+	    DEBUG("rd:%04x:0->%04lx:%04x;", DMASEG,
 		(unsigned long)req->rq_seg, req->rq_buffer);
-	    xms_fmemcpyw(req->rq_buffer, req->rq_seg, buffer_area, DMASEG, BLOCK_SIZE/2);
-	} else if (command == FD_READ && (req->rq_seg >> 16)) {	/* XMS buffer */
+	//} else if (command == FD_READ && (req->rq_seg >> 16)) {	/* XMS buffer */
 	    xms_fmemcpyw(req->rq_buffer, req->rq_seg, 0, DMASEG, BLOCK_SIZE/2);
 	}
     }
@@ -1024,24 +1027,26 @@ void setup_rw_floppy(void)
     output_byte(command);
     output_byte(head << 2 | current_drive);
 
+#ifdef INCLUDE_FD_FORMATTING
     if (command != FD_FORMAT) {
+#endif
 	output_byte(track);
 	output_byte(head);
-	if (read_track)
-	    output_byte(1);	/* always start at 1 */
-	else
-	    output_byte(sector+1); 
+	output_byte(sector+1); 
 
 	output_byte(2);		/* sector size = 512 */
 	output_byte(floppy->sect);
 	output_byte(floppy->gap);
 	output_byte(0xFF);	/* sector size, 0xff unless sector size==0 (128b) */
+
+#ifdef INCLUDE_FD_FORMATTING
     } else {
 	output_byte(2);		/* sector size = 512 */
 	output_byte(floppy->sect * 2); /* sectors per cyl */
 	output_byte(floppy->fmt_gap);
 	output_byte(FD_FILL_BYTE);
     }
+#endif
     DEBUG("S_OK;");
     if (reset)		/* If output_byte timed out */
 	redo_fd_request();
@@ -1070,11 +1075,14 @@ static void seek_interrupt(void)
  */
 static void transfer(void)
 {
-    /* DEBUG - turns on/off track buffer via bootopts */
-    read_track = xt_floppy[2] && !raw && (command == FD_READ) && (CURRENT_ERRORS < 4) &&
-	(floppy->sect <= MAX_BUFFER_SECTORS);
+#ifdef CONFIG_TRACK_CACHE
+    use_cache = (xt_floppy[2]>1) && !raw && (command == FD_READ) && (CURRENT_ERRORS < 4) &&
+	(cache_size >= 4);
 
-    DEBUG("trns%d-", read_track);
+    DEBUG("trns%d-", use_cache);
+#else
+    DEBUG("trns-");
+#endif
 
     configure_fdc_mode();	/* Make sure the controller is in the right mode,
 				 * may change between every transaction when 
@@ -1097,7 +1105,7 @@ static void transfer(void)
     	output_byte((head << 2) | current_drive);
     	output_byte(seek_track);
     	if (reset)		/* If something happened in output_byte() */
-		redo_fd_request();
+	    redo_fd_request();
     } else { 			/* implied seek */
 	current_track = seek_track;
 	setup_rw_floppy();
@@ -1274,7 +1282,6 @@ static void floppy_ready(void)
     DEBUG("RDY0x%x,%d,%d-", MEDIA_CHANGED, reset, recalibrate);
 #ifdef USE_DIR_REG
     if (MEDIA_CHANGED) {
-	cache_track = -1;	/* MAYBE NOT */
         if (current_type[current_drive] && !(just_opened & mask)) {
             changed_floppies |= (1 << current_drive); /* this will discard any queued I/O */
             printk("df%d: Drive was opened, purge pending I/O\n", current_drive);
@@ -1461,26 +1468,28 @@ static void redo_fd_request(void)
     fd_timeout.tl_expires = jiffies + 3 * HZ;
     add_timer(&fd_timeout);
 
-    DEBUG("prep %d|%d,%d|%d-", cache_track, seek_track, cache_drive, current_drive);
+    DEBUG("prep %d,%d|%d-", seek_track, cache_drive, current_drive);
 
-    if (!raw && (((seek_track << 1) + head) == cache_track) && (current_drive == cache_drive)) {
+#ifdef CONFIG_TRACK_CACHE
+    if (!raw && (current_drive == cache_drive) && start >= cache_start
+			&& start <= (cache_start + cache_len - nr_sectors + 1)) {
+
 	unsigned char *buf_ptr;
 
-	/* Requested block is in the cache. If reading, go get it.
-	 * If the sector count is odd, we cache sectors+1 when head=0 to get 
-	 * full blocks. When head=1 we read the entire track
-	 * and ignore the first sector.
-	 */
-	buf_ptr = (unsigned char *)(sector << 9);
+	/* Requested block is in the cache. If we're reading, go get it.
+	 * Otherwise, update it. */
+	buf_ptr = (unsigned char *)((start - cache_start) << 9);
 	DEBUG("bufrd chs %d/%d/%d-%x\n", seek_track, head, sector, buf_ptr);
 
 	if (command == FD_READ) {	/* requested data is in cache */
+	    cache_hits++;
 	    xms_fmemcpyw(req->rq_buffer, req->rq_seg, buf_ptr, DMASEG, BLOCK_SIZE/2);
 	    request_done(1);
 	    goto repeat;
     	} else if (command == FD_WRITE)	/* update track cache */
 	    xms_fmemcpyw(buf_ptr, DMASEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
     } 
+#endif
 
     if (seek_track != current_track)
 	seek = 1;
@@ -1648,7 +1657,7 @@ int floppy_open(struct inode *inode, struct file *filp)
     drive = MINOR(inode->i_rdev) >> MINOR_SHIFT;
     dev = drive & 3;
     fd_device[dev] = inode->i_rdev;
-    cache_drive = cache_track = -1;	
+    cache_drive = -1;	
 
     if (!israw) {			/* For block device access only */
 	old_dev = fd_device[dev];
@@ -1679,7 +1688,6 @@ int floppy_open(struct inode *inode, struct file *filp)
 	}
     }
     inode->i_size = ((sector_t)(floppy->size)) << 9;	/* NOTE: assumes sector size 512 */
-    printk("xt_floppy[2]=%d\n", xt_floppy[2]);
     DEBUG("df%d: open %s dev %04x, sz %lu, %s\n", drive, israw?"(raw)":"",
 		inode->i_rdev, inode->i_size, floppy->name);
 
@@ -1704,6 +1712,7 @@ void floppy_release(struct inode *inode, struct file *filp)
 //clear_raw:
 	changed_floppies &= ~(1 << drive);	/* clear media change flag */
 	current_type[drive] = NULL;	/* prevent next open from flagging media change */
+	printk("Cache hits: %u\n", cache_hits);
     }
 }
 
@@ -1807,4 +1816,13 @@ void INITPROC floppy_init(void)
     }
 #endif
     config_types();
+
+    /* sector cache setup */
+    if (xt_floppy[2] > 1)		/* temporary */
+	cache_size = xt_floppy[2]<<1;
+    else
+	cache_size = 2; 	/* minimal bounce buffer at DMASEG */
+    if (cache_size > (DMASEGSZ>>9)) cache_size = DMASEGSZ>>9;
+    printk("Cache size %dk, available %dk\n", xt_floppy[2], DMASEGSZ>>10);
+	
 }

--- a/tlvc/config.in
+++ b/tlvc/config.in
@@ -18,6 +18,9 @@ mainmenu_option next_comment
 		bool 'MK-88 Hardware (IRQ 3 keyboard)' CONFIG_HW_MK88 n
 		bool 'IBM PC/XT or compatible (8bit ISA)' CONFIG_HW_PCXT n
 		bool 'Add Precision timer (for debugging)' CONFIG_PREC_TIMER n
+		if [ "$CONFIG_PREC_TIMER" = "y" ]; then
+		    bool 'Add calibrated delay for drivers' CONFIG_CALIBRATE_DELAY n
+		fi
 
 		comment 'Devices'
 

--- a/tlvc/fs/super.c
+++ b/tlvc/fs/super.c
@@ -501,7 +501,11 @@ void mount_root(void)
     } while (*(++fs_type) && !retval);
 
 #if defined(CONFIG_BLK_DEV_BFD) || defined(CONFIG_BLK_DEV_FD)
-    if (ROOT_DEV == DEV_FD0 || ROOT_DEV == DEV_DF0) {
+#if defined(CONFIG_BLK_DEV_FD)
+    if (ROOT_DEV == DEV_DF0 || ROOT_DEV == DEV_DF1) {
+#else
+    if (ROOT_DEV == DEV_FD0 || ROOT_DEV == DEV_FD1) {
+#endif
 	close_filp(d_inode, filp);
 	printk("VFS: Insert root floppy and press ENTER\n");
 	wait_for_keypress();

--- a/tlvc/include/linuxmt/config.h
+++ b/tlvc/include/linuxmt/config.h
@@ -116,15 +116,9 @@
 #define REL_INITSEG	0x70	/* 0x200 bytes setup data */
 #define DMASEG		0x90	/* 0x400 bytes floppy sector buffer */
 #ifdef CONFIG_TRACK_CACHE	/* floppy track buffer in low mem */
-#ifdef CONFIG_HW_PCXT
-#define DMASEGSZ	0x1200	/* SECTOR_SIZE * 9 (4608), XT limit */
-#else
-#define DMASEGSZ	0x2400	/* SECTOR_SIZE * 18 (9216) */
-#endif
-//#define REL_SYSSEG     0x2D0	/* kernel code segment */
+#define DMASEGSZ	CONFIG_TRACK_CACHE_SZ * 1024
 #else
 #define DMASEGSZ 0x0400		/* BLOCK_SIZE (1024) */
-//#define REL_SYSSEG     0x0D0  /* kernel code segment */
 #endif
 #define REL_SYSSEG	0x90 + (DMASEGSZ>>4) /* kernel code segment */
 #define SETUP_DATA	REL_INITSEG
@@ -137,7 +131,7 @@
 #define REL_INITSEG	0x80  /* 0x200 bytes setup data */
 #define DMASEG		0xA0  /* 0x400 bytes floppy sector buffer */
 
-#define DMASEGSZ 0x2400	      /* SECTOR_SIZE * 18 (9216) > SECTOR_SIZE * 8 (8192) */
+#define DMASEGSZ 0x2400	      /* SECTOR_SIZE * 18 (9216) */
 #define REL_SYSSEG	0x2E0 /* kernel code segment */
 #define SETUP_DATA	REL_INITSEG
 #endif /* CONFIG_ARCH_PC98 && !CONFIG_ROMCODE */

--- a/tlvc/include/linuxmt/config.h
+++ b/tlvc/include/linuxmt/config.h
@@ -110,17 +110,22 @@
 
 
 #if (defined(CONFIG_ARCH_IBMPC) || defined(CONFIG_ARCH_8018X)) && !defined(CONFIG_ROMCODE)
+#if CONFIG_FLOPPY_CACHE > 9
+#define CONFIG_FLOPPY_CACHE 9
+#elif CONFIG_FLOPPY_CACHE < 1
+#define CONFIG_FLOPPY_CACHE 1
+#endif
 /* Define segment locations of low memory, must not overlap */
 #define DEF_OPTSEG	0x50	/* 0x200 bytes boot options*/
 #define OPTSEGSZ	0x200	/* max size of /bootopts file (1K max) */
 #define REL_INITSEG	0x70	/* 0x200 bytes setup data */
 #define DMASEG		0x90	/* 0x400 bytes floppy sector buffer */
-#ifdef CONFIG_TRACK_CACHE	/* floppy track buffer in low mem */
-#define DMASEGSZ	CONFIG_TRACK_CACHE_SZ * 1024
+#if CONFIG_FLOPPY_CACHE		/* floppy cache or bounce buffer in low mem */
+#define DMASEGSZ	CONFIG_FLOPPY_CACHE * 1024
 #else
-#define DMASEGSZ 0x0400		/* BLOCK_SIZE (1024) */
+#define DMASEGSZ	0x0400	/* 1 BLOCK (1024B) */
 #endif
-#define REL_SYSSEG	0x90 + (DMASEGSZ>>4) /* kernel code segment */
+#define REL_SYSSEG	DMASEG + (DMASEGSZ>>4) /* kernel code segment */
 #define SETUP_DATA	REL_INITSEG
 #endif 
 


### PR DESCRIPTION
This PR introduces a new sector cache implementation replacing the old track buffer in the `directfd` driver. The 'TRACK_CACHE' configuration option is also back, for reasons detailed below. This is part of a floppy 'boot and use' performance enhancement project discussed on #81. Some specifics about the changes:
- The old track cache would always cache at least a full track, from sector 1 regardless of which sector was actually requested (not very useful and time consuming). Further the buffer size was always 9k (18 sectors) - if compiled in.
- The new sector cache has a very different approach:
    - Fills the cache from the requested sector to the end of the cylinder or end of cache, whichever comes first.
    - The cache can be any (even) number of blocks from 2 (1k) to 18 (9k) or larger, which doesn't make much sense.
    - This means
        - Cache size 1k behaves exactly like having no cache at all
        - Cache size 9k combined with 9 sectors per track floppies (360k, 720k) means full cylinder cache if the requested sector is the first on track (head) 0 of that cyl.
        - The cache size can be tuned and set to whatever works best for the actual environment.
    - Cache hits are being counted and reported on device close (release), which unfortunately will never show on a root file system.
- The cache size can be set using a third parameter to the `xtflpy=` setting in `bootopts`. This is a temporary solution until the `sysctl` facility from ELKS has been implemented. The metric is kilobytes, if missing the value is 0 which is read as 1, the minimum.
- For now, the actual cache size and the available cache size is being reported at boot time.
- The variable size and potential absence of the sector cache forced a recite of the raw driver's mechanism to handle 64k physical memory boundaries. A raw request, if its buffer spans such a boundary will blend split into 3 (occasionally just 2) physical requests, isolating the boundary block to 1k using the bounce buffer (which is the first k of the sector cache if present). This part of the driver has had limited testing.

Also on this PR:
- Simplified `menuconfig` page for block devices.

Performance
Surprisingly it turns out that fast machines (like a 40MHz 386) does not benefit from floppy caching at all. Thus turning off the cache using `menuconfig` and release most of the memory is the right thing to do. Also somewhat surprising that a smaller (than max) cache, like 6 or 7k, in most cases will give better performance than a smaller and larger cache. Check #81 for more details about this.