### PR TITLE
[cmds, tools] System tools require raw devices, more etools

### DIFF
--- a/tlvc/tools/Makefile
+++ b/tlvc/tools/Makefile
@@ -35,6 +35,9 @@ all:
 	$(MAKE) -C elf2elks all
 	$(MAKE) -C elks-compress all
 	$(MAKE) -C eman all
+	$(MAKE) -C efdisk all
+	$(MAKE) -C emkfat all
+#	$(MAKE) -C emkfs all
 
 
 #########################################################################

--- a/tlvc/tools/efdisk/Makefile
+++ b/tlvc/tools/efdisk/Makefile
@@ -1,0 +1,52 @@
+# efdisk - manipulate partition tables in MBR on hard disks and 
+#	   image files
+#
+#########################################################################
+#
+# Note! Dependencies are done automagically by 'make dep', which also
+# removes any old dependencies. DON'T put your own dependencies here
+# unless it's something special (ie not a .c file).
+#
+#########################################################################
+# Relative path to base directory.
+
+BASEDIR 	= ../..
+
+#########################################################################
+# Define the variables required by the standard rules - see the standard
+# rules file (below) for details of these variables.
+
+USEBCC 		= N
+
+CLEANDEP	=
+
+CLEANME 	= ../bin/efdisk
+
+DEPEND  	=
+
+DISTFILES	=
+
+NOINDENT	=
+
+#########################################################################
+# Include standard commands.
+
+include $(BASEDIR)/Makefile-rules
+
+#########################################################################
+# Objects to be compiled.
+
+SRCS=$(TOPDIR)/tlvccmd/disk_utils/fdisk.c
+
+#OBJS=$(SRCS:.c=.o)
+
+#########################################################################
+# Commands.
+
+all:	../bin/efdisk
+
+../bin/efdisk: $(SRCS)
+	$(CC) -o ../bin/efdisk $(CFLAGS) $(SRCS)
+
+#########################################################################
+### Dependencies:

--- a/tlvc/tools/emkfat/Makefile
+++ b/tlvc/tools/emkfat/Makefile
@@ -1,0 +1,51 @@
+# emkfat - create FAT 16 or 32 file system
+#
+#########################################################################
+#
+# Note! Dependencies are done automagically by 'make dep', which also
+# removes any old dependencies. DON'T put your own dependencies here
+# unless it's something special (ie not a .c file).
+#
+#########################################################################
+# Relative path to base directory.
+
+BASEDIR 	= ../..
+
+#########################################################################
+# Define the variables required by the standard rules - see the standard
+# rules file (below) for details of these variables.
+
+USEBCC 		= N
+
+CLEANDEP	=
+
+CLEANME 	= ../bin/emkfat
+
+DEPEND  	=
+
+DISTFILES	=
+
+NOINDENT	=
+
+#########################################################################
+# Include standard commands.
+
+include $(BASEDIR)/Makefile-rules
+
+#########################################################################
+# Objects to be compiled.
+
+SRCS=$(TOPDIR)/tlvccmd/disk_utils/mkfat.c
+
+#OBJS=$(SRCS:.c=.o)
+
+#########################################################################
+# Commands.
+
+all:	../bin/emkfat
+
+../bin/emkfat: $(SRCS)
+	$(CC) -o ../bin/emkfat $(CFLAGS) $(SRCS)
+
+#########################################################################
+### Dependencies:

--- a/tlvccmd/disk_utils/fdisk.c
+++ b/tlvccmd/disk_utils/fdisk.c
@@ -379,7 +379,8 @@ void list_partition(char *devname)
 	unsigned long nr_sects = p->nr_sects | ((unsigned long)p->nr_sects_hi << 16);
 	char device[32];
 	strcpy(device, devname? devname: dev);
