### PR TITLE
[misc] Miscellaneous fixes and cleanups

### DIFF
--- a/tlvc/arch/i86/drivers/block/config.in
+++ b/tlvc/arch/i86/drivers/block/config.in
@@ -14,7 +14,7 @@ mainmenu_option next_comment
 	bool '  Native floppy support'		CONFIG_BLK_DEV_FD	y
 	bool '  Native IDE hardisk support'	CONFIG_BLK_DEV_HD	y
 	if [ "$CONFIG_BLK_DEV_HD" == "y" ]; then
-	    bool '  Include XT-IDE/CF support'	CONFIG_IDE_XT		n
+	    bool '  Include XT-IDE/CF support'	CONFIG_XT_IDE		n
 	fi
 	bool '  XT/MFM disk support'	CONFIG_BLK_DEV_XD	n
     fi

--- a/tlvc/arch/i86/drivers/block/directfd.c
+++ b/tlvc/arch/i86/drivers/block/directfd.c
@@ -1637,8 +1637,8 @@ static unsigned char * INITPROC find_base(int drive, int type)
 	printk("df%d: %s (type %d)", drive, floppy_type[*base].name, type);
 	return base;
     }
-    printk("df%d is unknown type %d", drive, type);
-    return NULL;
+    printk("df%d: unknown type %d, using type 1200k/AT", drive, type);
+    return probe_list[1];
 }
 
 /* CMOS 0x10 bits 7-4: Floppy 1 drive type,
@@ -1835,7 +1835,7 @@ void INITPROC floppy_init(void)
 #else
     fdc_version = FDC_TYPE_STD;	/* force std fdc type; can't test other. */
 #endif
