### PR TITLE
[kernel] Reworked the use of lowmem DMASEG in xd and floppy driver + more

### DIFF
--- a/tlvc/arch/i86/drivers/block/blk.h
+++ b/tlvc/arch/i86/drivers/block/blk.h
@@ -213,11 +213,12 @@ static void end_request(int uptodate)
     bh->b_reqnext = NULL;
 #endif
 
-    mark_buffer_uptodate(bh, uptodate);
     mark_buffer_clean(bh);      /* EXPERIMENTAL: moved from ll_rw_blk  */
+    mark_buffer_uptodate(bh, uptodate);
 #if DEBUG_ASYNC
+    //printk("debug level: %d\n", debug_level);
     if (debug_level == 1) printk("ER:%04x;", req);
-    if (debug_level > 3 {
+    if (debug_level > 3 ) {
 	__far unsigned int *content;
 	content = _MK_FP(req->rq_seg, (unsigned int) (req->rq_buffer));
 	printk("ER%d|%04x|%04x|%04x;", uptodate, req, req->rq_dev, *content);
@@ -252,9 +253,7 @@ static void end_request(int uptodate)
     req->rq_dev = -1U;
     req->rq_status = RQ_INACTIVE;
     CURRENT = req->rq_next;
-#if defined(MULTI_BH) || defined(ASYNC_IO)
     wake_up(&wait_for_request);
-#endif
 }
 
 #endif /* MAJOR_NR */

--- a/tlvc/arch/i86/drivers/block/blk.h
+++ b/tlvc/arch/i86/drivers/block/blk.h
@@ -20,7 +20,7 @@ struct request {
     unsigned char rq_cmd;	/* READ or WRITE */
     unsigned char rq_status;
     block32_t rq_blocknr;	/* Always sector nr! (unlike b_blocknr) */
-    unsigned char *rq_buffer;
+    char *rq_buffer;
     ramdesc_t rq_seg;		/* L2 main/xms buffer segment */
     struct buffer_head *rq_bh;
     struct request *rq_next;

--- a/tlvc/arch/i86/drivers/block/config.in
+++ b/tlvc/arch/i86/drivers/block/config.in
@@ -11,12 +11,12 @@ mainmenu_option next_comment
 	define_bool CONFIG_BLK_DEV_BIOS n
 	define_bool CONFIG_BLK_DEV_BFD n
 	define_bool CONFIG_BLK_DEV_BHD n
-	bool '  DIRECT floppy support'		CONFIG_BLK_DEV_FD	y
-	bool '  DIRECT IDE hardisk support'	CONFIG_BLK_DEV_HD	y
+	bool '  Native floppy support'		CONFIG_BLK_DEV_FD	y
+	bool '  Native IDE hardisk support'	CONFIG_BLK_DEV_HD	y
 	if [ "$CONFIG_BLK_DEV_HD" == "y" ]; then
 	    bool '  Include XT-IDE/CF support'	CONFIG_IDE_XT		n
 	fi
-	bool '  DIRECT XT/MFM disk support'	CONFIG_BLK_DEV_XD	n
+	bool '  XT/MFM disk support'	CONFIG_BLK_DEV_XD	n
     fi
     bool 'BIOS based drivers' CONFIG_BLK_DEV_BIOS n
     if [ "$CONFIG_BLK_DEV_BIOS" == "y" ]; then
@@ -29,7 +29,7 @@ mainmenu_option next_comment
     else
 	define_bool CONFIG_DMA n
     fi
-    int 'Floppy drive sector cache, 1-9KB, 0 to disable' \
+    int 'Floppy drive sector cache, 1-7KB, 0 to disable' \
 	    CONFIG_FLOPPY_CACHE 5
 
     comment 'Additional block devices'

--- a/tlvc/arch/i86/drivers/block/directfd.c
+++ b/tlvc/arch/i86/drivers/block/directfd.c
@@ -80,7 +80,7 @@
 #include <linuxmt/errno.h>
 #include <linuxmt/string.h>
 #include <linuxmt/debug.h>
-#include <linuxmt/memory.h>	/* for peek/poke */
+#include <linuxmt/memory.h>
 #include <linuxmt/stat.h>	/* for S_ISCHR() */
 
 #include <arch/dma.h>
@@ -109,8 +109,6 @@ void (*DEVICE_INTR) () = NULL;
 #else
 #define CLEAR_INTR
 #endif		/* DEVICE_INTR */
-
-#define _MK_LINADDR(seg, offs) ((unsigned long)((((unsigned long)(seg)) << 4) + (unsigned)(offs)))
 
 /* Driver configuration */
 

--- a/tlvc/arch/i86/drivers/block/xd.c
+++ b/tlvc/arch/i86/drivers/block/xd.c
@@ -79,7 +79,7 @@
 /*
  * TODO
  * - Add support for raw devices
- * - Add ioctl to manipulate drive parameters, such as automatic retries -
+ * - Add ioctl to manipulate runtime parameters, such as automatic retries -
  *   to be able to continue after hard errors and to support real performance 
  *   testing.
  * - Add format utility.
@@ -96,8 +96,8 @@
 #include <linuxmt/major.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/stat.h>	/* for S_ISCHR() */
-//#include <linuxmt/heap.h>	/* for heap_alloc */
 #include <linuxmt/string.h>	/* for memset */
+#include <linuxmt/memory.h>
 
 #include <arch/dma.h>
 #include <arch/system.h>
@@ -106,7 +106,6 @@
 #include <arch/ports.h>
 #include <arch/hdreg.h>		/* for ioctl defines */
 
-#define BIOSHD_DRIVE_PARMS      0x0800	/* from linuxmt/bioshd.h */
 #define MFMDISK		/* for blk.h */
 #define ASYNC_IO
 #define MINOR_SHIFT 5
@@ -677,19 +676,6 @@ void INITPROC xd_init(void)
 	 * smart choice.
 	 * Note: Old BIOSes will happily respond to CHS queries for non-existent drives!
 	 */
-#ifdef NOTYET
-	struct biosparms bdt;
-
-	bdt.ax = BIOSHD_DRIVE_PARMS;
-	bdt.dx = drive + 0x80;
-	bdt.es = bdt.di = bdt.si = 0;
-	if (call_bios(&bdt) == 0) {
-	    chs_src = 0;
-	    dp->heads = (bdt.dx >>8) + 1;
-	    dp->sectors = bdt.cx & 0x3f;
-	    dp->cylinders = (((bdt.cx & 0xc0) << 2) | (bdt.cx >> 8)) + 1;
-	} else
-#endif
 	i = drive*4;
 	if (hdparms[i]) {
 	    chs_src = 1;

--- a/tlvc/include/linuxmt/debug.h
+++ b/tlvc/include/linuxmt/debug.h
@@ -28,15 +28,12 @@
  * Kernel debug options, set =1 to turn on. Works across multiple files.
  */
 #define DEBUG_EVENT	1		/* generate debug events on CTRLP*/
-#define DEBUG_STARTDEF	0		/* default startup debug display*/
-#define DEBUG_BLKDRV	0		/* Disk/floppy drivers */
-#define DEBUG_RAW	0		/* Raw disk/floppy I/O */
-#define DEBUG_BLK	0		/* (direct) block level i/o*/
-#define	DEBUG_BIOSIO	0		/* BIOS block IO */
+#define DEBUG_LEVEL	0		/* default startup debug level */
 #define DEBUG_ETH	0		/* ethernet*/
 #define DEBUG_FAT	0		/* FAT filesystem*/
 #define DEBUG_FILE	0		/* sys open and file i/o*/
 #define DEBUG_NET	0		/* networking*/
+#define DEBUG_MAP	0		/* L1 mapping */
 #define DEBUG_MM	0		/* mem char device*/
 #define DEBUG_SCHED	0		/* scheduler/wait*/
 #define DEBUG_SIG	0		/* signals*/
@@ -44,7 +41,10 @@
 #define DEBUG_TTY	0		/* tty driver*/
 #define DEBUG_TUNE	0		/* tunable debug statements*/
 #define DEBUG_WAIT	0		/* wait, exit*/
-#define DEBUG_BUFFER	0		/* low level buffer tracing */
+#define DEBUG_CACHE	0		/* Floppy sector cache */
+#define DEBUG_ASYNC	0		/* Async req's added/completed */
+#define DEBUG_BUFFER	0		/* Block IO L1/L2 cache/buffer */
+#define DEBUG_RAW	0		/* Raw/char IO wrapper for block drivers */
 
 #if DEBUG_EVENT
 void dprintk(const char *, ...);		/* printk when debugging on*/
@@ -58,22 +58,24 @@ void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*
 #define debug_event(...)
 #endif
 
-#if DEBUG_BLKDRV
-#define debug_blkdrv	PRINTK
-#else
-#define debug_blkdrv(...)
-#endif
-
-#if DEBUG_BIOSIO
-#define debug_biosio	PRINTK
-#else
-#define debug_biosio(...)
-#endif
-
-#if DEBUG_BLK
+#if DEBUG_BUFFER
 #define debug_blk	PRINTK
 #else
 #define debug_blk(...)
+#endif
+
+#if DEBUG_RAW
+#define debug_raw	PRINTK
+#else
+#define debug_raw(...)
+#endif
+
+#if DEBUG_CACHE
+#define debug_cache     PRINTK
+#define debug_cache2    if (debug_level > 1) PRINTK
+#else
+#define debug_cache(...)
+#define debug_cache2(...)
 #endif
 
 #if DEBUG_ETH
@@ -98,12 +100,6 @@ void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*
 #define debugmem	PRINTK
 #else
 #define debugmem(...)
-#endif
-
-#if DEBUG_RAW
-#define debug_raw	PRINTK
-#else
-#define debug_raw(...)
 #endif
 
 #if DEBUG_NET
@@ -140,6 +136,12 @@ void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*
 #define debug_tune	PRINTK
 #else
 #define debug_tune(...)
+#endif
+
+#if DEBUG_MAP
+#define debug_map	PRINTK
+#else
+#define	debug_map(...)
 #endif
 
 #if DEBUG_WAIT

--- a/tlvc/include/linuxmt/fs.h
+++ b/tlvc/include/linuxmt/fs.h
@@ -126,7 +126,7 @@
 #endif
 
 struct buffer_head {
-    unsigned char		*b_data;	/* Address if in L1 buffer area, else 0 */
+    char		*b_data;	/* Address if in L1 buffer area, else 0 */
 #ifdef CONFIG_FAR_BUFHEADS
 };
 /* a little tricky here - buffer_head is split into near and far components */
@@ -486,7 +486,7 @@ extern void unmap_brelse(struct buffer_head *);
 extern void brelseL1(struct buffer_head *, int);
 extern void brelseL1_index(int, int);
 ramdesc_t buffer_seg(struct buffer_head *);
-extern unsigned char *buffer_data(struct buffer_head *);
+extern char *buffer_data(struct buffer_head *);
 #else
 #define map_buffer(bh)
 #define unmap_buffer(bh)
@@ -504,20 +504,10 @@ extern size_t block_write(struct inode *, struct file *, char *, size_t);
 extern size_t decompress(char *buf, seg_t seg, size_t orig_size, size_t compr_size, int safety);
 #endif
 
-//#define CHECK_MEDIA_CHANGE	/* enable media change handing in direct floppy driver */
-
 #if defined(CONFIG_BLK_DEV_FD) && defined(CHECK_MEDIA_CHANGE)
 extern int check_disk_change(kdev_t);
 #else
 #define check_disk_change(dev)      0
-#endif
-
-#ifdef BLOAT_FS
-extern int get_write_access(struct inode *);
-extern void put_write_access(struct inode *);
-#else
-#define get_write_access(_a)
-#define put_write_access(_a)
 #endif
 
 extern int _namei(const char *,struct inode *,int,struct inode **);

--- a/tlvc/include/linuxmt/memory.h
+++ b/tlvc/include/linuxmt/memory.h
@@ -4,7 +4,6 @@
 /* memory primitives */
 
 #include <linuxmt/types.h>
-#include <stddef.h>
 
 byte_t peekb (word_t off, seg_t seg);
 word_t peekw (word_t off, seg_t seg);

--- a/tlvc/include/linuxmt/memory.h
+++ b/tlvc/include/linuxmt/memory.h
@@ -30,6 +30,7 @@ word_t fmemcmpw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, s
 #define _FP_SEG(fp)     ((unsigned)((unsigned long)(void __far *)(fp) >> 16))
 #define _FP_OFF(fp)     ((unsigned)(unsigned long)(void __far *)(fp))
 #define _MK_FP(seg,off)	((void __far *)((((unsigned long)(seg)) << 16) | (off)))
+#define _MK_LINADDR(seg, offs) ((unsigned long)((((unsigned long)(seg)) << 4) + (unsigned)(offs)))
 
 /* unreal mode, A20 gate management */
 int check_unreal_mode(void);	/* check if unreal mode capable, returns > 0 on success */

--- a/tlvc/include/linuxmt/memory.h
+++ b/tlvc/include/linuxmt/memory.h
@@ -57,6 +57,7 @@ void linear32_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_
 		size_t count);
 void linear32_fmemcpyb(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 		size_t count);
+void linear32_fmemset(void *dst_off, addr_t dst_seg, byte_t val, size_t count);
 
 #else
 


### PR DESCRIPTION
This PR introduces the new scheme for allocating bounce buffers and floppy cache from low memory/DMASEG - discussed in https://github.com/ghaerr/elks/pull/2091 and https://github.com/Mellvik/TLVC/pull/88. The new DMASEG map has a bounce buffer for xd drives (XT class) or Lance ethernet (AT class) at the bottom, then a bounce buffer for the `directfd` driver, handling both DMA wraps and XMS bouncing. Then the floppy sector cache if configured. This means - for the `directfd` driver - that the cache and the bounce buffer are permanently separated and that the cache may be configured completely out of the code by setting the CONFIG_FLOPPY_CACHE value to 0 in menuconfig. For 386+ systems that don't need or benefit from the cache, this is meaningful memory saved.

Other changes to the `directfd` driver:
- A fix for the case that autconfig would fail on all (that is two) formats and loop endlessly. It will now try all (still 2) formats a few times, then fail.
- While it is possible to set the size of the FLOPPY cache to any number in menuconfig, the max is now 7k (14 sectors), corrected if necessary in `config.h`. As before, the actual size and the configured cache memory is reported at boot time - unless configured to 0.
- `fdcache=` in `/bootopts` may now be set to 0 and the cache will be disabled in the driver. Functionally this is similar to the way it worked before (when the bounce buffer and the cache were integrated), but then the 'turn-off' value was 1 to accommodate the bounce buffer, not 0.

Also in this PR is an update to the `xd.c` driver to work in the changes to the bounce buffer setup in `config.h`. These changes have not been tested yet for lack of working hardware. Further:
- Added DEBUG_RAW in `debug.h` and changed debug statements in `fs/block_dev.c` accordingly. `debug.h` has had a number of other additions too, part of a process to improve the debug tooling in TLVC.
- Some cleanups.
