### PR TITLE
[kernel] An important update of the wd ethernet driver

### DIFF
--- a/tlvc/arch/i86/drivers/net/wd.c
+++ b/tlvc/arch/i86/drivers/net/wd.c
@@ -4,8 +4,51 @@
  * and wd8013 (16 bit) in numerous variants, with (assumed) reliable detection
  * of 8 vs 16 bits.
  *
- * By @pawosm-arm September 2020. 16 bit support and various other enhancements by 
- * Helge Skrivervik (@mellvik) june 2022.
+ * Based on an early Linux WD driver by David Becker, 8003-port By @pawosm-arm
+ * September 2020. Rudimentary 16 bit support and various other enhancements by 
+ * Helge Skrivervik (@mellvik) june 2022. 
+ * Full 8013 (and probably 8216) support by @mellvik for TLVC March 2025
+ */
+/* 
+ * DEVELOPER NOTES - added March 2025 by @mellvik
+ *
+ * While the 8013 is basically compatible with the 8003, there are significant differences,
+ * in particular with the softconfig 8013 models (some early models have jumpers to
+ * select between jumper configuration or soft config).
+ *
+ * In particular, the soft-config units have a shadow register set containing the soft 
+ * settings. This shadow register set hides behind the upper half of the IO space used
+ * by the card, net_port+(8-15), and is enabled by setting the high bit in the
+ * (net_port+4) register. Specifically, the saved base address is at (net_port + 0xb) and
+ * the saved IRQ is at (net_port + 0xd).
+ *
+ * It appears (I'm getting this from various drivers, not from documentation) that both
+ * the 'main' and the shadow registers are actually NVRAM, or rather, they reflect the
+ * contents of the NVRAM. Both register sets, real and shadow, may be modified by first 
+ * writing to whatever reg(s) we want to change, then flip the high bit in register (net_port+1) 
+ * first on then off. That will supposedly make the changes permanent. I have not tested this.
+ *
+ * The *IMPORTANCE* of flipping these switches - the 'write NVRAM' and the 'open shadow register
+ * block' switches - back to their 'off' state, cannot be OVERSTATED. If the 'write NVRAM' switch
+ * is left on, writes (possibly accidental) to these registers may destroy the original
+ * contents and possibly leave the card unusable, if nothing else because the checksum is 
+ * now incorrect. Further, and this one hit me hard until I understood what was going on,
+ * if the 'enable shadow register set' bit in reg4 is left
+ * on, it will stay that way until power-cycled. Card reset doesn't change it back. Thus, after
+ * a reboot the driver will find garbage where the MAC address is supposed to be, the checksum is
+ * not a checksum but something else, and the card will be 'not found'.
+ *
+ * This knowledge may be used to get and change not only the MAC address (less useful), but
+ * the base address and the IRQ, most likely the shared memory address of the card, in the
+ * driver. The currenbt version of the driver makes no attempt to do that and it takes
+ * some code to do it because the information is encoded in NVRAM. Like, the irq must be 
+ * retreived like this:  irq = ((irqreg & 0x40) >> 4) + ((irqreg & 0x0c) >> 2)
+ * which still isn't the irq but an 'index' if you like. The driver needs an array that
+ * matches up the indexes to the actual IRQs, like irqmap[] = {0, 9, 3, 5, 7, 10, 11, 15}
+ *
+ * Maybe later. The kernel is already bursting at the seams, and /bootopts does a great
+ * job for system configuration.
+ *
  */
 
 #include <arch/io.h>
@@ -40,9 +83,9 @@
 #define WD_STOP_PG16	0x40U	/* Last page + 1 of RX ring if 16bit i/f */
 #define WD_STOP_PG32	0x80U	/* Last page + 1 of RX ring if 32K buf space */
 
