### PR TITLE
[kernel] Update BIOSHD to work with new low mem boot layout

### DIFF
--- a/tlvc/arch/i86/drivers/block/blk.h
+++ b/tlvc/arch/i86/drivers/block/blk.h
@@ -118,7 +118,6 @@ extern void resetup_one_dev(struct gendisk *dev, int drive);
 
 #endif
 
-extern struct wait_queue wait_for_request; /* for ASYNC_IO */
 #ifdef FLOPPYDISK	/* direct floppy */
 #define ASYNC_IO
 
@@ -179,6 +178,10 @@ static void floppy_off();	/*(unsigned int nr); */
 
 #define CURRENT		(blk_dev[MAJOR_NR].current_request)
 #define CURRENT_DEV	DEVICE_NR(CURRENT->rq_dev)
+
+#ifdef ASYNC_IO
+extern struct wait_queue wait_for_request;
+#endif
 
 static void (DEVICE_REQUEST) ();
 
@@ -253,7 +256,9 @@ static void end_request(int uptodate)
     req->rq_dev = -1U;
     req->rq_status = RQ_INACTIVE;
     CURRENT = req->rq_next;
+#ifdef ASYNC_IO
     wake_up(&wait_for_request);
+#endif
 }
 
 #endif /* MAJOR_NR */

--- a/tlvc/arch/i86/drivers/block/directfd.c
+++ b/tlvc/arch/i86/drivers/block/directfd.c
@@ -269,8 +269,8 @@ static int probing;
  */
 static struct fdev_s fdevice[MAX_FLOPPIES];
 
-/* On an XT with a 720k drive, probing will not work because the first 9 sectors
- * read correctly anyway, we need to fake the CMOS types via bootopts */
+/* On an XT with a 720k drive, regular density probing will not work because the 
+ * first 9 sectors read correctly anyway, we need to fake the CMOS types via bootopts */
 extern int xt_floppy[];
 extern int fdcache;	/* size of sector cache from bootopts */
 
@@ -1492,9 +1492,8 @@ static void redo_fd_request(void)
     }
 #endif
 
-    DEBUG("prep %d,%d|%d-", seek_track, cache_drive, current_drive);
-
 #if CONFIG_FLOPPY_CACHE 
+    DEBUG("prep %d,%d|%d-", seek_track, cache_drive, current_drive);
     if (!raw && (current_drive == cache_drive) && start >= cache_start
 			&& start <= (cache_start + cache_len - nr_sectors + 1)) {
 
@@ -1845,7 +1844,7 @@ void INITPROC floppy_init(void)
     /* sector cache setup - /bootopts fdcache= has preference, otherwise autoconfig */
     if (fdcache != -1)			/* allow fdcache=0 in bootopts */
 	cache_size = fdcache<<1;	/* cache size is sectors, fdcache is k bytes */
-    else if (SETUP_CPU_TYPE == 7)
+    else if (arch_cpu == 7)
 	cache_size = 0; 		/* sector cache is slowing down fast systems */
     else cache_size = FD_CACHE_SEGSZ>>9;	/* use menuconfig value */
 

--- a/tlvc/include/linuxmt/debug.h
+++ b/tlvc/include/linuxmt/debug.h
@@ -46,6 +46,7 @@
 #define DEBUG_BUFFER	0		/* Block IO L1/L2 cache/buffer */
 #define DEBUG_BLKDRV	0		/* Block driver level */
 #define DEBUG_RAW	0		/* Raw/char IO wrapper for block drivers */
+#define DEBUG_BIOSIO	0		/* BIOS low level block IO driver */
 
 #if DEBUG_EVENT
 void dprintk(const char *, ...);		/* printk when debugging on*/
@@ -63,6 +64,12 @@ void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*
 #define debug_blk	PRINTK
 #else
 #define debug_blk(...)
+#endif
+
+#if DEBUG_BIOSIO
+#define debug_biosio	PRINTK
+#else
+#define debug_biosio(...)
 #endif
 
 #if DEBUG_BLKDRV


### PR DESCRIPTION
BIOS based block IO now works with the recent changes to `config.h` - the bounce buffer/floppy cache segment. BIOS floppy has cache/track buffer disabled for now.

Also included a minor adjustment in the `directfd` driver to accommodate a recent change in where system configuration globals (specifically system CPU type) are located. 