### PR TITLE
[kernel] Fix boot when both xd/mfm and directhd drivers are present

### DIFF
--- a/tlvc/arch/i86/drivers/block/ll_rw_blk.c
+++ b/tlvc/arch/i86/drivers/block/ll_rw_blk.c
@@ -247,7 +247,7 @@ static void make_request(unsigned short major, int rw, struct buffer_head *bh)
 	req->rq_buffer = buffer_data(bh);
     }
 #if DEBUG_ASYNC
-    if (debug_level) printk("\n|seg%lx:%04x|%cblk%d|BH%04x|dev%04x;", (unsigned long)buffer_seg(bh),
+    if (debug_level) printk("|seg%lx:%04x|%cblk%d|BH%04x|dev%04x;", (unsigned long)buffer_seg(bh),
 		buffer_data(bh), rw == READ ? 'R' : 'W',
 		(word_t)ebh->b_blocknr, (word_t)bh, (word_t)buffer_dev(bh));
 #endif
@@ -428,6 +428,10 @@ void INITPROC blk_dev_init(void)
     directhd_init();
 #endif
 
+#ifdef CONFIG_BLK_DEV_XD
+    xd_init();
+#endif
+
 #ifdef CONFIG_BLK_DEV_FD
     floppy_init();
 #endif
@@ -438,10 +442,6 @@ void INITPROC blk_dev_init(void)
 
 #ifdef CONFIG_ROMFS_FS
     romflash_init();
-#endif
-
-#ifdef CONFIG_BLK_DEV_XD
-    xd_init();
 #endif
 
 }

--- a/tlvc/arch/i86/drivers/block/xd.c
+++ b/tlvc/arch/i86/drivers/block/xd.c
@@ -420,7 +420,7 @@ static void setup_DMA(int nr_sectors)
 #pragma GCC diagnostic ignored "-Wshift-count-overflow"
     use_xms = req->rq_seg >> 16;
     physaddr = (req->rq_seg << 4) + (unsigned int)req->rq_buffer;
-    dma_addr = _MK_LINADDR(XD_BOUNCE_SEG, 0);
+    dma_addr = _MK_LINADDR(XD_BOUNCESEG, 0);
 
     use_bounce = 0;
     count = nr_sectors<<9;
@@ -448,7 +448,7 @@ static void setup_DMA(int nr_sectors)
     debug_xd("setupDMA ");
 
     if (use_bounce && req->rq_cmd == WRITE)
-	xms_fmemcpyw(0, XD_BOUNCE_SEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
+	xms_fmemcpyw(0, XD_BOUNCESEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
 
     debug_xd("%d/%lx;", count, dma_addr);
     clr_irq();
@@ -531,7 +531,7 @@ static void do_xdintr(int irq, struct pt_regs *regs)
 		 */
 		if (CURRENT->rq_cmd == READ && use_bounce)
 			xms_fmemcpyw(CURRENT->rq_buffer, CURRENT->rq_seg, 0,
-					XD_BOUNCE_SEG, BLOCK_SIZE/2);
+					XD_BOUNCESEG, BLOCK_SIZE/2);
 		i = 1;	/* iodone */
 			
 done:

--- a/tlvc/arch/i86/drivers/char/rxd.c
+++ b/tlvc/arch/i86/drivers/char/rxd.c
@@ -77,7 +77,7 @@ void INITPROC rxd_init(void)
     /* Device initialization done by the block driver, nothing required */
     if (register_chrdev(RAW_XD_MAJOR, "rxd", &rxd_fops))
 	printk("RXD: Unable to get major %d for raw disk devices\n", RAW_XD_MAJOR);
-    printk("rxd: Raw access to block devices configured\n");
+    //printk("rxd: Raw access to block devices configured\n");
 }
 
 #endif


### PR DESCRIPTION
Allows system to boot (mount the right root dev) when both xd/mfm and directhd drivers are compiled in.

A kernel can have both drivers compiled in, but the likelihood that both are present is minimal. Anyway, the IDE drive is chosen as the root drive if found during init. Otherwise xd is used.