-#define TX_2X_PAGES	12U
-#define TX_1X_PAGES	6U
-#define TX_PAGES	TX_1X_PAGES
+#define TX_2X_PAGES	12		/* useful if 16+k buffer */
+#define TX_1X_PAGES	6
+#define TX_PAGES	TX_1X_PAGES	/* use one packet buffer for xmit */
 
 #define WD_FIRST_TX_PG	WD_START_PG
 #define WD_FIRST_RX_PG	(WD_FIRST_TX_PG + TX_PAGES)
@@ -54,7 +97,6 @@
 #define WD_8390_PORT	(net_port + WD_8390_OFFSET)
 #define WD_CMDREG5	5	/* Offset to 16-bit-only ASIC register 5. */
 
-#define	ISA16		0x80	/* Enable 16 bit access from the ISA bus. */
 #define	NIC16		0x40	/* Enable 16 bit access from the 8390. */
 
 #define E8390_RXCONFIG	0x04U	/* EN0_RXCR: broadcasts, no multicast or errors */
@@ -109,7 +151,7 @@
 #define EN1_CURPAG	0x07U	/* Current memory page RD WR */
 #define EN1_MULT	0x08U	/* Multicast filter mask array (8 bytes) RDWR */
 
-/* Bits in received packet status byte and EN0_RSR. */
+/* Bits in received packet status byte and EN0_RSR */
 #define ENRSR_RXOK	0x01U	/* Received a good packet */
 #define ENRSR_CRC	0x02U	/* CRC error */
 #define ENRSR_FAE	0x04U	/* frame alignment error */
@@ -119,17 +161,33 @@
 #define ENRSR_DIS	0x40U	/* receiver disable. set in monitor mode */
 #define ENRSR_DEF	0x80U	/* deferring */
 
-/* Bits in EN0_ISR - Interrupt status register. */
-#define ENISR_RX	0x01U	/* Receiver, no error */
-#define ENISR_TX	0x02U	/* Transmitter, no error */
-#define ENISR_RX_ERR	0x04U	/* Receiver, with error */
-#define ENISR_TX_ERR	0x08U	/* Transmitter, with error */
-#define ENISR_OFLOW	0x10U	/* Receiver overwrote the ring */
+/* Bits in EN0_ISR - Interrupt status register */
+#define ENISR_RX	0x01U	/* Packet received */
+#define ENISR_TX	0x02U	/* Transmit packet completed */
+#define ENISR_RX_ERR	0x04U	/* Receive error */
+#define ENISR_TX_ERR	0x08U	/* Transmit error */
+#define ENISR_OFLOW	0x10U	/* Receiver out of buffer space */
 #define ENISR_COUNTERS	0x20U	/* Counters need emptying */
-#define ENISR_RDC	0x40U	/* remote dma complete */
+#define ENISR_RDC	0x40U	/* Remote dma complete */
 #define ENISR_RESET	0x80U	/* Reset completed */
 #define ENISR_ALL	0x1fU	/* Enable these interrupts, skip RDC and stats */
 
