### PR TITLE
[cmd] Fixes several bugs in the ftp client

### DIFF
--- a/tlvccmd/man/man1/ftp.1
+++ b/tlvccmd/man/man1/ftp.1
@@ -1,4 +1,4 @@
-.TH FTP 1 ELKS
+.TH FTP 1 TLVC
 .SH NAME
 ftp \- Internet file transfer program
 .SH SYNOPSIS
@@ -37,7 +37,7 @@ server on that host; otherwise,
 will enter its command interpreter and await instructions
 from the user.  When 
 .B ftp
-is awaiting commands the prompt `ftp>'
+is awaiting commands, the prompt `ftp>'
 is provided to the user.  The following commands are recognized
 by
 .BR ftp .
@@ -45,7 +45,7 @@ Commands may be abbreviated to 3 characters.
 .TP
 \fB\&!\fP [ \fIcommand\fP [ \fIargs\fP ] ]
 Execute local commands via the shell.
-The first is taken to be a command to execute
+The first token is taken to be a command to execute
 directly, with the rest of the arguments as its arguments.
 Without arguments, the command is ignored.
 .TP
@@ -62,7 +62,7 @@ to support binary image transfer.
 Terminate the FTP session with the remote server
 and exit
 .BR ftp .
-An end of file will also terminate the session and exit.
+An end of file (^D) will also terminate the session and exit.
 .TP
 .BI cd " remote-directory"
 Change the working directory on the remote machine
@@ -70,9 +70,8 @@ to
 .IR remote-directory .
 .TP
 .B close
-Terminate the FTP session with the remote server, and
+Terminate the currently open session and
 return to the command interpreter.
-Any defined macros are erased.
 .TP
 .BI delete " remote-file"
 Delete the file
@@ -80,9 +79,9 @@ Delete the file
 on the remote machine.
 .TP
 \fBdebug\fP [ \fIdebug-value\fP ]
-Set or report debugging mode which determines the levels of detail in messages during operation.  If an optional
+Set or report the debug level which determines the amount of detail in messages during operation.  If an optional
 .I debug-value
-is specified, it is used to set the debugging level. Values above 4 are not meaningful.
+is specified, it is used to set the debug level. Values above 4 are not meaningful.
 Note that the 
 .I verbose
 command will set the debug-value to either 0 or one (toggle).
@@ -95,43 +94,55 @@ If
 is off, only minimal information is displayed, such as the file names transferred.
 .TP
 \fBdir\fP [ \fIremote-directory\fP ] [ \fIlocal-file\fP ]
-Print a listing of the directory contents in the
-directory,
-.IR remote-directory ,
-and, optionally, placing the output in
-.IR local-file .
-If no directory is specified, the current working
-directory on the remote machine is used.  If no local
-file is specified, or \fIlocal-file\fP is \fB-\fP,
+Print the contents of the
+current (remote) directory, or - if
+.I remote-directory
+is specified - list that directory.
+Optionally, if 
+.I local-file 
+is specified, place the output in that file.
+If no local file is specified, or \fIlocal-file\fP is \fB-\fP,
 output comes to the terminal.
+.TP
+\fBget\fP \fIremote-file\fP [ \fIlocal-file\fP ]
+Fetch 
+.I remotefile
+from the FTP server. If
+.I local-file
+is left unspecified, the remote file name is used. Note that the remote server may
+be case sensitive, which means that 'SETUP.DAT', 'setup.dat' and 'Setup.DAT' are different
+files.
 .TP
 \fBglob\fP
 Toggle filename expansion for \fBmget\fP and \fBmput\fP.
 If globbing is turned off with \fBglob\fP, the file name arguments
 are taken literally and not expanded.
-Globbing for \fBmput\fP is done as in \fBsash\fP(1).
+Globbing for \fBmput\fP is done as in 
+.BR sash (1).
 For \fBmget\fP, each remote file name is expanded
 separately on the remote machine and the lists are not merged.
 Expansion of a directory name is likely to be 
 different from expansion of the name of an ordinary file:
 the exact result depends on the foreign operating system and ftp server,
