### PR TITLE
[cmds] Update and enhance the fdisk command

### DIFF
--- a/tlvccmd/man/man8/fdisk.8
+++ b/tlvccmd/man/man8/fdisk.8
@@ -2,21 +2,56 @@
 .SH NAME
 fdisk \- create or update a partition table on a hard disk or SSD device
 .SH SYNOPSIS
-\fBfdisk\fR [\fB\-l\fR] [\fIfile\fR]
+\fBfdisk\fR [\fB\-l\fR] [\fB\-q\fR] [\fB\-g c/h/s\fR] [\fIfile\fR]
 .br
 .SH OPTIONS
 .TP 5
 .B \-l
 list the partition table and exit.
+.TP 5
+.B \-q
+quiet, don't print warnings.
+.TP 5
+.B -g c/h/s
+use this drive geometry (cyliders/heads/sectors). Useful only if 
+.B file
+is a plain image file, not a device. Geometry is automatically read off disk drives. Use the
+.I hdparm=
+setting in the 
+.I bootopts 
+file to manipulate the geometry of hard drives.
 .SH DESCRIPTION
 .PP
-When \fBfdisk\fR starts up, it reads in the partition table from 
+When \fBfdisk\fR starts up, it validates the 
+.B file
+argument if present, then reads in the partition table from 
 .BR file ,
 or - if no 
 .B file
-was specified, from the currently booted drive. If the boot drive is a floppy,
+was specified, from the currently booted drive. 
+.PP
+.B Fdisk
+will exit with an error message if 
+.B file
+or the booted drive is a floppy.
+.B File
+must be a raw (character) device unless it's a plain file. If 
+.B fdisk 
+uses the booted drive, it is converted to raw automatically before opening. The raw restriction
+does not apply if the program is compiled with the 
+.I CONFIG_BLK_DEV_BIOS
+define.
+.PP
+Image files are treated like devices, but should be accompanied by the 
+.B \-g
+c/h/s option to define the geomerty. If not present, the geometry will be guessed
+from the existing partiton table, which may or may not give correct results.
+If the partition table is empty or the MBR signature missing,
+the
+.B \-g
+option is mandatory, and 
 .B fdisk
-will fail and exit.
+will exit if it's missing.
 .PP
 Unless the 
 .B -l
@@ -48,10 +83,11 @@ command.
 .TP 10
 elks17# \fBfdisk\fP
 .nf
-Geometry: 7818 cylinders, 16 heads, 63 sectors.
+[/dev/rdhdb] Geometry: 7818 cylinders, 16 heads, 63 sectors.
 Command (? for help):
 .fi
-.R Fdisk 
+.LP
+.B Fdisk 
 enters interactive mode.
 .TP 10
 elks17# \fBfdisk -l\fP
@@ -64,7 +100,7 @@ Device      #:ID   Cyl Head Sect    Cyl Head Sect  Start   Size
 /dev/hda3   3:00     0    0    0      0    0    0      0      0
 /dev/hda4   4:80   332    0    1     432   15   63 7560000 101808
 .fi
-
+.LP
 .B Fdisk 
 lists the partition table, the asterisk in the ID-column indictating an active
 partition.


### PR DESCRIPTION
A significant update/enhancement to `fdisk`:
Planned as just an update to force `fdisk` to use raw devices, but it turned into a lot more:

- Regular (image) files are now acceptable targets for `fdisk` - see below.
- The target device/file is now `stat`ed early on to determine the optimal course of action: 
    - Reject floppy devices (using major device number) and block devices - unless CONFIG_BLK_DEV_BIOS is set - and to determine device type (or plain file).
    - Hard disks must be raw devices - again unless CONFIG_BLK_DEV_BIOS is set. If `fdisk` is using the ROOTDEV (no device on the command line), the name is changed into the corresponding raw device.
- Warnings are issued if no MBR is found and when the 'device' is a plain file. Warnings may be suppressed via the `-q` option. 
- `fdisk` can now operate on plain files, and can initialize a file if it has no MBR if the new `-g` (geometry) flag is used: `-g c/h/s` to set the geometry. This is a simplification of the 'big' Linux variant using `-C`, `-H`, `-S` for the same purpose. It could easily have created the file too, but `dd` manages that task more than adequately.
- If an image file has an MBR already, the geometry is determined (guessed) from the partition table unless the `-g` option is used, which is more reliable. If there is no MBR, a missing ´-g` option is an error and will cause termination.
- The _cylinder_ value of the geometry specification is really superfluous since the size of the file is easily available. It does, however, provide some extra flexibility at minimal  cost. The cylinder value is sainty checked against the size and adjusted if too large. The heads and sectors values are not sanity checked.
- Using the geometry option when the target is a device is not allowed since the geometry is obtained from the device itself. If there is a need to override the device data, the `hdparm=` setting in `bootopts` should be used.

The practical value of being able to work with image files is limited at this point, and was inspired by the fact that the `usage()` message in the original program mentioned it (`disk_device_or_image`) - and subsequently that its implementation turned out to be rather trivial. Whenever loopback volumes become supported, the ability to treat files may come in handy. 

An updated man page is part of this PR.