### PR TITLE
[kernel] Rearranged low memory enabling release of fd cache space

### DIFF
--- a/tlvc/arch/i86/drivers/block/bioshd.c
+++ b/tlvc/arch/i86/drivers/block/bioshd.c
@@ -969,7 +969,7 @@ static int do_bios_readwrite(struct drive_infot *drivep, sector_t start, unsigne
 	if (error) return 0;
 	if (usedmaseg) {
 		if (cmd == READ)	/* copy DMASEG up to xms*/
-			xms_fmemcpyw(buf, seg, 0, FD_BOUNCE_SEG, this_pass*(drivep->sector_size >> 1));
+			xms_fmemcpyw(buf, seg, 0, FD_BOUNCESEG, this_pass*(drivep->sector_size >> 1));
 		set_cache_invalid();
 	}
 	return this_pass;

--- a/tlvc/arch/i86/drivers/block/genhd.c
+++ b/tlvc/arch/i86/drivers/block/genhd.c
@@ -362,7 +362,7 @@ void INITPROC setup_dev(register struct gendisk *dev)
 #endif
 	memset((void *)dev->part, 0, sizeof(struct hd_struct)*dev->max_nr*dev->max_p);
 	dev->init(dev);
-	printk("setup_dev %04x/%d(%d)\n", dev, dev->major,sizeof(struct hd_struct)*dev->max_nr*dev->max_p);
+	//printk("setup_dev %04x/%d(%d)\n", dev, dev->major,sizeof(struct hd_struct)*dev->max_nr*dev->max_p);
 
 /*
  * A system can have only one disk 'category' - BIOS, IDE/ATA or XD.

--- a/tlvc/init/main.c
+++ b/tlvc/init/main.c
@@ -159,7 +159,9 @@ static void INITPROC early_kernel_init(void)
     ROOT_DEV = SETUP_ROOT_DEV;      /* default root device from boot loader */
 
 #ifdef CONFIG_BOOTOPTS
-    hasopts = parse_options();         /* parse options found in /bootops */
+    hasopts = parse_options();		/* parse options found in /bootops */
+#else
+    fdcache = CONFIG_FLOPPY_CACHE;	/* no bootopts -> use CONFIG */
 #endif
 
     /* create near heap at end of kernel bss */
@@ -289,11 +291,11 @@ static void INITPROC do_init_task(void)
 	sys_dup(num);		/* open stdout*/
 	sys_dup(num);		/* open stderr*/
     //}
+    seg_add(REL_INITSEG, fdcache>0?FD_CACHESEG:FD_BOUNCESEG);
 
 #ifdef CONFIG_BOOTOPTS
     /* Release /bootopts parsing buffers and the setup data segment */
     heap_add(options, OPTSEGSZ);
-    seg_add(DEF_OPTSEG, DMASEG);	/* DEF_OPTSETG through REL_INITSEG */
 
     /* pass argc/argv/env array to init_command */
 


### PR DESCRIPTION
Discussed in https://github.com/Mellvik/TLVC/pull/109#issuecomment-2526204965

TLVC low memory has been rearranged to enable the release of an allocated floppy cache if unused (i.e. `fdcache=` in `bootopts` set to 0 or unset.  This reduces the 'penalty' of allocating a nominal floppy sector cache in the kernel configuration and then not taking advantage of that space. By placing the cache immediately after the `bootopts` buffer and the system setup segment, which are always released, the entire block can be release as one, which means 6.5k bytes if 5k has been allocated to the FD cache.

Also fixes a bug in `init/main.c` which would always disable the floppy cache if no `bootopts` was found or configured.

`meminfo` has been updated to work with these changes. Tested with and without all combinations of with/without ftext kernel, bootopts. 

This implementation does not enable the release of a partly unused floppy sector cache. If (say) 7k has been configured and only 5k used (by `fdcache=` in `bootopts`), the unused block will not be released. It is not clear that the code needed to take advantage of such an esoteric situation would be worth it. 
