### PR TITLE
[cmds] Another meminfo update

### DIFF
--- a/tlvc/arch/i86/kernel/system.c
+++ b/tlvc/arch/i86/kernel/system.c
@@ -41,13 +41,14 @@ unsigned int INITPROC setup_arch(void)
 	/* Heap allocations at even addresses */
 	endbss = (unsigned int)(_endbss + 1) & ~1;
 
-	/* Calculate size of heap, which extends end of kernel data segment */
+	/* Calculate or set size of heap which - unless set specifically,
+	 * extends to the end of end of the kernel DS */
 
-#ifdef SETUP_HEAPSIZE
-	if (!heapsize)          /* may also be set via heap= in /bootopts */
+#ifdef SETUP_HEAPSIZE		/* MK88 only */
+	if (!heapsize)
 	    heapsize = SETUP_HEAPSIZE;
 #endif
-	if (heapsize) {
+	if (heapsize) {			/* may be set via heap= in /bootopts */
             heapsegs = (1 + ~endbss) >> 4;  /* max possible heap in segments */
             if ((heapsize >> 4) < heapsegs) /* allow if less than max */
         	heapsegs = heapsize >> 4;
@@ -57,7 +58,7 @@ unsigned int INITPROC setup_arch(void)
            membase = kernel_ds + 0x1000;
            heapsize = 1 + ~endbss;
 	}
-	//debug("endbss %x heap %x kdata size %x\n", endbss, heapsize, (membase-kernel_ds)<<4);
+	//debug("endbss %x heap %x kdata size %lx\n", endbss, heapsize, (long_t)(membase-kernel_ds)<<4);
 
 	if (!memend) 				/* bootopts setting overrides */
 		memend = SETUP_MEM_KBYTES << 6;

--- a/tlvccmd/sys_utils/meminfo.c
+++ b/tlvccmd/sys_utils/meminfo.c
@@ -350,7 +350,7 @@ void mem_map(void)
 	} else {	/* we have a released segment, figure out size and show */
 	    char *type;
 	    if (start - segs[i].base <= 0x40)
-		type = "[setup data]";
+		type = "[setup-data]";
 	    else
 		type = "[Unused FDcache]";
 	    p_block(1, (long_t)(segs[i].end-segs[i].base)<<4, type, main_msg);


### PR DESCRIPTION
`meminfo` will now show external buffers - if present - as a visible block in main memory with the `-P` and `-M` options.

Likewise, the assumption that the kernel DS segment always totals to 64k is gone, variable kernel heaps display correctly when the graphic options are used.

Plus some adjustments.