+/*
+ * Model name codes from device register net_port+0xe:
+ * 0x03 - 8003
+ * 0x26 - 8013W
+ * 0x27 - 8013EP
+ * 0x28 - 8013WC
+ * 0x29 - 8013EPC or EWC
+ * 0x2A - 8216T
+ * 0x2B - 8216C or BT
+ * 0x2C - 8216EBP
+ * The letter suffixes seem to mean:
+ * T - Twisted Pair
+ * B - BNC
+ * C - Combo (all 3)
+ * E, P, W - ???
+ */
 
 typedef struct {
 	unsigned char status;	/* status */
@@ -141,8 +199,8 @@ static struct wait_queue rxwait;
 static struct wait_queue txwait;
 
 static byte_t usecount;
-static byte_t is_8bit;
-static byte_t model_name[] = "wd80x3";
+static byte_t is_8bit = 0xff;
+static byte_t model_name[] = "wd8013";
 static byte_t dev_name[] = "wd0";
 static byte_t stop_page; 	/* actual last pg of ring (+1) */
 static unsigned char found;
@@ -162,7 +220,7 @@ extern struct eth eths[];
  * Get MAC
  */
 
-static void wd_get_hw_addr(word_t * data)
+static void wd_get_hw_addr(word_t *data)
 {
 	unsigned u;
 
@@ -176,46 +234,54 @@ static void wd_get_hw_addr(word_t * data)
  */
 
 static int INITPROC wd_probe(void) {
-	int i, tmp = 0;
+	int i, type, tmp = 0;
 
+	//wd_reset();	/* Experimental, Should not be required */'
+#if DEBUG
+	for (i = 0; i < 16; i++)
+		printk("%x;", type = inb(net_port+i));
+	printk("\n");
+#endif
 	for (i = 0; i < 8; i++)
 		tmp += inb(net_port + 8 + i);
-	if (inb(net_port + 8) == 0xff	/* Extra check to avoid soundcard. */
-		|| inb(net_port + 9) == 0xff
-		|| (tmp & 0xff) != 0xFF)
+	if (inb(net_port + 8) == 0xff
+		|| inb(net_port + 9) == 0xff	/* Extra check to avoid soundcard. */
+		|| (tmp & 0xff) != 0xFF)	/* checksum test */
 		return -ENODEV;	
+
+	/* config flag processing */
+	verbose = (net_flags&ETHF_VERBOSE);	/* set verbose messages */
+	if (net_flags&ETHF_8BIT_BUS)  is_8bit = 1;
+	if (net_flags&ETHF_16BIT_BUS) is_8bit = 0;
 
 	/*  device found - check what type */
 	tmp = inb(net_port+1);			/* fiddle with 16bit bit */
+
 	outb(tmp ^ 0x01, net_port+1 );		/* attempt to clear 16bit bit */
-	if (((inb(net_port+1) & 0x01) == 0x01)	/* A 16 bit card */
-				&& (tmp & 0x01) == 0x01	) {		/* In a 16 slot. */
+	if (((type = (inb(net_port+1) & 0x01)) == 0x01)	/* A 16 bit card */
+				&& (tmp & 0x01) == 0x01		/* In a 16 slot */
+				&& (is_8bit != 1)) {		/* and not forced to 8bit mode */
 		int asic_reg5 = inb(net_port+WD_CMDREG5);
 		/* Magic to set ASIC to word-wide mode. */
 		outb(NIC16 | (asic_reg5&0x1f), net_port+WD_CMDREG5);
-		outb(tmp, net_port+1);
-		model_name[4] = '1';
-		is_8bit = 0;		/* We have a 16bit board here! */
-		stop_page = WD_STOP_PG16;	// FIXME: calculate from config parameter
-						// since some interfaces have large (32k)
-						// buffer ram
-		netif_stat.oflow_keep = 3;
+		is_8bit = 0;		/* may be unset at this point, indicate 16bit */
+		netif_stat.oflow_keep = 3;	/* should be scaled by RAM size */
 	} else {
-		model_name[4] = '0';	// FIXME: Incorrect if 16bit i/f in 8bit slot */
-		is_8bit = 1;		/* board must be 8 bit */
-		if (!(net_flags & (ETHF_8BIT_BUS | ETHF_16BIT_BUS)))
-			 netif_stat.if_status |= NETIF_AUTO_8BIT;
+		if (!type) model_name[4] = '0';	
+		is_8bit = 1;	/* We're running 8bit regardless of bus and type */
 		netif_stat.oflow_keep = 1;
-		stop_page = WD_STOP_PG8;
 	}
-	/* do the config flag processing */
-	if (net_flags&ETHF_8BIT_BUS)  is_8bit = 1;
-	if (net_flags&ETHF_16BIT_BUS) is_8bit = 0;	/* overrides 8bit */
-	if (net_flags&0x07)				/* Force buffer size */
-		stop_page = WD_STOP_PG4 << (net_flags&0x03);
-	verbose = (net_flags&ETHF_VERBOSE);	/* set verbose messages */
-	//printk("net_flags %04x stop_page %02x verbose %d\n", net_flags, stop_page, verbose);
+	if ((unsigned)inb(net_port+0xe) > 0x29) {	/* update to wd8216 */
+		model_name[3] = '2';
+		model_name[5] = '6';
+	}
 	outb(tmp, net_port+1);			/* Restore original reg1 value. */
+	stop_page = WD_STOP_PG8;	/* this is always the default */
+	if (net_flags&0x07)		/* Force buffer size */
+		stop_page = WD_STOP_PG4 << (net_flags&0x03);
+#if DEBUG
+	printk("net_flags %04x stop_page %02x verbose %d\n", net_flags, stop_page, verbose);
+#endif
 
 	return 0;
 }
@@ -227,8 +293,11 @@ static int INITPROC wd_probe(void) {
 static void wd_reset(void)
 {
 	outb(WD_RESET, net_port);
-	// FIXME: should wait until reset has completed, works OK on slow machines.
-	outb(((net_ram >> 9U) & 0x3fU) | WD_MEMENB, net_port);
+	/* FIXME: It's unclear whether reset is instant or we should wait/delay
+	 * a little. That's presumably what the Reset Complete interrupt is for. */
+
+	/* Do NOT enable shared mem here */
+	//outb(((net_ram >> 9) & 0x3f) | WD_MEMENB, net_port);
 }
 
 /*
@@ -303,15 +372,17 @@ static void wd_init_8390(int strategy)
 
 static void wd_start(void)
 {
-	if (inb(net_port + 14U) & 0x20U) /* enable IRQ on softcfg card */
-		outb(inb(net_port + 4U) | 0x80U, net_port + 4U);
-	outb(((net_ram >> 9U) & 0x3fU) | WD_MEMENB, net_port);
+	outb(((net_ram >> 9U) & 0x3f) | WD_MEMENB, net_port);
 
 	outb(E8390_TXCONFIG, WD_8390_PORT + EN0_TXCR); /* xmit on */
 	outb(E8390_RXCONFIG, WD_8390_PORT + EN0_RXCR); /* rx on */
 
 	outb(E8390_NODMA | E8390_PAGE0 | E8390_START, WD_8390_PORT + E8390_CMD);
 	outb(ENISR_ALL, WD_8390_PORT + EN0_IMR);	/* enable interrupts */
+	if (inb(net_port + 14) & 0x20)	/* enable IRQ on 8013 and later */
+		outb(1, net_port + 6);	/* enabled by default, turned off in wd_stop()
+					 * which is important in order to release the 
+					 * IRQ line for other uses .. */
 }
 
 /*
@@ -320,20 +391,22 @@ static void wd_start(void)
 
 static void wd_stop(void)
 {
-	outb(((net_ram >> 9U) & 0x3fU) & ~WD_MEMENB, net_port);
-	outb(0, WD_8390_PORT + EN0_IMR);	/* disable interrupts */
+	outb(((net_ram >> 9) & 0x3f) & ~WD_MEMENB, net_port);	/* turn off shared mem */
+	outb(0, WD_8390_PORT + EN0_IMR);	/* mask all interrupts */
+	if (inb(net_port + 14) & 0x20)
+		outb(0, net_port + 6); 		/* turn off interrupts on 8013, 8216 */
 }
 
 /*
  * Clear overflow
  *
- *	For ELKS, when an overflow occurs, the kernel will probably just have
+ *	For TLVC/ELKS, when an overflow occurs, the kernel will probably just have
  *	received a wakeup() from a RxComplete interrupt. 
  *	If the overflow handler purges the receive buffer
  *	completely, the next read will fail - there is nothing to read. No big
  *	deal, but noisy (error messages) and inefficient since the buffer is at
- *	least 8k. So we let 1 or more packets survive the overflow recovery (as
- *	specified by the parameter to wd_init_8390() ).
+ *	least 8k. So in most cases we let 1 or more packets survive the overflow 
+ *	recovery (as specified by the parameter to wd_init_8390() ).
  */
 
 static void wd_clr_oflow(int keep)
@@ -513,12 +586,12 @@ static word_t wd_rx_stat(void)
 	outb(E8390_NODMA | E8390_PAGE0, WD_8390_PORT + E8390_CMD);
 	set_irq();
 
-	return (current_rx_page == rxing_page) ? 0U : WD_STAT_RX;
+	return (current_rx_page == rxing_page) ? 0 : WD_STAT_RX;
 }
 
 static word_t wd_tx_stat(void)
 {
-	return (inb(WD_8390_PORT + E8390_CMD) & E8390_TRANS) ? 0U :
+	return (inb(WD_8390_PORT + E8390_CMD) & E8390_TRANS) ? 0 :
 		WD_STAT_TX;
 }
 
@@ -551,7 +624,7 @@ static int wd_select(struct inode * inode, struct file * filp, int sel_type)
  * I/O control
  */
 
-static int wd_ioctl(struct inode * inode, struct file * file,
+static int wd_ioctl(struct inode *inode, struct file *file,
 	unsigned int cmd, unsigned int arg)
 {
 	int err = 0;
@@ -592,7 +665,7 @@ static int wd_ioctl(struct inode * inode, struct file * file,
  * Device open
  */
 
-static int wd_open(struct inode * inode, struct file * file)
+static int wd_open(struct inode *inode, struct file *file)
 {
 	int err = 0;
 
@@ -618,7 +691,7 @@ static int wd_open(struct inode * inode, struct file * file)
  * Release (close) device
  */
 
-static void wd_release(struct inode * inode, struct file * file)
+static void wd_release(struct inode *inode, struct file *file)
 {
 	if (--usecount == 0) {
 		wd_stop();
@@ -657,6 +730,7 @@ static void wd_int(int irq, struct pt_regs * regs)
 {
 	word_t stat;
 
+	//kputchar('I');
 	outb(0, WD_8390_PORT + EN0_IMR);/* Block interrupts,
 					 * should not be required since the IRQ line
 					 * is held high until all unmasked bits have
@@ -694,7 +768,9 @@ static void wd_int(int irq, struct pt_regs * regs)
 		}
 		if (stat & (ENISR_RDC|ENISR_COUNTERS)) {  /* Remaining bits - should not happen */
 			// FIXME: Need to add handling of the statistics registers
-			printk("eth: RDC/Stat error, status 0x%x\n", stat & 0xe0);
+			// On 8216 cards, the RDC bit is set with every RX interrupt
+			// even when the RDC interrupt has been masked.
+			//printk("eth: RDC/Stat error, status 0x%x\n", stat);
 			outb(ENISR_RDC|ENISR_COUNTERS, WD_8390_PORT + EN0_ISR);
 		}
 	}
@@ -709,26 +785,26 @@ static void wd_int(int irq, struct pt_regs * regs)
 void INITPROC wd_drv_init(void)
 {
 	unsigned u;
-	word_t hw_addr[6U];
+	word_t hw_addr[6];
 	byte_t *mac_addr = (byte_t *)&netif_stat.mac_addr;
 
 	if (!net_port) {
 		printk("eth: %s ignored\n", dev_name);
 		return;
 	}
-	u = wd_probe();
 	printk("eth: %s at 0x%x, irq %d, ram 0x%x",
 		dev_name, net_port, net_irq, net_ram);
-	if (u) {
+	if (wd_probe()) {
 		printk(" not found\n");
 	} else {
 		found++;
 		wd_get_hw_addr(hw_addr);
 		for (u = 0; u < 6; u++) 
-			mac_addr[u] = hw_addr[u]&0xffU;
-		printk(", (%s) MAC %02X", model_name, mac_addr[0]);
-		for (u = 1U; u < 6U; u++) 
+			mac_addr[u] = hw_addr[u]&0xff;
+		printk(", (%s%s) MAC %02X", model_name, is_8bit?", 8bit":"", mac_addr[0]);
+		for (u = 1; u < 6; u++) 
 			printk(":%02X", mac_addr[u]);
+		if (verbose) printk(", type 0x%x", inb(net_port+0xe)&0xff);
 		printk(", flags 0x%x\n", net_flags);
 	}
 	eths[ETH_WD].stats = &netif_stat;

--- a/tlvccmd/man/man4/wd.4
+++ b/tlvccmd/man/man4/wd.4
@@ -1,31 +1,32 @@
 .TH WD 4
 .SH NAME
-wd0 \- Driver for the wd/smc 8003 and 8013 ISA Ethernet controller family
+wd0 \- Driver for the wd/smc 8003/8013/8216 ISA Ethernet controller family
 .SH SYNOPSIS
 .nf
-wd8003, wd8013
+wd8003, wd8013, wd8216
 	/bootopts: wd0=11,0x300,0xcc00,0x80
 	/dev/wd0 - major: 9 minor: 1
 .fi
 .SH DESCRIPTION
 The \fBwd0\fP 
-device refers to the ELKS driver for the wd8003/8013 family of 10Mbps 
-Ethernet interfaces (aka NICs) running
-on the PC ISA 8 or 16 bit bus. The 
+device refers to the TLVC driver for the WD/SMC family of 10Mbps 
+Ethernet interfaces (aka NICs) running on the PC ISA 8 or 16 bit bus. The 
 \fBwd8013\fP
-has a full width 16 bit (double) edge connector an may be used in 16 or 8 bit modes. The
+and later models have a full width 16 bit (double) edge connector an may
+be used in 16 or 8 bit modes. The
 .B wd8003
 has a single, 8bit wide edge connector and is an 8 bit only device.
 .PP
-The driver will attempt to recognize the type of controller and adjust settings accordingly. 
+The driver will attempt to recognize the type of controller and bus width, and 
+adjust settings accordingly. 
 The actual settings will be displayed at boot time. If autodetection does not work, all settings
-may be overridden via the 
+may be overridden via the flags-parameter in the
 .I /bootopts
 file.
 .SH CONFIGURATION
 The default settings for the interface are set in the
 .I ports.h 
-file in the ELKS source tree, see the FILES section below. These settings may conveniently
+file in the TLVC source tree, see the FILES section below. These settings may conveniently
 be overridden at boot-time via the
 .I /bootopts
 file using the syntax shown in the SYNOPSIS section above.
@@ -58,7 +59,7 @@ file set the verbose flag (0x80) in the flags field to aid debugging.
 .nf
 	NAME		VALUE	FUNCTION
 	ETHF_8BIT_BUS   0x10    Force  8 bit bus
-	ETHF_16BIT_BUS  0x20    Force 16 bit bus (currently unused)
+	ETHF_16BIT_BUS  0x20    Force 16 bit bus
 	ETHF_VERBOSE    0x80    Turn on console error messages
 .fi
 
@@ -66,7 +67,8 @@ file set the verbose flag (0x80) in the flags field to aid debugging.
 When the \fBne0\fP
 interface has been configured into the running kernel via
 \fImenuconfig\fP,
-a boot message will indicate whether the configuration works or not. The following message indicates success:
+a boot message will indicate whether the configuration works or not.
+The following message indicates success:
 .PP
 .nf
 eth: wd0 at 0x320, irq 11, ram 0xcc00, (wd8013) MAC 00:00:C0:BC:8F:4B, 
@@ -76,22 +78,24 @@ eth: wd0 at 0x320, irq 11, ram 0xcc00, (wd8013) MAC 00:00:C0:BC:8F:4B,
 The interface was found at the specified I/O address, the shared memory address works and
 the displayed MAC (Ethernet) address was found and set. 
 The interrupt line (IRQ) is reported but not tested or activated at this point. If the interface does 
-not seem to work, the IRQ may be wrong.  
-If the interface has several connection options (AUI, BNC and/or TP), the card may need to 
+not seem to work, the IRQ may be wrong. Verify this by trying an outgoing 
+.I telnet
+command from the TLVC system. Since the driver will collect arrived packets when sending a packet,
+an outgoing 
+.I telnet
+connection will enable traffic to flow, even for other connections, for as long as it's 
+active. If it stops, type enter and it continues.
+.PP 
+If the interface has several connection options (AUI, BNC and/or TP), this may also be the source
+of the problem. The card may need to 
 be configured specifically for the connection type in use.
 .PP
 If the interface is reported as 'not found' it is likely that the I/O address is wrong. 
-.PP
-.nf
-eth: wd0 at 0x320, irq 11, ram 0xcc00 not found
-.fi
-.PP
-Check the configuration again – in particular the IRQ and the shared memory address.
-On most reasonably modern NICs this means firing 
-up a configuration utility under MSDOS to do so called 'soft configuration'. 
-Older NICs are configured via physical jumpers,
-some have both, one jumper setting indicating 'soft configuration'. Make sure that the shared
-memory address is used by other ISA interfaces.
+Use the DOS
+.I EZSETUP
+program to configure jumperless cards.
+Also make sure that the shared
+memory address is not used by other ISA interfaces.
 .PP
 If the interface seems to work  or partly work but emit error messages while 
 transferring data, make sure you set the
@@ -128,12 +132,13 @@ more than once - indicate a hardware malfunction.
 \fIeth: mismatched read page pointers %2x vs %2x.\fR
 .fi
 This should never happen and indicates either a driver bug or a physical hardware problem.
-Contact the ELKS suppofrt sommunity if you see this error.
+Contact the TLVC support community if you see this error.
 .PP
 .nf
 \fIwd0: Rcv oflow (0x%x), keep %d\fR
 .fi
-The interface was unable to handle the amount of incoming traffic and had to discard one or more packets.
+The interface was unable to handle the amount of incoming traffic and had to 
+discard one or more packets.
 Since incoming packets are transferred directly from the interface buffer to user space,
 with no buffering by the operating system, this may occur regularly when under heavy load. 
 If it happens in light load conditions, it may indicate a hardware or network media problem.
@@ -199,4 +204,4 @@ ioctl is currently unused and disabled.
 .BR bootopts (5).
 .SH AUTHOR
 Adapted from the ELKS ne2k driver by @pawosm-arm (2020), expanded and partly 
-rewritten by @mellvik (2022).
+rewritten by @mellvik/TLVC (2022, 2025).


### PR DESCRIPTION
This update fixes a number of known and unknown problems in the WD ethernet driver. The old driver was adapted to - and worked well with - the wd8003 series of 8bit cards. The quick 2023 update to support the wd8013 series worked, but only with some cards and under some circumstances. Here are the most important fixes and enhancements in this version (also refer to the developer notes in the source):
- Support for 8216 (aka 'ultra'?) NICs (see #146) (the 8216 likely has a lot of untapped potential).
- A 8013 (or later) card in an 8bit system would prevent the 3C509, possibly others,  from working.
- A misplaced statement - innocuous to the 8003 - would accidentally enable the alternate register set in some 8013 and all 8216 cards which would prevent interrupts from working and leave the card unbootable ('un-initializeable') until power cycle. 
- Interrupts are now properly enabled and disabled on 8013 and 8216 cards, freeing up the IRQ line for other uses after device close. Likewise, the shared memory is now freed properly on device close.
- Device probing now handles config (bootopts) flags correctly
- Shared RAM is now set to 8k regardless of device type, may be overridden via bootopts. I have not found any cards that have more than 8k.
- Some noisy messages have been eliminated.
- The boot (config) message will now indicate 8bit mode when appropriate.