-and can be previewed by doing `\fBmls\fP\ \fIremote-files\fP\ \fB-\fP' (not currently implemented in ELKS).
+and can be previewed by doing `\fBmls\fP\ \fIremote-files\fP\ \fB-\fP' (not currently implemented).
 Note:  \fBmget\fP and \fBmput\fP are not meant to transfer
 entire directory subtrees of files.  That can be done by
-transferring a \fBtar\fP(1) archive of the subtree (in binary mode).
+transferring a
+.BR tar (1)
+archive of the subtree in binary mode.
 When transferring full directories, using `*' may some times cause
 .B ftp
 to run out of memory. In such cases, try `.' instead.
 .TP
-\fBhash\f
+.B hash
 Toggle hash-sign (``#'') printing for each data block
 transferred.  The size of a data block is 1024 bytes.
-(Currently not implemented in ELKS.)
+(Currently not implemented in TLVC.)
 .TP
 \fBhelp\fP
 Prints a list of the known commands with a short explanation.
 .TP
-\fBlcd\fP [ \fIdirectory\fP ]
+\fBlcd\fP [ \fIdirectory\fR ]
 Change the working directory on the local machine.  If
 no 
 .I directory
@@ -162,10 +173,10 @@ in which case,
 .B ftp
 will attempt to contact an FTP server at that port.
 If the 
-.I auto-login
+.I auto-connect
 option is on (default), 
 .B ftp
-will also attempt to automatically log the user in to
+will also attempt to automatically connect - and potentially log the user in - to
 the FTP server (see below).
 .TP
 .B prompt
@@ -175,7 +186,8 @@ user to selectively retrieve or store files.
 If prompting is turned off (default is on), any \fBmget\fP or \fBmput\fP
 will transfer all files.
 The options are y/n/q where `q' will cause exit to the 
-.B ftp command prompt. This is particularly useful on ELKS because a ^C
+.B ftp
+command prompt. This is particularly useful on TLVC because a ^C
 will terminate the 
 .B ftp
 program, not the current transfer.
@@ -204,7 +216,7 @@ Clear reply queue.
 This command re-synchronizes command/reply sequencing with the remote
 ftp server.
 Resynchronization may be necessary following a violation of the ftp protocol
-by the remote server. This command is currently not implemented on ELKS.
+by the remote server. This command is currently not implemented on TLVC.
 .TP
 .BI rmdir " directory-name"
 Delete a directory on the remote machine.
@@ -220,8 +232,7 @@ Because of the nature of TCP connection establishment, there may be speed differ
 when transferring many files (`mget', `mput').
 .TP
 .B status
-Show the current status of
-.BR ftp .
+Show the current status of local parameters and the connection if any.
 .TP
 .B system
 Show the type of operating system running on the remote machine.
