### PR TITLE
[kernel,fs] Udates xms support and various cleanups

### DIFF
--- a/tlvc/arch/i86/lib/unreal.S
+++ b/tlvc/arch/i86/lib/unreal.S
@@ -40,6 +40,7 @@
 	.global	set_a20
 	.global	linear32_fmemcpyw
 	.global	linear32_fmemcpyb
+	.global	linear32_fmemset
 
 # Check if unreal mode capable. Currently requires 32-bit CPU (386+)
 # Returns 1 if OK, otherwise error code (-1=not 386, -2=in V86 mode).
@@ -402,6 +403,55 @@ linear32_fmemcpyb:
 	mov    %ss,%ax
 	mov    %ax,%ds
 	pop    %es
+	ret
+
+#
+# void linear32_fmemset(void *dst_off, addr_t dst_seg, byte_t val, size_t count)
+# WARNING: Requires 32-bit CPU, with unreal mode and A20 gate enabled!
+#          Trashes EAX, EBX, ECX, ESI and EDI without saving.
+#
+linear32_fmemset:
+	push   %si
+	push   %es
+	mov    %di,%dx
+
+	//pushf               // save interrupt status
+	//cli                 // uncomment if extended registers used in interrupt routines
+	xorl   %esi,%esi
+	mov    %sp,%si
+
+	xorl   %ecx,%ecx
+	mov    14(%si),%cx    // word count -> ECX
+
+	xorl   %ebx,%ebx
+	mov    6(%si),%bx     // word dest offset -> EBX
+	movl   8(%esi),%edi   // long dest address -> EDI
+	addl   %ebx,%edi      // EDI is linear destination
+
+	xorl   %eax,%eax
+	mov    12(%si),%al    // byte val -> EAX
+	mov    %al,%ah
+
+	xor    %bx,%bx        // ES = DS = 0 for 32-bit linear addressing
+	mov    %bx,%es
+	mov    %bx,%ds
+
+	cld
+	shrl   $1,%ecx        // store words
+	addr32 rep stosw      // word [ES:EDI++] <- AX, ECX times
+	addr32 nop            // 80386 B1 step chip bug on address size mixing
+
+	rcll    $1,%ecx       // then possibly final byte
+	addr32 rep stosb      // byte [ES:EDI++] <- AL, ECX times
+	addr32 nop            // 80386 B1 step chip bug on address size mixing
+
+	//popf                // restore interrupt status
+
+	mov    %dx,%di
+	mov    %ss,%ax
+	mov    %ax,%ds
+	pop    %es
+	pop    %si
 	ret
 
 # The GDT contains 8-byte DESCRIPTORS for each protected-mode segment.

--- a/tlvc/arch/i86/mm/xms.c
+++ b/tlvc/arch/i86/mm/xms.c
@@ -4,12 +4,12 @@
  * Nov 2021 Greg Haerr
  */
 
-#include <linuxmt/types.h>
+#include <linuxmt/config.h>
 #include <linuxmt/memory.h>
 #include <linuxmt/kernel.h>
 #include <linuxmt/init.h>
-
 #include <linuxmt/string.h>
+#include <linuxmt/debug.h>
 #include <arch/segment.h>
 
 /* linear address to start XMS buffer allocations from */
@@ -51,10 +51,10 @@ int xms_init(void)
 		return 0;
 	}
 #endif
-	printk("A20 was %s", verify_a20()? "on" : "off");
+	debug("A20 was %s", verify_a20()? "on" : "off");
 	enable_a20_gate();
 	enabled = verify_a20();
