### PR TITLE
[cmd] Update fdtest to use the directfd driver and raw IO

### DIFF
--- a/tlvccmd/misc_utils/fdtest.c
+++ b/tlvccmd/misc_utils/fdtest.c
@@ -2,16 +2,17 @@
  * fdtest - A program to test floppy disk I/O speed in user space
  */
 #include <stdio.h>
-#include <time.h>
 #include <signal.h>
 #include <stdlib.h>
 #include <unistd.h>
 #include <fcntl.h>
 #include <sys/types.h>
 #include <sys/stat.h>
+#include <sys/ioctl.h>
 #include <linuxmt/bioshd.h>
 #include <linuxmt/biosparm.h>
 #include <linuxmt/memory.h>
+#include <linuxmt/mem.h>
 
 #define USE_DIRECTFD
 #ifndef USE_DIRECTFD
@@ -30,10 +31,11 @@ struct biosparms bdt;
 #define BD_FL bdt.fl
 #endif
 
-#define MAX		30		/* max # of sectors per read */
-#define SECSIZE		512		/* sector size*/
+#define MAX		18*2		/* max # of sectors per read */
+#define SECSIZE		512L		/* sector size*/
 
 unsigned char iobuf[MAX * SECSIZE];
+unsigned long __far *jp;
 int verbose = 0;
 int out = 0;
 
@@ -62,14 +64,52 @@ int read_disk(unsigned short drive, unsigned short cylinder, unsigned short head
 }
 #endif
 
+int timer_init(void)
+{
+    unsigned int kds, jaddr;
+    int fd = open("/dev/kmem", O_RDONLY);
+
+    if (fd < 0) {
+        perror("/dev/kmem");
+        return -1;
+    }
+    if ((ioctl(fd, MEM_GETDS, &kds) < 0) || (ioctl(fd, MEM_GETJIFFADDR, &jaddr)) < 0 )  {
+        perror("ktcp: ioctl error in /dev/kmem");
+        return -1;
+    }
+    jp = _MK_FP(kds, jaddr);
+    close(fd);
+    return 0;
+}
+
+/*
+ * read a full track of single sectors with increasing sector numbers to get a
+ * reasonable average single sector access time - return the average in ms */
+static int av_sec_time(int fd, int b)
+{
+	int i;
+	long t, a = 0;
+
+	lseek(fd, 0, SEEK_SET);
+	for (i = 0; i < b; i++) {
+		t = *jp;
+		read(fd, iobuf, SECSIZE);
+		a += *jp - t;
+	}
+	a /= b;		/* average */
+	fprintf(stderr, "Average sector read time (no seek): %ldms\n", a*10);
+	return (int)(a*10);
+}
+
+
 int main(int ac, char **av)
 {
-	unsigned short drive, cylinder, head, sector;
+	unsigned short drive, cylinder, head, sector, step = 0;
 	unsigned short start_dma_page, end_dma_page;
 	unsigned long normalized_seg;
-	int i, max, direct = 0;
-	unsigned short bs = 1;
-	time_t t, tt;
+	int i, j, max, direct = 0;
+	unsigned short bs = 0;
+	long start, end;
 #ifdef USE_DIRECTFD
 	long lba;
 	char *device = "/dev/rdf0";
@@ -102,6 +142,10 @@ int main(int ac, char **av)
 			head = atoi(*(++av));
 			ac--;
 			break;
+		case 'S':	/* use this many cyls to measure step time */
+			step = atoi(*(++av));
+			ac--;
+			break;
 		case 's':	/* select staring sector, 1 to MAX or max */
 			sector = atoi(*(++av));
 			ac--;
@@ -132,6 +176,7 @@ int main(int ac, char **av)
 			return(1);
 		}	
 	}
+	timer_init();
 #ifdef USE_DIRECTFD
 	lba = (cylinder<<1 + head)*max + (sector - 1);
 	if ((fd = open(device, O_RDONLY)) < 0) {
@@ -139,28 +184,31 @@ int main(int ac, char **av)
 		exit(1);
 	}
 	lseek(fd, lba*SECSIZE, SEEK_SET);
+	if (!bs) bs = max;
 
-#else
+#endif
 	/* dma start/end pages must be equal to ensure I/O within 64k DMA boundary for INT 13h*/
