### PR TITLE
[cmds] Enhancements to /bin/sys, /bin/mount

### DIFF
--- a/tlvccmd/rootfs_template/bin/sys
+++ b/tlvccmd/rootfs_template/bin/sys
@@ -27,11 +27,14 @@ create_dev_dir()
 	mknod $MNT/dev/rhda4	c 5 4
 	mknod $MNT/dev/xda	b 6 0
 	mknod $MNT/dev/xda1	b 6 1
-	mknod $MNT/dev/xda2	b 6 3
-	mknod $MNT/dev/xda3	b 6 4
-	mknod $MNT/dev/xda4	b 6 2
+	mknod $MNT/dev/xda2	b 6 2
+	mknod $MNT/dev/xda3	b 6 3
+	mknod $MNT/dev/xda4	b 6 4
 	mknod $MNT/dev/rxda	c 6 0
 	mknod $MNT/dev/rxda1	c 6 1
+	mknod $MNT/dev/rxda2	c 6 2
+	mknod $MNT/dev/rxda3	c 6 3
+	mknod $MNT/dev/rxda4	c 6 4
 	mknod $MNT/dev/df0	b 2 0
 	mknod $MNT/dev/df1	b 2 32
 	mknod $MNT/dev/rdf0	c 2 0

--- a/tlvccmd/sys_utils/mount.c
+++ b/tlvccmd/sys_utils/mount.c
@@ -14,6 +14,7 @@
 #include <stdlib.h>
 #include <errno.h>
 #include <ctype.h>
+#include <limits.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
 #include <sys/types.h>
@@ -64,7 +65,7 @@ int main(int argc, char **argv)
 	int	flags = 0;
 	int	query = 0;
 	char	*option;
-	char	fsname[18];
+	char	fsname[PATH_MAX];
 
 	argc--;
 	argv++;
@@ -132,7 +133,7 @@ int main(int argc, char **argv)
 		return 1;
 	}
 
-	strncpy(fsname, argv[0], 18);
+	strncpy(fsname, argv[0], PATH_MAX-2);
 	if (isalpha(fsname[strlen(fsname)-1])) {	/* we're mounting a flat drive,
 							 * check that it really is flat */
 		strcat(fsname, "1");
@@ -144,7 +145,7 @@ int main(int argc, char **argv)
 	if (flags == 0 && type == 0)
 		flags = MS_AUTOMOUNT;
 	if (mount(argv[0], argv[1], type, flags) < 0) {
-		char failed[] = "mount failed";
+		char *failed = "mount failed";
 		if (flags & MS_AUTOMOUNT) {
 			type = (!type || type == FST_MINIX)? FST_MSDOS: FST_MINIX;
 			if (mount(argv[0], argv[1], type, flags) >= 0)

--- a/tlvccmd/sys_utils/mount.c
+++ b/tlvccmd/sys_utils/mount.c
@@ -17,9 +17,7 @@
 #include <limits.h>
 #include <sys/mount.h>
 #include <sys/stat.h>
-#include <sys/types.h>
 #include <linuxmt/fs.h>
-#include <linuxmt/limits.h>
 
 #define errmsg(str) write(STDERR_FILENO, str, sizeof(str) - 1)
 


### PR DESCRIPTION
- `/bin/sys`: Updated to fully support `xd` devices
- `mount`: 
    - When a flat drive is specified (like `/dev/hda`), mount will now attempt to open the first partition on that device in order to avoid the chaos that some times ensues when erroneously mounting a partitioned device as flat.
    - When attempting to mount a filesystem with an unsupported file system type, like FAT when FAT support is not compiled in, a reasonable error message is displayed instead of the rather confusing (if technically correct) 'no such device'.