-	if (device[0] == '/') {
+	if (is_file) device[0] = 0;		/* no device names if image file */
+	else if (device[0] == '/') {
 		char *p = &device[strlen(device)];
 		*p++ = '1' + i;
 		*p = 0;

--- a/tlvccmd/disk_utils/fsck.c
+++ b/tlvccmd/disk_utils/fsck.c
@@ -56,7 +56,7 @@
  *	-f force filesystem check even if filesystem marked as valid
  *
  * The device may be a block device or a image of one, but this isn't
- * enforced (but it's not much fun on a character device :-).
+ * enforced.
  */
 
 #include <stdio.h>
@@ -903,6 +903,7 @@ int main(int argc, char ** argv)
 	int count;
 	int retcode = 0;
 	struct termios termios,tmp;
+	struct stat sbuf;
 
 	if (argc && *argv)
 		program_name = *argv;
@@ -929,6 +930,14 @@ int main(int argc, char ** argv)
 	}
 	if (!device_name)
 		usage();
+	if (stat(device_name, &sbuf)) {
+		printf("Cannot stat %s\n", device_name);
+		usage();
+	}
+#ifndef CONFIG_BLK_DEV_BIOS
+	if (!S_ISREG(sbuf.st_mode) && !S_ISCHR(sbuf.st_mode)) 
+		die("Raw device or image file required");
+#endif
 	if (repair && !automatic) {
 		if (!isatty(0) || !isatty(1))
 			die("need terminal for interactive repairs");

--- a/tlvccmd/disk_utils/mkfs.c
+++ b/tlvccmd/disk_utils/mkfs.c
@@ -314,10 +314,15 @@ int main(int argc, char ** argv)
 		die("unable to open device");
 	if (fstat(DEV,&statbuf)<0)
 		die("unable to stat %s");
+#ifndef CONFIG_BLK_DEV_BIOS
+	if (!S_ISREG(statbuf.st_mode) && !S_ISCHR(statbuf.st_mode))
+		die("Image file or raw device required");
+#endif
 	if (!(buf = malloc(512))) 
 		die("Cannot malloc buffer memory"); 
 	if (((BLOCKS -1)<<10) > statbuf.st_size) {
-		printf("Requested blockcount (%lu) exceeds device size (%lu)\n", BLOCKS, statbuf.st_size);
+		printf("Requested blockcount (%lu) exceeds device size (%lu)\n", 
+			BLOCKS, statbuf.st_size);
 		exit(-1);
 	}
 

--- a/tlvccmd/man/man8/fsck.8
+++ b/tlvccmd/man/man8/fsck.8
@@ -2,7 +2,7 @@
 .SH NAME
 fsck \- perform filesystem consistency check
 .SH SYNOPSIS
-\fBfsck\fR [\fB\-aflrsvw\fR]\fR [\fIdevice\fR] ...\fR
+\fBfsck\fR [\fB\-aflrsvw\fR]\fR [\fIdevice\fR]
 .br
 .SH OPTIONS
 .TP 5
@@ -28,62 +28,82 @@ Turn on verbose mode
 Warn about inodes that can't be cleared
 .SH EXAMPLES
 .TP 25
-.B fsck /dev/hda1
-# Check filesystem on \fI/dev/hda1\fR
+.B fsck /dev/rdhda1
+# Check filesystem on \fI/dev/rdhda1\fR
 .TP 25
-.B fsck \-a /dev/fd1
-# Automatically fix errors on \fI/dev/fd1\fR
+.B fsck \-a /dev/rdf1
+# Automatically fix errors on \fI/dev/rdf1\fR
 .TP 25
-.B fsck \-l /dev/fd0
-# List the contents of \fI/dev/fd0\fR
+.B fsck \-l /dev/rdf0
+# List the contents of \fI/dev/rdf0\fR
 .TP 25
-.B fsck \-c 2 3 /dev/hda2
-# Check and list \fI/dev/hda2\fR i-nodes 2 & 3
+.B fsck \-avf /dev/rdf1
+# Force file system check, automatic repair and verbose output on \fI/dev/rdf0\fR
+.nf
+tlvc16# fsck -avf /dev/rdf1
+Forcing filesystem check on /dev/rdf1.
+
+   112 inodes used (88%)
+   322 zones used (89%)
+
+    49 regular files
+     8 directories
+    40 character device files
+    15 block device files
+     0 links
+     0 symbolic links
+------
+   112 files
+tlvc16#
+.fi
 .SH DESCRIPTION
 .PP
-\fIFsck\fR performs consistency checks on the filesystems which reside 
-on the specified devices. Without options,
+\fIFsck\fR performs consistency checks on the filesystem residing 
+on the specified device. Unless the system is using BIOS IO, the device 
+must be a character (raw) device.
+.PP
+Without options,
 .IR fsck
 checks and reports but makes noe changes.
 When either the \fB\-a\fR or \fB\-r\fR flags are given, the filesystem
-will be repaired if errors are found. In the absence of the \fB\-a\fR flag, the user will be prompted for
-every error found. Entering a newline (or a 'y') means 'yes', 'n' means 'no' and 'a' means 'activate automatic mode'
-and \fIfsck\fR will continue as if the \fB\-a\fR flag was present: Fix errors without asking. Responses
-are case-insensitive.
+will be repaired if errors are found. In the absence of the \fB\-a\fR flag, the
+user will be prompted for
+every error found. Entering a newline (or a 'y') means 'yes', 'n' means 'no' and 'a'
+means 'activate automatic mode'
+and \fIfsck\fR will continue as if the \fB\-a\fR flag was present: Fix errors without asking.
+Responses are case-insensitive.
 .PP
 When a filesystem is unmounted cleanly, its superblock is marked as such and 
 .IR fsck
-will simply report that the filesystem is clean and exit. 
+will simply exit siliently unless the \fB\-v\fR option is present.
 A complete check may still be performed by specifying the
 \fR\-f\fR option.
 .PP
 The normal case is for 
 .IR fsck
-to run silently. If no errors are found, it just exits. Adding the \fR\-v\fR option activates verbose mode 
-and 
+to run silently. If no errors are found, it just exits.
+Adding the \fR\-v\fR option activates verbose mode and 
 .IR fsck
-will report statisics about the filesystem.
+will report statistics about the filesystem if checked, otherwise that it was 
+clean and not check was required.
 .PP
-Before running \fIfsck\fR on a mounted filesystem, it must first be unmounted.
-Trying to repair a mounted filesystem is dangerous and should not be 
-attempted.
+.I Fsck
+should always be run on unmounted filesystems.
+Running it on a mounted filesystem is generally meaningless because the filesystem is likely
+to be modified while \fIfsck\fR runs. Modifying a mounted filsystem is outright dangerous and
+will likely cause filesystem damage and system crash. 
 .PP
 To repair the root filesystem (which cannot be unmounted), first 
 kill any and all processes. 
 Type \fIsync\fR to force any buffered changes to disk,
-run \fIfsck\fR on the root filesystem and immediately reboot the
-computer by typing \fIreboot\fR.
+run \fIfsck\fR with the appropriate options on the root filesystem and immediately reboot the
+computer via the \fIreboot\fR command.
 .PP
 It is necessary to kill all processes before repairing the root filesystem
 to prevent them from modifying any disk blocks while \fIfsck\fR is running.
 This is only necessary for the root filesystem, any other filesystem can
 simply be unmounted before it is checked.
 .SH BUGS
-.IR fsck
-needs significant amounts of memory to run and may fail with a 'no memory' error if the system is short on memory. It is advisable to run
-.IR fsck
-early in the system startupå process in order to avoid such problems.
-.PP
 .IR fsck
 works with minix version 1 filesystems only. The maximum supported filesystem size is 64MB.
 .SH "SEE ALSO"

--- a/tlvccmd/man/man8/makeboot.8
+++ b/tlvccmd/man/man8/makeboot.8
@@ -7,7 +7,7 @@ makeboot \- prepare device as a system boot device
 .SH OPTIONS
 .TP 5
 .B \-M
-Write the ELKS MBR (Master Boot Record) to the first sector of the specified device.
+Write the TLVC MBR (Master Boot Record) to the first sector of the specified device.
 .TP 5
 .B \-F
 Create a 'flat' (unpartitioned) device. 
@@ -22,28 +22,28 @@ Copy system files from the current root to the target device.
 Copy the bootblock from the current root partition to \fB/dev/hda4\fP:
 .sp
 .nf
-# makeboot /dev/hda4
-System on /dev/hda1: Minix (CHS 7818/16/63 at offset 63)
-Target on /dev/hda4: Minix (CHS 7818/16/63 at offset 7560000)
+# makeboot /dev/rdhda4
+System on /dev/rdhda1: Minix (CHS 7818/16/63 at offset 63)
+Target on /dev/rdhda4: Minix (CHS 7818/16/63 at offset 7560000)
 Bootblock written
 .fi
 .TP 5
-Write the ELKS MBR til the specified device:
+Write the TLVC MBR til the specified device:
 .sp
 .nf
-# makeboot \-M /dev/hda4
-Writing MBR on /dev/hda
+# makeboot \-M /dev/rdhda4
+Writing MBR on /dev/rdhda
 .fi
 .sp
-Notice that while a partition (/dev/hda4) is specified on the command line, 
+Notice that while a partition (/dev/rdhda4) is specified on the command line, 
 .B makeboot
-changes that into a device (/dev/hda) since that's where the MBR goes.
+changes that into a device (/dev/rdhda) since that's where the MBR goes.
 .TP 5
-Replace the bootblock on \fB/dev/hda4\fP with the one in \fB./minix.bin\fP and copy system files to the target partition.
+Replace the bootblock on \fB/dev/rdhda4\fP with the one in \fB./minix.bin\fP and copy system files to the target partition.
 .sp
 .nf
 # makeboot \-s \-f ./minix.bin /dev/hda4
-Target on /dev/hda4: Minix (CHS 7818/16/63 at offset 7560000)
+Target on /dev/rdhda4: Minix (CHS 7818/16/63 at offset 7560000)
 Bootblock written
 Copying /linux to /tmp/mnt/linux
 Copying /bootopts to /tmp/mnt/bootopts
@@ -52,8 +52,8 @@ System copied
 .SH DESCRIPTION
 \fBmakeboot\fR prepares a device or partition for booting by installing a 
 bootloader and \- if the \fB-s\fP option is present \- some system files.
-The partition or device must already contain a file system, which may be either FAT (MSDOS) 
-or Minix.
+The partition or device must must be a raw (character) device and already contain
+a file system, which may be either FAT (MSDOS) or Minix.
 .PP
 Without options, a bootblock is copied from the current root device to the target. 
 A different bootblock may be specifying via the \fB-f\fP option, see examples above.
@@ -62,33 +62,33 @@ Such transfer requires that the running system and the target has the same file 
 will complain and exit if this is not the case.
 .PP
 If the 
-.B -s
-option is present, the ELKS kernel (\fI/linux\fR) and the kernel configuration file 
+.B \-s
+option is present, the TLVC kernel (\fI/linux\fR) and the kernel configuration file 
 .I /bootopts
 will be copied to the target.
 .PP
 The 
-.B -M
+.B \-M
 option may be used to write a Master Boot Record (MBR) to the target device. The 
 MBR will preserve the partition information currently present in the first sector of the target device.
 This operation is similar to the MSDOS 
 'fdisk /MBR' command.
 Refer to the
-.BR MBR (8)
-manpage for details about the ELKS MBR.
+.BR MBR (5)
+manpage for details about the TLVC MBR.
 .PP
 .B makeboot
-also supports 'flat devices' - aka unpartitioned devices. While lloppies are always unpartitioned,
-hard sisks usually have partitions and a Master Boot Record. By writing the 
+also supports 'flat devices' - aka unpartitioned devices. While floppies are always unpartitioned,
+hard disks usually have partitions and a Master Boot Record. By writing the 
 .I bootblock 
 to the first sector(s) of the disk, the entire disk becomes a single partition. The
-.I -F
+.I \-F
 option does this.
 .PP
 .B makeboot
 is used by the 
-.B sys
-command to build a fully pouplated and bootable ELKS system from floppy or from another disk.
+.BR sys (8)
+command to build a fully pouplated and bootable TLVC system from floppy or from another disk.
 .PP
 \fBfloppy\fP:
 on the specified devices.
@@ -98,7 +98,8 @@ cannot replace the MBR on the current root device.
 .SH "SEE ALSO"
 .BR sys (8),
 .BR mkfs (8),
-.BR minix (8),
-.BR FAT (8),
-.BR MBR (8),
+.BR mkfat (8),
+.BR minix (5),
+.BR FAT (5),
+.BR MBR (5),
 .BR boot (8).

--- a/tlvccmd/man/man8/mkfs.8
+++ b/tlvccmd/man/man8/mkfs.8
@@ -1,4 +1,4 @@
-.TH MKFS 9
+.TH MKFS 8
 .SH NAME
 mkfs \- make a MINIX file system
 .SH SYNOPSIS
@@ -6,11 +6,14 @@ mkfs \- make a MINIX file system
 .I device blocks
 .SH EXAMPLES
 .TP 20
-.B mkfs /dev/fd1 1440
-# Make a file system on \fI/dev/fd1\fR
+.B mkfs /dev/rdf1 1440
+# Make a file system on \fI/dev/rdf1\fR
 .TP 20
-.B mkfs /dev/fd1 360
+.B mkfs /dev/rdf1 360
 # Make empty 360 block file system
+.TP 20
+.B mkfs /dev/rdhda3 65535
+# Create a maximum size filesystem on the hard disk partition \fI/dev/rdhda3\fR.
 .SH DESCRIPTION
 .PP
 .I Mkfs
@@ -18,10 +21,11 @@ creates an empty MINIX version 1 file system, with a size in 1K-blocks
 .I blocks
 for use with
 .B mount.
-The native ELKS file system is MINIX.
+Unless the system is using BIOS IO, the device must be a raw (character) device as in the examples.
+The native TLVC file system is MINIX.
 .PP
 The maximum size of a file system is 65535 blocks, which is
-65 Mb.
+64 Mb or 67,107,840 bytes.
 .SH "SEE ALSO"
 .BR fsck (8),
 .BR mount (8).


### PR DESCRIPTION
`mkfat` and `fdisk` have joined `man` as automatically made host commands with the names `emkfat` and `efdisk` respectively .

System commands accessing storage devices outside a mounted file system are now required to use raw devices: `fsck`, `mkfat`, `mkfs` and `makeboot`. In addition to `fdisk` in #128 . 

By pulling in `CONFIG_BLK_DEV_BIOS`, BIOS devices will work like before until they get their own raw drivers.