@@ -247,7 +258,7 @@ A synonym for help.
 Command arguments which have embedded spaces may be quoted with
 quote (") marks.
 .SH "ABORTING A FILE TRANSFER"
-[This functionality is currently not implemented in the ELKS client.]
+[This functionality is currently not implemented in the TLVC client.]
 To abort a file transfer, use the terminal interrupt key
 (usually Ctrl-C).
 Sending transfers will be immediately halted.
@@ -273,6 +284,18 @@ program must be killed by hand.
 Options may be specified at the command line, or to the 
 command interpreter.
 .PP
+The 
+.B \-A
+(active) option makes \fIport\fR mode the default when entering the 
+.B ftp
+command prompt (see also the 
+.B passive
+command above.
+.PP
+The 
+.B \-P
+(passive) option does the opposite, this is the default mode.
+.PP
 The
 .B \-v
 (verbose on) option is equivalent to setting `-d' or `-d 1'.
@@ -281,11 +304,15 @@ The
 .B \-n
 option restrains 
 .B ftp
-from attempting \*(lqauto-login\*(rq upon initial connection.
-If auto-login is enabled, 
+from attempting \*(lqauto-connect\*(rq upon initial connection.
+If auto-connect is enabled and the 
+.B \-u 
+and 
+.B \-p
+options (see below) are not used, 
 .B ftp
-will prompt for the remote machine login name (default is the user
-identity on the local machine), and, if necessary, prompt for a password
+will prompt for the remote machine login name (default is 'ftp')
+and, if necessary, prompt for a password
 and an account with which to login.
 .PP
 The
@@ -301,12 +328,23 @@ Numbers above 4 are not meaningful.
 The
 .B \-g
 option disables file name globbing.
+.PP
+.B \-u \fIusername\fR
+Use this username as the default when loggin on to the remote server. If the
+.B \-p
+option is present, 
+.B ftp
+will attempt to autologin at startup.
+.PP
+.B \-p \fIpassword\fR
+Use this password to attempt auto-login to the remote server. If auto-login fails, the connection will be closed and the 'ftp>' prompt will appear. A new connection may be established using the
+'open' command.
 .SH "QEMU support"
-When running ELKS inside the QEMU emulator, use the 
+When running TLVC inside the QEMU emulator, use the 
 .B \-q option with 
 .B ftp 
 in order to map addresses and ports correctly. With this option, `passive' mode file transfers
-between ELKS and the host are fully supported. If connecting inside the ELKS system (loopback), both `passive' 
+between TLVC and the host are fully supported. If connecting inside the TLVC system (loopback), both `passive' 
 and `port' modes work.
 .SH "SEE ALSO"
 ftpd(8)
@@ -314,7 +352,7 @@ ftpput(1)
 ftpget(1)
 .PP
 For more details refer to the 
-.I ELKS file transfer wiki.
+.I TLVC file transfer wiki.
 .SH BUGS
 Correct execution of many commands depends upon proper behavior
 by the remote server.
@@ -323,6 +361,8 @@ File name mapping beween hosts with different OSes are undefined and may yield u
 .PP
 File modes are neither queried not preserved. 
 .PP
-The ELKS
+When using globbing to fetch a remote directory and that directory contains a directory, behaviour is unspecified and server OS dependent.
+.PP
+The TLVC
 .B ftp
 client has no support for command line history or editing.

--- a/tlvccmd/man/man1/ftp.1
+++ b/tlvccmd/man/man1/ftp.1
@@ -32,10 +32,16 @@ is to communicate may be specified on the command line.
 If this is done,
 .B ftp
 will immediately attempt to establish a connection to an FTP
-server on that host; otherwise, 
-.B ftp
-will enter its command interpreter and await instructions
-from the user.  When 
+server on that host - unless the 
+.B \-n
+('auto-connect') option is present. Further, if the
+.B \-u
+and
+.B \-p
+options (username and password) are present,
+. ftp
+will attempt  a complete login to the remote host before entering 
+its command interpreter and await instructions from the user. When 
 .B ftp
 is awaiting commands, the prompt `ftp>'
 is provided to the user.  The following commands are recognized
@@ -106,7 +112,7 @@ output comes to the terminal.
 .TP
 \fBget\fP \fIremote-file\fP [ \fIlocal-file\fP ]
 Fetch 
-.I remotefile
+.I remote-file
 from the FTP server. If
 .I local-file
 is left unspecified, the remote file name is used. Note that the remote server may
@@ -130,14 +136,15 @@ entire directory subtrees of files.  That can be done by
 transferring a
 .BR tar (1)
 archive of the subtree in binary mode.
-When transferring full directories, using `*' may some times cause
+When transferring full directories, using `*' may some times
+(large directories, long filenames) cause
 .B ftp
 to run out of memory. In such cases, try `.' instead.
 .TP
 .B hash
 Toggle hash-sign (``#'') printing for each data block
-transferred.  The size of a data block is 1024 bytes.
-(Currently not implemented in TLVC.)
+transferred.  The size of a data block is 1024 bytes
+(currently not implemented).
 .TP
 \fBhelp\fP
 Prints a list of the known commands with a short explanation.


### PR DESCRIPTION
The second (`time()`) resolution timer was used for timing transfers - which crashed the program on short transfers because the time was used in division. The fix uses `gettimeofday()` instead. Short file transfers (1 packet data) on a reasonably fast machine clocks in at 10ms.

Also fixes a bug that caused newly created local files to stick around even if the connection never succeeded.