### PR TITLE
[kernel] Experimental heap_free valitity checks

### DIFF
--- a/tlvc/include/linuxmt/heap.h
+++ b/tlvc/include/linuxmt/heap.h
@@ -37,7 +37,7 @@ struct heap {
 	list_s free;
 	word_t size;
 	byte_t tag;
-	byte_t unused;
+	byte_t canary;
 };
 
 typedef struct heap heap_s;


### PR DESCRIPTION
Adds 'canary' based and 'list' based validity checks for `heap_free` for discussion, re. #105.

@ghaerr, to me these two variants do exactly the same, which means the first (list based) alternative is due for deletion. Do you agree?