-	if (verbose) {
-		start_dma_page = (_FP_SEG(iobuf) + ((__u16) iobuf >> 4)) >> 12;
-		end_dma_page = (_FP_SEG(iobuf) + ((__u16) (iobuf + max * 512 - 1) >> 4)) >> 12;
-		normalized_seg = (((__u32)_FP_SEG(iobuf) + (_FP_OFF(iobuf) >> 4)) << 16) +
+	start_dma_page = (_FP_SEG(iobuf) + ((__u16) iobuf >> 4)) >> 12;
+	end_dma_page = (_FP_SEG(iobuf) + ((__u16) (iobuf + max * 512 - 1) >> 4)) >> 12;
+	normalized_seg = (((__u32)_FP_SEG(iobuf) + (_FP_OFF(iobuf) >> 4)) << 16) +
 			(_FP_OFF(iobuf) & 15);
+	if (verbose) {
+		fprintf(stderr, "[iobuf @ %04x:%04x] ", _FP_SEG(iobuf), (unsigned int)iobuf);
 		fprintf(stderr, "dma start page %x, dma end page %x, buffer at %x:%x - ",
 			start_dma_page, end_dma_page, _FP_SEG(normalized_seg), _FP_OFF(normalized_seg));
 		fprintf(stderr, start_dma_page == end_dma_page? "OK\n": "ERROR\n");
 	}
+	if (start_dma_page != end_dma_page)
+		fprintf(stderr, "Warning: Buffer spans 64k boundary, IO will be split!\n");
 
 	signal(SIGINT, SIG_IGN);	/* any signal here will likely crash the system */
-#endif
 
 	if (direct) {
 		int  blocks = 0;
 
-		fprintf(stderr, "Testing entire drive %d, max %d incr %d\n", drive, max, bs);
-		cylinder = 0;
-		t = time(NULL);
+		fprintf(stderr, "Reading drive %d from cyl %d, spt %d incr %d\n", 
+				 drive, cylinder, max, bs);
+		start = *jp;
 
 #ifdef USE_DIRECTFD
 		while (read(fd, iobuf, bs*SECSIZE) > 0) {
@@ -199,39 +247,76 @@ int main(int ac, char **av)
 			blocks++; 
 			if (!verbose) write(2, ".", 1);
 		}
-		fprintf(stderr, "\nRead %d blocks in %ld seconds\n", blocks, time(NULL) - t);
+		end = *jp;
+		i = (end-start)/100;
+		j = (end-start)%100;
+	        fprintf(stderr, "\nRead %d blocks in %d.%ds (%ldms per block)\n",
+			blocks, i, j, (end-start)*10/blocks);
 		return(0);
 	}
 
-	fprintf(stderr, "Reading %d sectors individually\n", max);
-	t = time(NULL);
-	for (i=0; i < max; i++)
+	fprintf(stderr, "%s: Using %d sectors per track, %d per cyl, start @ %d/%d/%d (lba %ld)\n\n", 
+		device, max, max<<1, cylinder, head, sector, lba);
+	start = *jp;
+	for (i=0; i < bs; i++) {
 #ifdef USE_DIRECTFD
-		read(fd, iobuf, SECSIZE);
+		j = read(fd, iobuf, SECSIZE);
+		if (j != SECSIZE)
+			fprintf(stderr, "short read, expected %d, got %d\n", (int)SECSIZE, j);
 #else
 		(void)read_disk(drive, cylinder, head, sector+i, 1);
 #endif
-	fprintf(stderr, "%ld secs\n", time(NULL) - t);
+	}
+	end = *jp;
+	j = (int)(end-start)*10;	/* turn into ms */
+	fprintf(stderr, "%2d sectors (1-by-1):\t%dms (%dms/sector)\n", bs, j, j/bs);
 	
-	fprintf(stderr, "Reading %d sectors as %d 1024-byte blocks\n", max, max/2);
-	t = time(NULL);
-	for (i=0; (sector+i) < max-1; i += 2)
+	lseek(fd, lba*SECSIZE, SEEK_SET);
+	start = *jp;
+	for (i=0;  i <= bs; i += 2) {
 #ifdef USE_DIRECTFD
-		read(fd, iobuf, SECSIZE<<1);
+		j = read(fd, iobuf, SECSIZE<<1);
+		if (j != SECSIZE<<1)
+			fprintf(stderr, "short read, expected %d, got %d\n",
+							(int)SECSIZE<<1, j);
 #else
 		(void)read_disk(drive, cylinder, head, sector+i, 2);
 #endif
-	fprintf(stderr, "%ld secs\n", time(NULL) - t);
-	
-	fprintf(stderr, "Reading %d sectors at once\n", max);
-	t = time(NULL);
+	}
+	end = *jp;
+	j = (int)(end-start)*10;
+	fprintf(stderr, "%2d 1k blocks:\t\t%dms (%dms/block)\n", bs/2, j, j/(bs/2));
+
+	lseek(fd, lba*SECSIZE, SEEK_SET);
+	start = *jp;
 #ifdef USE_DIRECTFD
-	read(fd, iobuf, max*SECSIZE);
-	close(fd);
+	j = read(fd, iobuf, bs*SECSIZE);
+	if (j != bs*SECSIZE)
+			fprintf(stderr, "short read, expected %d, got %d\n",
+							bs*(int)SECSIZE, j);
 #else
 	(void)read_disk(drive, cylinder, head, sector, max);
 #endif
-	tt = time(NULL);
-	fprintf(stderr, "%ld secs\n", tt-t);
-	
+	end = *jp;
+	j = end-start;
+	fprintf(stderr, "%2d sectors in 1 op:\t%dms\n", bs, (int)j*10);
+	i = av_sec_time(fd, max);
+	if (out)
+		write(1, iobuf, bs*512);
+	if (step) {
+		long seek = (long)(max*step*2 - 1) * SECSIZE;
+
+		lseek(fd, (off_t)0, SEEK_SET);
+		read(fd, iobuf, (size_t)SECSIZE);	/* move to cyl 0 before we start */
+		lseek(fd, seek, SEEK_SET);
+		start = *jp;
+		read(fd, iobuf, (size_t)SECSIZE);
+		lseek(fd, (off_t)0, SEEK_SET);
+		read(fd, iobuf, (size_t)SECSIZE);
+		end = *jp;
+		//fprintf(stderr, "seek to %ld (jif %ld)\n", seek, end-start);
+		seek = (end-start)*10L - i*2L; /* movement time, back and forth, ms */
+		fprintf(stderr, "Seek time (%d steps*2): %ldms, step rate %ldms\n", 
+				 step, seek, seek/(2L*(long)step));
+	}
 }


### PR DESCRIPTION
The `fdtest` needed a long overdue update to work properly with TLVC and the `directfd` driver. Most of the old code (using direct BIOS calls) is now commented out: Access to raw IO allows a utility to do physical IO which is what this utility needs to do its testing.

Actually, the `dd` utility can do most of what `fdtest` does - with the help of the external `time` program. However, if a 'skip-length` - blocks to skip between each operation, is added, all kinds of new possibilities opens up for this program.

The timer needs to be fixed to report higher time resolution than 1 second.