### PR TITLE
[cmd] Prevent fdisk from creating partition beyond end of medium.

### DIFF
--- a/tlvccmd/disk_utils/fdisk.c
+++ b/tlvccmd/disk_utils/fdisk.c
@@ -166,8 +166,8 @@ void add_part(void)
     oset = MBR + PARTITION_START + ((part - 1) * 16);
 
     printf("Total cylinders: %d\n", geometry.cylinders);
-    for (scyl = geometry.cylinders + 1; scyl < 0 || scyl > geometry.cylinders;) {
-	printf("First cylinder (%d-%d): ", 0, geometry.cylinders);
+    for (scyl = geometry.cylinders; scyl < 0 || scyl > geometry.cylinders-1;) {
+	printf("First cylinder (%d-%d): ", 0, geometry.cylinders-1);
 	fflush(stdout);
 	fgets(buf, 31, stdin);
 	scyl = atoi(buf);
@@ -187,8 +187,8 @@ void add_part(void)
     p.cyl	= (scyl & 0xff);
     p.sys_ind	= PARTITION_TYPE;
 
-    for (ecyl = geometry.cylinders + 1; ecyl < scyl || ecyl > geometry.cylinders;) {
-	printf("Ending cylinder (%d-%d): ", 0, geometry.cylinders);
+    for (ecyl = geometry.cylinders; ecyl < scyl || ecyl > geometry.cylinders-1;) {
+	printf("Ending cylinder (%d-%d): ", 0, geometry.cylinders-1);
 	fflush(stdout);
 	fgets(buf, 31, stdin);
 	ecyl = atoi(buf);


### PR DESCRIPTION
Apparently since the beginning of time, `fdisk` has allowed creation of partitions 1 cylinder beyond the end of medium (by equating cylinder count with cylinder numbers). This minor update fixes that.