### PR TITLE
[cmds] Minor fix to fdisk to avoid accidental catastrophes

### DIFF
--- a/tlvccmd/disk_utils/fdisk.c
+++ b/tlvccmd/disk_utils/fdisk.c
@@ -428,6 +428,9 @@ int main(int argc, char **argv)
 		} else {
 			if (*dev != 0) usage();
 			else strcpy(dev, argv[i]);
+			/* get rid of partitions */
+			while (isdigit(dev[strlen(dev)-1]))
+				dev[strlen(dev)-1] = '\0';
 		}
 	}
 


### PR DESCRIPTION
Automatically remove partition number from device name on the `fdisk` command line. Previously, a partition was accepted as a drive, which means a (non existing) partition table could be modified and thus the volume seriously damaged.