### PR TITLE
[kernel] Make precision timer routines mandatory, not configurable.

### DIFF
--- a/tlvc/config.in
+++ b/tlvc/config.in
@@ -17,10 +17,7 @@ mainmenu_option next_comment
 		bool 'Compaq DeskPro Hardware (fast mode)' CONFIG_HW_COMPAQFAST n
 		bool 'MK-88 Hardware (IRQ 3 keyboard)' CONFIG_HW_MK88 n
 		bool 'IBM PC/XT or compatible (8bit ISA)' CONFIG_HW_PCXT n
-		bool 'Add Precision timer (for debugging)' CONFIG_PREC_TIMER n
-		if [ "$CONFIG_PREC_TIMER" = "y" ]; then
-		    bool 'Add calibrated delay for drivers' CONFIG_CALIBRATE_DELAY n
-		fi
+		bool 'Add calibrated delay for drivers' CONFIG_CALIBRATE_DELAY n
 
 		comment 'Devices'
 

--- a/tlvc/kernel/printk.c
+++ b/tlvc/kernel/printk.c
@@ -46,8 +46,6 @@
 #include <arch/divmod.h>
 #include <stdarg.h>
 
-#define CONFIG_PREC_TIMER   1   /* =1 to include %k precision timer printk format */
-
 dev_t dev_console;
 
 #ifdef CONFIG_CONSOLE_SERIAL
@@ -88,7 +86,6 @@ static void kputs(const char *buf)
 /* convert 1/1193182s get_ptime() pticks (0.838usec through 42.85sec) for display */
 static unsigned long conv_ptick(unsigned long v, int *pDecimal, int *pSuffix)
 {
-#ifdef CONFIG_PREC_TIMER
     unsigned int c;
     int Suffix = 0;
 
@@ -110,7 +107,6 @@ static unsigned long conv_ptick(unsigned long v, int *pDecimal, int *pSuffix)
     if (Suffix == 0)      *pSuffix = ('s' << 8) | 'u';
     else if (Suffix == 1) *pSuffix = ('s' << 8) | 'm';
     else                  *pSuffix = 's';
-#endif
     return v;
 }
 


### PR DESCRIPTION
Increasingly useful not only for debugging, having these tools optional is no longer useful. Thanks @ghaerr.