### PR TITLE
[kernel] Fix for mv directory hang in #138

### DIFF
--- a/tlvc/fs/buffer.c
+++ b/tlvc/fs/buffer.c
@@ -744,7 +744,7 @@ void unmap_buffer(struct buffer_head *bh)
         } else
 #endif
         if (--ebh->b_mapcount == 0) {
-            debug_map("unmap: %d\n", buf_num(bh));
+            debug_map("unmap: %d/%d\n", buf_num(bh), ebh->b_blocknr);
             wake_up(&L1wait);
         } else
             debug_map("unmap_buffer: %d mapcount %d\n", buf_num(bh), ebh->b_mapcount+1);

--- a/tlvc/fs/inode.c
+++ b/tlvc/fs/inode.c
@@ -42,6 +42,7 @@ static int nr_free_inodes;
 
 void finvalidate_inodes(kdev_t, int);
 
+/* Remove inode from free list */
 static void remove_inode_free(register struct inode *inode)
 {
     register struct inode *ino;
@@ -225,7 +226,7 @@ void iput(register struct inode *inode)
 {
     register struct super_operations *sop;
 
-    debug("iput dev %D ino %lu count %d\n",
+    debug_inode("iput dev %D ino %lu count %d\n",
         inode->i_dev, (unsigned long)inode->i_ino, inode->i_count);
     if (inode) {
 	wait_on_inode(inode);
@@ -334,12 +335,12 @@ struct inode *iget(struct super_block *sb, ino_t inr)
     register struct inode *n_ino;
 
     if (!sb) panic("iget0");
-    debug("iget dev %D ino %lu\n", sb->s_dev, (unsigned long)inr);
+    debug_inode("iget dev %D ino %lu\n", sb->s_dev, (unsigned long)inr);
 
     n_ino = NULL;
     goto start;
     do {
-	debug("iget: getting an empty inode...\n");
+	debug_inode("iget: getting an empty inode...\n");
 	n_ino = get_empty_inode();	/* This function may sleep and someone else */
       start:				/* can create the inode */
 	inode = inode_llru;
@@ -348,7 +349,7 @@ struct inode *iget(struct super_block *sb, ino_t inr)
 	} while ((inode = inode->i_prev) != NULL);
     } while (n_ino == NULL);
     inode = n_ino;			/* Inode not found, use the new structure */
-    debug("iget: got one...\n");
+    debug_inode("iget: got one...\n");
 
     inode->i_sb = sb;
     inode->i_dev = sb->s_dev;

--- a/tlvc/fs/minix/namei.c
+++ b/tlvc/fs/minix/namei.c
@@ -375,7 +375,7 @@ static int empty_dir(register struct inode *inode)
   bad_dir:
     printk("Bad directory on device %D\n", inode->i_dev);
   empt_dir:
-    unmap_brelse(bh);
+    unmap_brelse(bh);	/* bh == NULL is OK */
     return 1;
 }
 

--- a/tlvc/fs/minix/namei.c
+++ b/tlvc/fs/minix/namei.c
@@ -344,8 +344,10 @@ static int empty_dir(register struct inode *inode)
     /* Cache s_dirsize to reduce dereference overhead */
     dirsize = inode->i_sb->u.minix_sb.s_dirsize;
 
-    if ((unsigned short)(inode->i_size) & (dirsize - 1)) goto bad_dir;
-    if (inode->i_size < (__u32)(dirsize << 1)) goto bad_dir;
+    if ((unsigned short)(inode->i_size) & (dirsize - 1)) /* assumes dirsize is power of 2 */
+	goto bad_dir;
+    if (inode->i_size < (__u32)(dirsize << 1))	/* cannot have less than 2 entries */
+	goto bad_dir;
     bh = minix_bread(inode, 0, 0);
     if (!bh) goto bad_dir;
     map_buffer(bh);
@@ -356,7 +358,7 @@ static int empty_dir(register struct inode *inode)
     bo = (__u32)dirsize;
     while ((bo += dirsize) < inode->i_size) {
 	offset = (__u16)bo & (BLOCK_SIZE - 1);
-	if (!offset) {
+	if (!offset) {				/* get next dir-block */
 	    unmap_brelse(bh);
 	    bh = minix_bread(inode, (__u16)(bo >> BLOCK_SIZE_BITS), 0);
 	    if (!bh)
@@ -364,17 +366,16 @@ static int empty_dir(register struct inode *inode)
 	    map_buffer(bh);
 	}
 	de = (struct minix_dir_entry *) (bh->b_data + offset);
-	if (de->inode) {
+	if (de->inode) {		/* valid entry found, not empty */
 	    unmap_brelse(bh);
 	    return 0;
 	}
     }
-    brelse(bh);
     goto empt_dir;
   bad_dir:
-    unmap_brelse(bh);
     printk("Bad directory on device %D\n", inode->i_dev);
   empt_dir:
+    unmap_brelse(bh);
     return 1;
 }
 

--- a/tlvc/fs/namei.c
+++ b/tlvc/fs/namei.c
@@ -502,8 +502,8 @@ int sys_link(char *oldname, char *pathname)
     error = namei(oldname, &oldinode, 0, 0);
     if (!error) {
         error = do_mknod(pathname, offsetof(struct inode_operations,link), (int)oldinode, 0);
-        if (error)
-            iput(oldinode);
+        //if (error)
+            //iput(oldinode);
     }
     return error;
 #endif

--- a/tlvc/include/linuxmt/minix_fs_sb.h
+++ b/tlvc/include/linuxmt/minix_fs_sb.h
@@ -12,12 +12,12 @@ struct minix_sb_info {
     unsigned short		s_imap_blocks;
     unsigned short		s_zmap_blocks;
     unsigned short		s_firstdatazone;
-    unsigned short		s_log_zone_size;
-    unsigned long		s_max_size;
+    unsigned short		s_log_zone_size;/* log2(zone_size/block_size) */
+    unsigned long		s_max_size;	/* max file size */
     block_t			s_imap[MINIX_I_MAP_SLOTS];
     block_t			s_zmap[MINIX_Z_MAP_SLOTS];
-    unsigned short		s_dirsize;
-    unsigned short		s_namelen;
+    unsigned short		s_dirsize;	/* size of a directory entry */
+    unsigned short		s_namelen;	/* max filename length incl NULL */
     unsigned short		s_mount_state;
 };
 


### PR DESCRIPTION
Fixes both problems reported on #138:

1) The `trying to free free inode` error message turned out to be harmless and caused by an unnecessary `iput` after a call to `do_mknod` in `fs/namei.c`. 

2) The system hang after `mv`ing a certain number of directories turned out to be a problem in `rmdir()`, specifically in `empty_dir()` in `minix/namei.c`, where a leftover from our mega-L1-L2 buffer cleanup last year left a buffer mapped when it should have been unmapped. Any action that involved rmdir would leave a L1 buffer mapped forever, and the system would eventually run out and go into a spin waiting for a release.