### PR TITLE
[kernel] Add configurable size kernel file & inode structures

### DIFF
--- a/tlvc/arch/i86/drivers/block/init.c
+++ b/tlvc/arch/i86/drivers/block/init.c
@@ -60,7 +60,7 @@ void INITPROC device_init(void)
 
     for (p = gendisk_head; p; p = p->next)
 	setup_dev(p);
-	    printk("boot_rootdev 0x%x, ", boot_rootdev);
+    //printk("boot_rootdev 0x%x, ", boot_rootdev);
 
     /*
      * The bootloader may have passed us a ROOT_DEV which is actually a BIOS

--- a/tlvc/fs/file_table.c
+++ b/tlvc/fs/file_table.c
@@ -19,7 +19,7 @@
  *            the system.
  */
 
-struct file file_array[NR_FILE];
+struct file *file_array;
 
 /*
  * Find an unused file structure and return a pointer to it.
@@ -34,7 +34,7 @@ int open_filp(unsigned short flags, struct inode *inode, struct file **fp)
     register struct file_operations *fop;
 
     while (f->f_count) {
-	if (++f >= &file_array[NR_FILE]) {	/* TODO: is nr_file const? */
+	if (++f >= &file_array[nr_files]) {
 	    printk("\nNo filps\n");
 	    return -ENFILE;
 	}

--- a/tlvc/include/linuxmt/config.h
+++ b/tlvc/include/linuxmt/config.h
@@ -35,15 +35,15 @@
 
 /* The following can be set for minimal systems or for QEMU emulation testing:
  * 10 buffers (@20 = 200), 2 ttyq (@80 = 160), 4k L1 cache, 512 heap free,
- * 10 tasks (@876 = 8760) = ~13728.
- * Use bufs=10 cache=4 tasks=10 in /bootopts
+ * 10 tasks (@876 = 8760), 64 inodes (@80 = 5120), 64 files (@14 = 896) = ~19744.
+ * Use buf=10 cache=4 task=10 inode=64 file=64  in /bootopts
  */
 #if defined(CONFIG_HW_MK88)
-#define SETUP_HEAPSIZE            13728         /* force kernel heap size */
+#define SETUP_HEAPSIZE		19744	/* force kernel heap size */
 #endif
 //#undef SETUP_MEM_KBYTES
-//#define SETUP_MEM_KBYTES        256     /* force available memory in 1K bytes */
-//#define SETUP_MEM_KBYTES_ASM    SETUP_MEM_KBYTES
+//#define SETUP_MEM_KBYTES	256	/* force available memory in 1K bytes */
+//#define SETUP_MEM_KBYTES_ASM	SETUP_MEM_KBYTES
 
 #endif /* CONFIG_ARCH_IBMPC */
 

--- a/tlvc/include/linuxmt/fs.h
+++ b/tlvc/include/linuxmt/fs.h
@@ -426,11 +426,14 @@ extern struct inode_operations pipe_inode_operations;
 extern struct inode_operations sock_inode_operations;
 #endif
 
+extern int nr_inodes;
+extern int nr_files;
+
 extern int fs_may_mount(kdev_t);
 extern int fs_may_umount(kdev_t,struct inode *);
 extern int fs_may_remount_ro(kdev_t);
 
-extern struct file file_array[];
+extern struct file *file_array;
 extern struct super_block super_blocks[];
 
 extern void invalidate_inodes(kdev_t);

