### PR TITLE
[kernel] Bugfix for occasional problem with umounting minix fs

### DIFF
--- a/tlvc/fs/exec.c
+++ b/tlvc/fs/exec.c
@@ -504,6 +504,7 @@ int sys_execve(const char *filename, char *sptr, size_t slen)
     /* this could be a good place to set the effective user identifier
      * in case the suid bit of the executable had been set */
 
+	iput(currentp->t_inode);
 	currentp->t_inode = inode;
 
     /* can I trust the following fields?  */

--- a/tlvc/fs/inode.c
+++ b/tlvc/fs/inode.c
@@ -89,14 +89,15 @@ static void list_inode_status(void)
 
     do {
         if (inode->i_count || inode->i_dev || inode->i_dirt) {
-            printk("\n#%2d: dev %D inode %5lu dirty %d count %u", i, inode->i_dev,
-                (unsigned long)inode->i_ino, inode->i_dirt, inode->i_count);
+            inode->i_path[sizeof(inode->i_path)-1] = '\0';
+            printk("\n#%2d: dev %p inode %5lu cnt %2d %c %06o %s", i, inode->i_dev,
+                (unsigned long)inode->i_ino, inode->i_count, inode->i_dirt? 'D':' ',
+                inode->i_mode, S_ISSOCK(inode->i_mode)? " [socket]": inode->i_path);
         }
         i++;
         if (inode->i_count) inuse++;
     } while ((inode = inode->i_prev) != NULL);
     printk("\nTotal inodes inuse %d/%d (%d free)\n", inuse, NR_INODE, nr_free_inodes);
-
 }
 #endif
 

--- a/tlvc/fs/namei.c
+++ b/tlvc/fs/namei.c
@@ -195,6 +195,16 @@ static int dir_namei(const char *pathname, size_t * namelen,
     return error;
 }
 
+/* saves path for list_inode_status */
+static void save_path(struct inode *inode, const char *pathname)
+{
+#ifdef CHECK_FREECNTS
+    if (!inode->i_path[0])
+        fmemcpyb(inode->i_path, kernel_ds, (void *)pathname, current->t_regs.ds,
+            sizeof(inode->i_path));
+#endif
+}
+
 /*
  *	_namei()
  *
@@ -227,6 +237,7 @@ int _namei(const char *pathname, register struct inode *base, int follow_links,
 	    } else
 		iput(base);
 	    *res_inode = inode;
+	    save_path(inode, pathname);
 	} else
 	    iput(base);
     }
@@ -362,6 +373,7 @@ int open_namei(const char *pathname, int flag, int mode,
 	    inode->i_dirt = 1;
 	}
 	*res_inode = inode;
+        save_path(inode, pathname);
     } else iput(inode);
 #undef inode
 

--- a/tlvc/include/linuxmt/fs.h
+++ b/tlvc/include/linuxmt/fs.h
@@ -8,6 +8,7 @@
 #ifdef __KERNEL__
 
 #include <linuxmt/config.h>
+#include <linuxmt/trace.h>
 #include <linuxmt/types.h>
 #include <linuxmt/wait.h>
 #include <linuxmt/kdev_t.h>
@@ -239,6 +240,9 @@ struct inode {
 #endif
 		void * generic_i;
     } u;
+#ifdef CHECK_FREECNTS
+    char	i_path[16];
+#endif
 };
 
 struct file {

--- a/tlvccmd/sys_utils/ps.c
+++ b/tlvccmd/sys_utils/ps.c
@@ -226,7 +226,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	printf("  PID   GRP  TTY USER STAT ");
+	printf("  PID  PPID  PGRP  TTY USER STAT ");
 #ifdef CONFIG_CPU_USAGE
 	printf("CPU");
 #endif
@@ -259,9 +259,10 @@ int main(int argc, char **argv)
 		}
 		pwent = getpwuid(task_table.uid);
 
-		/* pid grp tty user stat*/
-		printf("%5d %5d %4s %-8s%c ",
+		/* pid ppid grp tty user stat*/
+		printf("%5d %5d %5d %4s %-8s%c ",
 				task_table.pid,
+				task_table.ppid,
 				task_table.pgrp,
 				tty_name(fd, (unsigned int)task_table.tty, ds),
 				(pwent ? pwent->pw_name : "unknown"),


### PR DESCRIPTION
As reported in #59, unmounting a minix file system was impossible after having executed `ash` locally on that FS. The problem turned out to much broader than that and was finally located in `execve()` where a missing `iput` on the old/parent process inode caused the inode counter to continually increase and thus remain busy.

The problem had no other effect than preventing amounts until the system ran out of available inodes, which rarely happened. The fix is one simple line of code in `fs/exec.c`. 

@ghaerr, I found out that you fixed this in ELKS some time between v 0.7 and 0.8 - and it's my turn to ask: Was it code inspection or a regular bug hunt?

BTW thanks for the updated inode ^N listing code, making the path visual like that was great!