### PR TITLE
[kernel, bootopts] Change net= to NET= and more

### DIFF
--- a/tlvccmd/rootfs_template/bootopts
+++ b/tlvccmd/rootfs_template/bootopts
@@ -1,7 +1,7 @@
 ## boot options max 1023 bytes, see wiki for details
 console=ttyS0,57600 3	# serial console and init-level (3)
 #debug=2
-#net=ne0 		# start netw on boot w/this interface
+NET=ne0 		# start netw on boot w/this interface
 #root=df0
 #TZ=MDT7
 LOCALIP=10.0.2.15
@@ -12,7 +12,7 @@ wd0=2,0x280,0xCC00,0x80
 #3c0=11,0x330,,0x80
 ee0=11,0x360,,0x80
 comirq=,,7,10		# IRQ for com ports, up to 4
-cache=8		# L1 cache
+#cache=8		# L1 cache
 #bufs=40		# L2 buffers
 #xmsbufs=0	# if supported
 #heap=30	# max heap (kB)
@@ -22,7 +22,7 @@ cache=8		# L1 cache
 #netbufs=2,0	# netw buffers, recv/trans, ne2k only
 #tasks=18	# max tasks, default 16, max 20
 #sync=30		# autosync secs
-xtflpy=3,1	# meaningful for XT systems w/720k drive(s) (type3)
+#xtflpy=3,1	# meaningful for XT systems w/720k drive(s) (type3)
 fdcache=5	# floppy read cache for slow systems <= 286
 #xtide=0x300,5,1,,, # addr, IRQ, flgs for 2 XT-IDE controllers
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys

--- a/tlvccmd/rootfs_template/etc/net.cfg
+++ b/tlvccmd/rootfs_template/etc/net.cfg
@@ -2,8 +2,7 @@
 # sourced by /bin/net for ktcp and daemons
 # Keep size < 1k!
 
-# Default IP address, gate and network mask.
-# These can be IP addresses or names in /etc/hosts.
+# Literal IP addresses or names in /etc/hosts.
 if test "$LOCALIP" != ""; then localip=$LOCALIP; else localip=10.0.2.15; fi
 if test "$GATEWAY" != ""; then gateway=$GATEWAY; else gateway=10.0.2.2; fi
 netmask=255.255.255.0
@@ -13,7 +12,7 @@ mtu=
 #mtu="-m 1000"
 
 # default link layer [ne0|wd0|3c0|ee0|le0|slip|cslip]
-link=ne0
+if test "$NET" != ""; then link=$NET; else  link=ne0; fi
 
 # default serial port and baud rate if slip/cslip
 device=/dev/ttyS0

--- a/tlvccmd/rootfs_template/etc/rc.sys
+++ b/tlvccmd/rootfs_template/etc/rc.sys
@@ -19,10 +19,10 @@ fi
 #
 # start networking
 #
-# check /bootopts "net=" env variable
-case "$net" in
+# check /bootopts "NET=" env variable
+case "$NET" in
 ee0|ne0|wd0|3c0)
-	net start $net
+	net start $NET
 	;;
 slip)
 	net start slip
@@ -31,8 +31,8 @@ cslip)
 	net start cslip
 	;;
 *)
-	if test "$net" != ""; then
-		echo "Unrecognized /bootopts network option: net=$net"
+	if test "$NET" != ""; then
+		echo "Unrecognized /bootopts network option: NET=$NET"
 	fi
 	;;
 esac


### PR DESCRIPTION
Changes the `bootopts` parameter `net=` to `NET=` in order to make it propagate in the user shell default environment. This simplifies the use of the `net start` command in setting where this command is used a lot.

Also changes the automatic turning off `fdcache` on 386 and later machines: Keep the setting in `bootopts` if `debug` is set.

Finally, this PR updates the boot device table in `init/main.c` (used to set `ROOTDEV`) to recognize MFM (`xd`) disks. 