--- a/tlvc/init/main.c
+++ b/tlvc/init/main.c
@@ -251,7 +251,8 @@ static void INITPROC kernel_banner(seg_t start, seg_t end, seg_t init, seg_t ext
     printk("8018X machine, ");
 #endif
 
-    printk("syscaps 0x%x, %uK base ram, %d tasks.\n", sys_caps, SETUP_MEM_KBYTES, max_tasks);
+    printk("syscaps 0x%x, %uK base ram, %d tasks, %d files, %d inodes\n",
+	    sys_caps, SETUP_MEM_KBYTES, max_tasks, nr_files, nr_inodes);
     printk("TLVC %s (%u text, %u ftext, %u data, %u bss, %u heap)\n",
            system_utsname.release,
            (unsigned)_endtext, (unsigned)_endftext, (unsigned)_enddata,
@@ -588,6 +589,14 @@ static int INITPROC parse_options(void)
 		}
 		if (!strncmp(line,"tasks=", 6)) {
 			max_tasks = (int)simple_strtol(line+6, 10);
+			continue;
+		}
+		if (!strncmp(line,"inodes=",7)) {
+			nr_inodes = (int)simple_strtol(line+7, 10);
+			continue;
+		}
+		if (!strncmp(line,"files=",6)) {
+			nr_files = (int)simple_strtol(line+6, 10);
 			continue;
 		}
 		if (!strncmp(line,"comirq=", 7)) {

--- a/tlvccmd/rootfs_template/bootopts
+++ b/tlvccmd/rootfs_template/bootopts
@@ -15,12 +15,13 @@ comirq=,,7,10		# IRQ for com ports, up to 4
 cache=6			# L1 cache
 bufs=40			# L2 buffers
 xmsbufs=200		# if supported
+#files=64 inodes=96
 hdparms=306,4,17,128,614,4,17,-1 # CHSW values for 2 drives, overrides CMOS and drive values
 netbufs=2,0	# netw buffers, recv/trans, ne2k only
-tasks=12	# max tasks, default 16, max 20
+tasks=14	# max tasks, default 16, max 20
 sync=30		# autosync secs
-xtflpy=3,1	# meaningful for XT systems w/720k drive(s) (type3)
-fdcache=8	# floppy sector cache, for slow systems <= 286
+#xtflpy=3,1	# meaningful for XT systems w/720k drive(s) (type3)
+fdcache=5	# floppy sector cache, for slow systems <= 286
 #xtide=0x300,,,,, # Set addr, IRQ, flgs for 2 XT-IDE drives
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell

--- a/tlvccmd/rootfs_template/bootopts
+++ b/tlvccmd/rootfs_template/bootopts
@@ -14,11 +14,14 @@ ee0=11,0x360,,0x80
 comirq=,,7,10		# IRQ for com ports, up to 4
 cache=6			# L1 cache
 bufs=40			# L2 buffers
-xmsbufs=200		# if supported
-#files=64 inodes=96
+xmsbufs=0		# if supported
+heap=30			# set max heap (k bytes)
+memsize=640		# set system RAM size, k bytes
+#tasks=6 bufs=2 cache=12 files=20 inodes=24 heap=20 n # very compact
+files=64 inodes=96
 hdparms=306,4,17,128,614,4,17,-1 # CHSW values for 2 drives, overrides CMOS and drive values
 netbufs=2,0	# netw buffers, recv/trans, ne2k only
-tasks=14	# max tasks, default 16, max 20
+tasks=18	# max tasks, default 16, max 20
 sync=30		# autosync secs
 #xtflpy=3,1	# meaningful for XT systems w/720k drive(s) (type3)
 fdcache=5	# floppy sector cache, for slow systems <= 286

--- a/tlvccmd/rootfs_template/bootopts
+++ b/tlvccmd/rootfs_template/bootopts
@@ -15,15 +15,15 @@ comirq=,,7,10		# IRQ for com ports, up to 4
 cache=6		# L1 cache
 bufs=40		# L2 buffers
 xmsbufs=0	# if supported
-#heap=30	# set max heap (k bytes)
-#memsize=640	# set system RAM size, k bytes
+#heap=30	# max heap (kB)
+#memsize=640	# system RAM (kB)
 files=64 inodes=96
 hdparms=306,4,17,128,614,4,17,-1 # CHSW values for 2 drives, overrides CMOS and drive values
-netbufs=2,0	# netw buffers, recv/trans, ne2k only
+#netbufs=2,0	# netw buffers, recv/trans, ne2k only
 tasks=18	# max tasks, default 16, max 20
 sync=30		# autosync secs
 #xtflpy=3,1	# meaningful for XT systems w/720k drive(s) (type3)
-fdcache=5	# floppy sector cache, for slow systems <= 286
-#xtide=0x300,,,,, # Set addr, IRQ, flgs for 2 XT-IDE drives
+fdcache=5	# floppy read cache for slow systems <= 286
+#xtide=0x300,,,,, # addr, IRQ, flgs for 2 XT-IDE drives
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell

--- a/tlvccmd/rootfs_template/bootopts
+++ b/tlvccmd/rootfs_template/bootopts
@@ -12,12 +12,11 @@ wd0=2,0x280,0xCC00,0x80
 #3c0=11,0x330,,0x80
 ee0=11,0x360,,0x80
 comirq=,,7,10		# IRQ for com ports, up to 4
-cache=6			# L1 cache
-bufs=40			# L2 buffers
-xmsbufs=0		# if supported
-heap=30			# set max heap (k bytes)
-memsize=640		# set system RAM size, k bytes
-#tasks=6 bufs=2 cache=12 files=20 inodes=24 heap=20 n # very compact
+cache=6		# L1 cache
+bufs=40		# L2 buffers
+xmsbufs=0	# if supported
+#heap=30	# set max heap (k bytes)
+#memsize=640	# set system RAM size, k bytes
 files=64 inodes=96
 hdparms=306,4,17,128,614,4,17,-1 # CHSW values for 2 drives, overrides CMOS and drive values
 netbufs=2,0	# netw buffers, recv/trans, ne2k only


### PR DESCRIPTION
The size of the kernel file and inode tables are now configurable via the new `inodes=` and `files=` parameters in `/bootopts`. Along with the formerly introduced `tasks=` parameter, this addition makes it easier to tune the system to actual usage and available resources (memory in particular). 

When not present, the values default to the settings in `linuxmt/config.h` which traditionally have been 64 for files and 96 for inodes.

A minimal configuration for a system short on memory would be
`tasks=6 bufs=8 cache=4 files=20 inodes=24`

In order for a configuration this tight to complete startup properly, add `n` by itself to `bootopts` to prevent `/etc/rc.sys` from running.

Also included is a more detailed output from the boot process indicating the max # of tasks, files and inodes in the running system:
`PC/AT class, cpu 7, syscaps 0xff, 639K base ram, 14 tasks, 64 files, 96 inodes`

This improvement is lifted from ELKS: https://github.com/ghaerr/elks/pull/1987#issue-2501810174 and https://github.com/ghaerr/elks/pull/1840#issue-2213809481 -- thanks @ghaerr.