-	printk(" now %s, ", enabled? "on" : "off");
+	debug(" now %s, ", enabled? "on" : "off");
 	if (!enabled) {
 		printk("disabled, A20 error, ");
 		return 0;

--- a/tlvc/fs/file_table.c
+++ b/tlvc/fs/file_table.c
@@ -44,28 +44,11 @@ int open_filp(unsigned short flags, struct inode *inode, struct file **fp)
     f->f_mode = (mode_t) ((flags + 1) & O_ACCMODE);
     f->f_count = 1;
 /*    f->f_pos = 0;*/	/* FIXME - should call lseek *//* Set to zero by memset() */
-#ifdef BLOAT_FS
-    f->f_version = ++event;
-#endif
     f->f_inode = inode;
-#ifdef BLOAT_FS
-    if (f->f_mode & FMODE_WRITE) {
-	result = get_write_access(inode);
-	if (result) goto cleanup_file;
-    }
-#endif
-
-#ifdef BLOAT_FS
-/*    f->f_reada = 0;*/ /* Set to zero by memset() */
-#endif
 
     if (inode->i_op) f->f_op = inode->i_op->default_file_ops;
     fop = f->f_op;
     if (fop && fop->open && (result = fop->open(inode, f))) {
-#ifdef BLOAT_FS
-	if (f->f_mode & FMODE_WRITE) put_write_access(inode);
-      cleanup_file:
-#endif
 	f->f_count--;
     }
     *fp = f;
@@ -80,8 +63,5 @@ void close_filp(struct inode *inode, register struct file *f)
     fop = f->f_op;
     if (fop && fop->release) fop->release(inode, f);
 
-#ifdef BLOAT_FS
-    if (f->f_mode & FMODE_WRITE) put_write_access(inode);
-#endif
     f->f_count--;
 }


### PR DESCRIPTION
This PR adds `linear32_fmemset` to the xms code and introduces a number of cleanups from ELKS.

It also introduces an elusive bug - yet to be located: When XMS code is compiled in, part of the console output from the boot process is garbled - as if the console port serial speed gets disturbed. Fix for this is coming shortly.  

```
Direct console, polling kbd 80x25 emulating ANSI (3 virtual consoles)
ttyS0 at 0x3f8, irq 4 is a 16550A
xms: using unreal mode, 100 xms buffers (100K ram), 10K cache, 20 req hdrs
eth: ne0 at 0x300, irq 12, (ne2k) MAC 52:54:00:12:34:56 (QEMU), flags 0x80, bufs 2r/0t
eth: wd0 at 0x280, irq 2, ram 0xcc00 not found
eth: ee0 at 0x360, irq 11, (ee16) not found
athd0: AT/IDE controller at 0x1f0
athd0d0: IDE CHS: 63/16/63 , Multisector I/O, max 16 sects
athd1: Controller not found at 0x170 (376)
athd: found 1 hard drive 
df: Direct floppy driver, FDC 8272A @ irq 6, DMA 2
df0: 1.44M (type 4) [CMOS]
Partitions: dhda:(0,63504) no mbr (flat drive assumed)
?????1?1??߾?ُ?G?<Qˈ?????t???C??ó?U??PRQS????&??1?????????̈?1Ҋ?0???A??(ӋF?9?v??^?????u?8?v???PQR?F?^???s0???*?x??N?ZYX?u?X?O??F??.?a?ZYX?)F?tF???S????&??1?????????̈?1Ҋ?0???A??(ӋF?9?v??^?????u?8?v???PQR?F?^???s0???*?x??N?ZYX?u?X?O??F??.?a?ZYX?)F?tF??????̈?1Ҋ?0???A??(ӋF?9?v??^?????u?8?v???PQR?F?^???s0???*?x??N?ZYX?u?X?O??F??.?a?ZYX?)F?tF???
Delay calibration index: 115, skew: 0

w1??]_^á

ű???뼋?????F?tF???F??g???]?Running /etc/rc.sys script
Starting networking on ne0
ktcp -b -p ne0 10.0.2.15 10.0.2.2 255.255.255.0
ktcp: ip 10.0.2.15, gateway 10.0.2.2, netmask 255.255.255.0
ktcp: /dev/ne0 mac 52.54.00.12.34.56 mtu 1500
Starting daemons 'telnetd' 'ftpd -d' 
Tue Nov  5 15:46:31 2024
[35]

[tlvc15] TLVC 0.6.0

login: 
```