### PR TITLE
[libc,kernel,cmd] Rewrite of times() lib routine, time(1) cmd

### DIFF
--- a/tlvc/arch/i86/drivers/char/mem.c
+++ b/tlvc/arch/i86/drivers/char/mem.c
@@ -273,6 +273,9 @@ int kmem_ioctl(struct inode *inode, struct file *file, int cmd, char *arg)
     case MEM_GETJIFFADDR:
 	retword = (unsigned)&jiffies;
 	break;
+    case MEM_GETJIFFIES:
+	put_user_long(jiffies, arg);
+	return 0;
     case MEM_GETSEGALL:
         retword = (unsigned short)&_seg_all;
         break;

--- a/tlvc/include/linuxmt/mem.h
+++ b/tlvc/include/linuxmt/mem.h
@@ -13,6 +13,7 @@
 #define MEM_GETJIFFADDR 11
 #define MEM_GETSEGALL	12
 #define MEM_GETBSS_SZ	13
+#define MEM_GETJIFFIES	14
 
 struct mem_usage {
 	unsigned int free_memory;

--- a/tlvccmd/misc_utils/time.c
+++ b/tlvccmd/misc_utils/time.c
@@ -8,22 +8,16 @@
 #include <sys/times.h>
 #include <sys/wait.h>
 
-static void printt(char * s, long us)
+static void printt(char *s, long jf)
 {
-	long mins, secs;
+	unsigned long mins, secs;
 
-	if (us < 1000L && us > 499L)	/* round up to 1/1000 second*/
-		us = 1000L;
-	mins = us / 60000000L;
-	if (mins)
-		us -= mins * 60000000L;
+	mins = jf/6000;
+	if (mins) jf -= mins*6000;
+	secs = jf/100;
+	if (secs) jf -= secs*100;
 
-	secs = us / 1000000L;
-	if (secs)
-		us -= secs * 1000000L;
-
-	fprintf(stderr, "%s\t%lum%lu.%03lus\n", s, mins, secs, us/1000);
-	
+	fprintf(stderr, "%s\t%lum%lu.%03lus\n", s, mins, secs, jf*10);
 }
 
 


### PR DESCRIPTION
This update came to be from the weirdest of circumstances: The `time` command turned out to not work for long running programs. 'Long running' being not hours, but days. But what is it that takes days on TLVC? It's as simple as this:

The command `hd /dev/rxda` - where `xda` is a 10MB MFM drive running on a 4.77MHz Compaq Portable Plus, output to the physical console. The `hd` command is very slow in itself, the console hardware likewise. Add the XT-speed 8088 and we're talking like 36 hours of execution time. While the `time` command reported 1minute, 16 secs.

Reducing the task to just cover `/dev/rxda2`, the Minix partition sized at about 3MB, and the command finished in a day, but `time` still reported 1min, 16secs.

The fix became more than just finding an obvious overflow:
- Rewrite the `times()` library routine to return system clock ticks instead of microseconds, thus matching the corresponding system call on  'big' Linux and Unix.
- To make that part really simple, a `MEM_GETJIFFIES` ioctl was added to the `mem` char driver. `MEM_GETJIFADDR` would work but would be overly complicated given that there is no reuse of the far pointer between calls.
- Simplify the `time` command to use jiffies instead of usecs.

![IMG_0513](https://github.com/user-attachments/assets/fd912519-4a02-4bef-bbf2-702fdcaacb52)
