### PR TITLE
[kernel,cmd] Another simplification of low memory usage

### DIFF
--- a/tlvc/arch/i86/drivers/block/directfd.c
+++ b/tlvc/arch/i86/drivers/block/directfd.c
@@ -1841,14 +1841,7 @@ void INITPROC floppy_init(void)
     config_types();
 
 #if CONFIG_FLOPPY_CACHE
-    /* sector cache setup - /bootopts fdcache= has preference, otherwise autoconfig */
-    if (fdcache != -1)			/* allow fdcache=0 in bootopts */
-	cache_size = fdcache<<1;	/* cache size is sectors, fdcache is k bytes */
-    else if (arch_cpu == 7)
-	cache_size = 0; 		/* sector cache is slowing down fast systems */
-    else cache_size = FD_CACHESEGSZ>>9;	/* use menuconfig value */
-
-    if (cache_size > (FD_CACHESEGSZ>>9)) cache_size = FD_CACHESEGSZ>>9;
+    cache_size = fdcache<<1;	/* cache_size is sectors, fdcache is Kbytes */
     printk("Floppy cache %dk, available %dk\n", cache_size>>1, FD_CACHESEGSZ>>10);
 	
 #endif

--- a/tlvc/include/linuxmt/mm.h
+++ b/tlvc/include/linuxmt/mm.h
@@ -8,7 +8,7 @@ struct segment {
 	list_s    all;
 	list_s    free;
 	seg_t     base;
-	segext_t  size;	/* paragraphs */
+	segext_t  size;		/* paragraphs */
 	byte_t    flags;
 	byte_t    ref_count;
 	word_t    pid;

--- a/tlvc/include/linuxmt/mm.h
+++ b/tlvc/include/linuxmt/mm.h
@@ -27,7 +27,7 @@ typedef struct segment segment_s;
 #define SEG_FLAG_FDAT	 0x04   /* app fmemalloc far data */
 #define SEG_FLAG_EXTBUF	 0x05   /* ext/main memory buffers */
 #define SEG_FLAG_RAMDSK	 0x06   /* ram disk buffers */
-#define DEG_FLAG_BUFHEAD 0x07	/* bufheads for ext/xms buffers */
+#define SEG_FLAG_BUFHEAD 0x07	/* bufheads for ext/xms buffers */
 
 #ifdef __KERNEL__
 


### PR DESCRIPTION
Another simplification/optimization of low memory usage as discussed in https://github.com/Mellvik/TLVC/pull/114#issuecomment-2543878716

OPTSEG is no longer released after boot, but instead reused as the floppy bounce buffer. Also, if there is a floppy cache in use, the setup_data segment (512b) is reused as part of that. Thus, there will in many cases not be anything to release from low memory after boot and overall memory usage is reduced.

Part of the update is to move processing of the `fdcache=` bootopts parameter from the `directfd` driver to `init/main.c` to ensure that the fdcache may be released as main memory if possible.  

The `meminfo` -M display has been adjusted accordingly, a simplification really because there are fewer variants to consider. Some variants have not been tested yet.