-    printk("%s: Direct floppy driver, FDC %s @ irq %d, DMA %d", DEVICE_NAME, 
+    printk("%s: Floppy controller, FDC %s @ irq %d, DMA %d", DEVICE_NAME, 
 	    fdc_version == 0x80 ? "8272A" : "82077", FLOPPY_IRQ, FLOPPY_DMA);
     configure_fdc_mode();
 #ifdef USE_DIR_REG

--- a/tlvc/arch/i86/drivers/char/console-bios.c
+++ b/tlvc/arch/i86/drivers/char/console-bios.c
@@ -168,7 +168,7 @@ struct tty_ops bioscon_ops = {
     Console_conout
 };
 
-void console_init(void)
+void INITPROC console_init(void)
 {
     Console *C;
     int i;

--- a/tlvc/include/linuxmt/debug.h
+++ b/tlvc/include/linuxmt/debug.h
@@ -23,6 +23,7 @@
 #define DEBUG_ETH	0		/* ethernet*/
 #define DEBUG_FAT	0		/* FAT filesystem*/
 #define DEBUG_FILE	0		/* sys open and file i/o*/
+#define DEBUG_INODE	0		/* track inode handling */
 #define DEBUG_NET	0		/* networking*/
 #define DEBUG_MAP	0		/* L1 mapping */
 #define DEBUG_MM	0		/* mem char device*/
@@ -99,6 +100,12 @@ void debug_setcallback(int evnum, void (*cbfunc)()); /* callback on debug event*
 #define debug_file	PRINTK
 #else
 #define debug_file(...)
+#endif
+
+#if DEBUG_INODE
+#define debug_inode	PRINTK
+#else
+#define debug_inode(...)
 #endif
 
 #if DEBUG_MM

--- a/tlvccmd/ash/Makefile
+++ b/tlvccmd/ash/Makefile
@@ -25,7 +25,7 @@ OBJS=	builtins.o cd.o dirent.o error.o eval.o exec.o expand.o input.o \
 OBJS += bltin/echo.o bltin/history.o
 OBJS += bltin/expr.o bltin/regexp.o bltin/operators.o
 
-LDFLAGS += -maout-heap=20000 -maout-stack=2304
+LDFLAGS += -maout-heap=14000 -maout-stack=2304
 
 #
 # Set READLINE in shell.h and add -ledit to LIBS if you want to use the

--- a/tlvccmd/minix3/Makefile
+++ b/tlvccmd/minix3/Makefile
@@ -10,7 +10,7 @@ cal: cal.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o cal cal.o $(TINYPRINTF) $(LDLIBS)
 
 diff: diff.o
-	$(LD) $(LDFLAGS) -o diff diff.o $(LDLIBS)
+	$(LD) $(LDFLAGS) -maout-heap=0x2000 -o diff diff.o $(LDLIBS)
 
 file: file.o $(TINYPRINTF)
 	$(LD) $(LDFLAGS) -o file file.o $(TINYPRINTF) $(LDLIBS)

--- a/tlvccmd/rootfs_template/bin/sys
+++ b/tlvccmd/rootfs_template/bin/sys
@@ -61,6 +61,9 @@ create_dev_dir()
 	mknod $MNT/dev/hdb4	b 5 36
 	mknod $MNT/dev/rhdb	c 5 32
 	mknod $MNT/dev/rhdb1	c 5 33
+	mknod $MNT/dev/rhdb2	c 5 34
+	mknod $MNT/dev/rhdb3	c 5 35
+	mknod $MNT/dev/rhdb4	c 5 36
 	mknod $MNT/dev/hdc	b 5 64
 	mknod $MNT/dev/hdc1	b 5 65
 	mknod $MNT/dev/rhdc	c 5 64
@@ -69,15 +72,6 @@ create_dev_dir()
 	mknod $MNT/dev/hdd1	b 5 67
 	mknod $MNT/dev/rhdd	c 5 96
 	mknod $MNT/dev/rhdd1	b 5 67
-	mknod $MNT/dev/rhda1	c 5 1
-	mknod $MNT/dev/rhda2	c 5 2
-	mknod $MNT/dev/rhda3	c 5 3
-	mknod $MNT/dev/rhda4	c 5 4
-	mknod $MNT/dev/rhdb	c 5 32
-	mknod $MNT/dev/rhdb1	c 5 33
-	mknod $MNT/dev/rhdb2	c 5 34
-	mknod $MNT/dev/rhdb3	c 5 35
-	mknod $MNT/dev/rhdb4	c 5 36
 	mknod $MNT/dev/rd0	b 2 0
 	mknod $MNT/dev/rd1	b 2 1
 	mknod $MNT/dev/tty2	c 4 1

--- a/tlvccmd/rootfs_template/bootopts
+++ b/tlvccmd/rootfs_template/bootopts
@@ -1,7 +1,7 @@
 ## boot options max 1023 bytes, see wiki for details
 console=ttyS0,57600 3	# serial console and init-level (3)
-debug=0
-net=ne0 		# start netw on boot w/this interface
+#debug=2
+#net=ne0 		# start netw on boot w/this interface
 #root=df0
 #TZ=MDT7
 LOCALIP=10.0.2.15
@@ -12,17 +12,17 @@ wd0=2,0x280,0xCC00,0x80
 #3c0=11,0x330,,0x80
 ee0=11,0x360,,0x80
 comirq=,,7,10		# IRQ for com ports, up to 4
-cache=6		# L1 cache
-bufs=40		# L2 buffers
-xmsbufs=0	# if supported
+cache=8		# L1 cache
+#bufs=40		# L2 buffers
+#xmsbufs=0	# if supported
 #heap=30	# max heap (kB)
 #memsize=640	# system RAM (kB)
-files=64 inodes=96
-hdparms=306,4,17,128,614,4,17,-1 # CHSW values for 2 drives, overrides CMOS and drive values
+#files=64 inodes=96
+#hdparms=823,4,38,-1,63,16,63,-1 # CHSW values for 2 drives, overrides CMOS and drive values
 #netbufs=2,0	# netw buffers, recv/trans, ne2k only
-tasks=18	# max tasks, default 16, max 20
-sync=30		# autosync secs
-#xtflpy=3,1	# meaningful for XT systems w/720k drive(s) (type3)
+#tasks=18	# max tasks, default 16, max 20
+#sync=30		# autosync secs
+xtflpy=3,1	# meaningful for XT systems w/720k drive(s) (type3)
 fdcache=5	# floppy read cache for slow systems <= 286
 #xtide=0x300,5,1,,, # addr, IRQ, flgs for 2 XT-IDE controllers
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys

--- a/tlvccmd/rootfs_template/etc/inittab
+++ b/tlvccmd/rootfs_template/etc/inittab
@@ -17,4 +17,4 @@ t2:56:respawn:/bin/getty /dev/tty2
 t3:56:respawn:/bin/getty /dev/tty3
 s0:2346:respawn:/bin/getty /dev/ttyS0
 s1:46:respawn:/bin/getty /dev/ttyS1 9600
-s2:3:respawn:/bin/getty /dev/ttyS2 19200
+s2:6:respawn:/bin/getty /dev/ttyS2 57600

--- a/tlvccmd/rootfs_template/etc/mount.cfg
+++ b/tlvccmd/rootfs_template/etc/mount.cfg
@@ -5,14 +5,14 @@
 #
 #set -x
 
-fsck="fsck -r"
+fsck="fsck -a"
 
 # check a mounted filesystem
 check_mounted_filesystem()
 {
 	echo -n "$fsck $1: "
 	umount $1
-	$fsck $1
+	$fsck `echo $1|sed s,v/,v/r,`
 	mount -o remount,rw $1 $2
 }
 
@@ -20,7 +20,7 @@ check_mounted_filesystem()
 check_filesystem()
 {
 	echo "$fsck $1: "
-	$fsck $1
+	$fsck `echo $1|sed s,v/,v/r,`
 }
 
 # determine fs type

--- a/tlvccmd/rootfs_template/etc/net.cfg
+++ b/tlvccmd/rootfs_template/etc/net.cfg
@@ -1,26 +1,23 @@
-# TLVC Networking Configuration File
+# TLVC NetConfig File
 # sourced by /bin/net for ktcp and daemons
+# Keep size < 1k!
 
 # Default IP address, gate and network mask.
 # These can be IP addresses or names in /etc/hosts.
 if test "$LOCALIP" != ""; then localip=$LOCALIP; else localip=10.0.2.15; fi
-gateway=10.0.2.2
+if test "$GATEWAY" != ""; then gateway=$GATEWAY; else gateway=10.0.2.2; fi
 netmask=255.255.255.0
 
 # reduce for 8bit NE2K w/4K buffer
 mtu=
 #mtu="-m 1000"
 
-# default link layer [ne0|wd0|3c0|slip|cslip]
+# default link layer [ne0|wd0|3c0|ee0|le0|slip|cslip]
 link=ne0
 
 # default serial port and baud rate if slip/cslip
 device=/dev/ttyS0
 baud=38400
-
-# to use ftp/ftpd in qemu
-#export QEMU=1
-# Note: Set QEMU in /bootopts instead!
 
 # daemons to start are actually shell variable command lines see below
 netstart="telnetd ftpd"

--- a/tlvccmd/sys_utils/man.c
+++ b/tlvccmd/sys_utils/man.c
@@ -124,7 +124,7 @@ static char manorcat[] = "man:cat";
    char *mc, *mp, *ms, *su, *nmc, *nmp, *nms, *nsu;
    int rv = -1;
 
-                  manpath = getenv("MANPATH");
+   manpath = getenv("MANPATH");
    if (!manpath) manpath = defpath;
    if (!mansect) mansect = getenv("MANSECT");
    if (!mansect) mansect = defsect;


### PR DESCRIPTION
... including
- simplifying IDE boot messages
- change CONFIG_IDE_XT to CONFIG_XT_IDE to match the name of the actual interface
- add heap to the `diff` command so it actually works
- reduce the previously added heapsize to `ash` to a sane value
- fix typo that prevented `net.cfg` from working
- add `debug_inode` to `debug.h`
- updates `sys`, `inittab` and `bootopts`
- fix `directhd.c` so the _release routine works with the new raw regime