### PR TITLE
[kernel] Experimental: seg_alloc allocates align1k requests from top

### DIFF
--- a/tlvc/arch/i86/mm/malloc.c
+++ b/tlvc/arch/i86/mm/malloc.c
@@ -25,8 +25,9 @@
 list_s _seg_all;
 static list_s _seg_free;
 
+#define ALLOW_TOPDWN_ALLOC
 
-// Split segment if enough large
+// Split segment if large enough
 
 static segment_s *seg_split(segment_s *s1, segext_t size0)
 {
@@ -34,8 +35,7 @@ static segment_s *seg_split(segment_s *s1, segext_t size0)
 
 	if (size2 >= SEG_MIN_SIZE) {
 
-		// TODO: use pool_alloc
-		segment_s * s2 = (segment_s *)heap_alloc (sizeof(segment_s), HEAP_TAG_SEG);
+		segment_s *s2 = (segment_s *)heap_alloc (sizeof(segment_s), HEAP_TAG_SEG);
 		if (!s2)
 			return 0;   // heap_alloc gives heap full message
 
@@ -45,8 +45,8 @@ static segment_s *seg_split(segment_s *s1, segext_t size0)
 		s2->ref_count = 0;
 		s2->pid = 0;
 
-		list_insert_after (&s1->all, &s2->all);
-		list_insert_after (&s1->free, &s2->free);
+		list_insert_after(&s1->all, &s2->all);
+		list_insert_after(&s1->free, &s2->free);
 
 		s1->size = size0;
 
@@ -63,18 +63,35 @@ static segment_s *seg_free_get(segext_t size0, word_t type)
 {
 	// First get the smallest suitable free segment
 
-	segment_s *best_seg = 0;
+	segment_s *seg, *best_seg = 0;
 	segext_t best_size = 0xFFFF;
 	list_s *n = _seg_free.next;
 	segext_t size00 = size0, incr = 0;
+#ifdef ALLOW_TOPDWN_ALLOC
 
-	while (n != &_seg_free) {
-		segment_s *seg = structof(n, segment_s, free);
+	if (type & SEG_FLAG_ALIGN1K) {	/* allocate from the top end, always 1kaligned */
+	    list_s *p = _seg_all.prev;
+	    while (p != &_seg_all) {
+		seg = structof(p, segment_s, all);
+		if (seg->flags == SEG_FLAG_FREE && seg->size >= size00) {
+		    best_seg = seg_split(seg, seg->size-size00); /* allocate lower seg */
+						/* ... which creates a new upper seg */
+		    goto OK;
+		}
+		p = seg->all.prev;
+	    }
+	} else
+#endif
+	{
+	    while (n != &_seg_free) {
+		seg = structof(n, segment_s, free);
 		segext_t size1 = seg->size;
 
+#ifndef ALLOW_TOPDWN_ALLOC
 		if (type & SEG_FLAG_ALIGN1K)
 			size00 = size0 + ((~seg->base + 1) & ((1024 >> 4) - 1));
-		if ((seg->flags == SEG_FLAG_FREE) && (size1 >= size00) && (size1 < best_size)) {
+#endif
+		if (/*(seg->flags == SEG_FLAG_FREE) &&*/ (size1 >= size00) && (size1 < best_size)) {
 			best_seg  = seg;
 			best_size = size1;
 			incr = size00 - size0;
@@ -82,18 +99,21 @@ static segment_s *seg_free_get(segext_t size0, word_t type)
 		}
 
 		n = seg->free.next;
+	    }
 	}
 
 	// Then allocate that free segment
 
 	if (best_seg) {
 		seg_split(best_seg, size00);			// split off upper segment
+#ifndef ALLOW_TOPDWN_ALLOC
 		if (incr)
 			best_seg = seg_split(best_seg, incr);	// split off lower segment
-
+#endif
+OK:
 		best_seg->flags = SEG_FLAG_USED | type;
 		best_seg->ref_count = 1;
-		list_remove (&(best_seg->free));
+		list_remove(&(best_seg->free));
 	}
 
 	return best_seg;
@@ -132,7 +152,7 @@ void seg_free(segment_s *seg)
 	//   - head if still alone to increase 'exact hit'
 	//     chance on next allocation of same size
 
-	list_s * i = &_seg_free;
+	list_s *i = &_seg_free;
 	seg->flags = SEG_FLAG_FREE;
 	seg->pid = 0;
 


### PR DESCRIPTION
This experimental change modifies the behaviour of `seg_alloc` to allocate requests with the SEG_FLAG_ALIGN1K from the top of conventional memory instead of from the bottom.

This has two distinct advantages: There is no need for alignment, `memend` is always aligned and requests asking for alignment are presumably aligned (this may be checked and enforced, it isn't right now). Also, this behaviour delivers less fragmentation because there are no small ('artificial') segments created to force alignment, and because the few cases where this is useful (right now it is Ramdisk and ext_buf, the former being allocated separately so it's not an issue) are permanent, there is no deallocation of the segment for the duration of the 'session'.

There is more code to cleanup if this turns out to work well. The final cost in terms of code is non-zero but small thanks to the simplification of the existing code.

The changes to `buffer.c` are mostly related to boot messages.