### PR TITLE
[kernel] Make bootopts processing more robust

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -15,6 +15,17 @@ all: .config include/autoconf.h
 	$(MAKE) -C tlvccmd all
 	$(MAKE) -C image all
 
+image:
+	$(MAKE) -C image
+
+images:
+	$(MAKE) -C image images
+
+kimage: kernel image
+
+kernel:
+	$(MAKE) -C tlvc
+
 kclean:
 	$(MAKE) -C tlvc kclean
 

--- a/tlvc/arch/i86/kernel/strace.c
+++ b/tlvc/arch/i86/kernel/strace.c
@@ -156,13 +156,12 @@ void trace_begin(void)
  */
 void trace_end(unsigned int retval)
 {
-    __ptask currentp = current;
     int n;
     static int max;
 
     /* Check for kernel stack overflow */
-    if (currentp->kstack_magic != KSTACK_MAGIC) {
-        printk("KSTACK(%d) KERNEL STACK OVERFLOW\n", current->pid);
+    if (current->kstack_magic != KSTACK_MAGIC) {
+        printk("KSTACK(%P) KERNEL STACK OVERFLOW\n");
         do_exit(SIGSEGV);
     }
 

--- a/tlvc/fs/buffer.c
+++ b/tlvc/fs/buffer.c
@@ -197,12 +197,6 @@ int INITPROC buffer_init(void)
     if (xms_enabled)
         bufs_to_alloc = nr_xms_bufs;
 #endif
-#if 0	/* Now handled in init/main.c */
-    if (!bufs_to_alloc) {
-	bufs_to_alloc = nr_map_bufs; 	/* avoid crash if bufs=0 */
-	printk("Warning: L2-buffers cannot be 0, set equal to cache size\n");
-    }
-#endif
 #ifdef CONFIG_FAR_BUFHEADS
     if (bufs_to_alloc > 2975) bufs_to_alloc = 2975; /* max 64K far bufheads @22 bytes*/
 #else

--- a/tlvc/init/main.c
+++ b/tlvc/init/main.c
@@ -687,8 +687,8 @@ static void INITPROC finalize_options(void)
 
 	/* convert argv array to stack array for sys_execv */
 	if (strchr(init_command, 'h')) /* quick check for any shell */
-	    while (args > 1) argv_init[args--] = NULL;
-	    //args = 1; 	/* delete args if not running init */
+	    while (args > 1)	/* delete args if not running init */
+		argv_init[args--] = NULL;
 	else
 	    args--;
 	argv_init[0] = (char *)args;		/* 0 = argc */

--- a/tlvc/init/main.c
+++ b/tlvc/init/main.c
@@ -314,6 +314,8 @@ static void INITPROC do_init_task(void)
         current->ppid = 1;      /* turns off auto-child reaping */
 
     /* run /bin/init or init= command, normally no return */
+    if (strchr(init_command, 'h')) 
+	argv_init[2] = NULL; 	/* don't confuse /bin/sh w/cmd line args! */
     run_init_process_sptr(init_command, (char *)argv_init, argv_slen);
 #else
     try_exec_process(init_command);
@@ -571,7 +573,8 @@ static int INITPROC parse_options(void)
 			continue;
 		}
 		if (!strncmp(line,"bufs=", 5)) {
-			nr_ext_bufs = (int)simple_strtol(line+5, 10);
+			int n = (int)simple_strtol(line+5, 10);
+			if (n) nr_ext_bufs = n;	/* keep default if 0 */
 			continue;
 		}
 		if (!strncmp(line,"cache=", 6)) {


### PR DESCRIPTION
Fixes two problems in system startup processing:

- If the system boots into a shell, `argv` is zeroed to avoid the shell trying to execute parameters meant for `init`
- If the `bufs=` parameter is set to zero, it's ignored and startup is using the config-value instead. This takes care of the case when external buffers are configured and `bufs` set to zero, which would hang the system.

Also, while testing this, a compile time error in `trace.c` was uncovered and fixed. ^O buffer status trace now works again.