### PR TITLE
Miscellaneous fixes and updates

### DIFF
--- a/tlvc/arch/i86/drivers/block/directhd.c
+++ b/tlvc/arch/i86/drivers/block/directhd.c
@@ -518,7 +518,7 @@ int INITPROC directhd_init(void)
 #if defined(CONFIG_FS_XMS_BUFFER) || defined(USE_LOCALBUF)
 	localbuf = heap_alloc(BLOCK_SIZE, HEAP_TAG_DRVR);	/* permanent bounce buffer */
 	if (!localbuf) {
-	    printk("athd: cannot allocate bounce buffer\n");
+	    printk("hd: cannot allocate bounce buffer\n");
 	    return -ENOMEM;
 	}
 	ide_buffer = (word_t *)localbuf;
@@ -532,7 +532,7 @@ int INITPROC directhd_init(void)
 	mdelay(OLD_IDE_DELAY);
 	i = STATUS(port);
 	if (!i || (i & 1) == 1) { /* error - drive not found or non-ide */
-	    //printk("athd%d (port 0x%x) not found (%x)\n", drive, port, i);
+	    //printk("hd%d (port 0x%x) not found (%x)\n", drive, port, i);
 	    continue;	/* Proceed with next drive.
 			 * Always do this, even if the master drive
 			 * is missing.  */
@@ -629,7 +629,7 @@ int INITPROC directhd_init(void)
 	    }
 #endif	/* USE_MULTISECT_IO */
 	    printk("\n");
-	    //printk("athd%d: IDE data 47-49: %04x, %04x, %04x\n", drive, 
+	    //printk("hd%c: IDE data 47-49: %04x, %04x, %04x\n", 'a'+drive, 
 		//ide_buffer[47], ide_buffer[48], ide_buffer[49]);
 	} else
 	    printk("hd%c: No valid drive ID\n", ('a'+drive));
@@ -639,7 +639,7 @@ int INITPROC directhd_init(void)
 #endif
     }
     if (!hdcount) {
-	printk("athd: no drives found\n");
+	printk("hd: no drives found\n");
 	return 0;
     }
 

--- a/tlvc/arch/i86/drivers/block/genhd.c
+++ b/tlvc/arch/i86/drivers/block/genhd.c
@@ -70,7 +70,7 @@ static void INITPROC print_minor_name(register struct gendisk *hd,
     printk(":(%lu,%lu) ", hdp->start_sect, hdp->nr_sects);
 }
 
-static void INITPROC add_partition(struct gendisk *hd, unsigned short int minor,
+static void INITPROC add_partition(struct gendisk *hd, unsigned short minor,
 			  sector_t start, sector_t size)
 {
     struct hd_struct *hdp = &hd->part[minor];

--- a/tlvc/arch/i86/drivers/block/init.c
+++ b/tlvc/arch/i86/drivers/block/init.c
@@ -44,7 +44,7 @@
 extern int directhd_initialized;
 #endif
 
-int boot_rootdev;	/* set by /bootopts options if configured*/
+int boot_rootdev;	/* set by /bootopts options if configured */
 extern int boot_partition;
 char running_qemu;	/* for directhd/fd */
 
@@ -60,7 +60,6 @@ void INITPROC device_init(void)
 
     for (p = gendisk_head; p; p = p->next)
 	setup_dev(p);
-    //printk("boot_rootdev 0x%x, ", boot_rootdev);
 
     /*
      * The bootloader may have passed us a ROOT_DEV which is actually a BIOS

--- a/tlvc/arch/i86/drivers/char/eth.c
+++ b/tlvc/arch/i86/drivers/char/eth.c
@@ -15,6 +15,7 @@ extern struct file_operations ne2k_fops;    /* 0 CONFIG_ETH_NE2K */
 extern struct file_operations wd_fops;      /* 1 CONFIG_ETH_WD */
 extern struct file_operations el3_fops;     /* 2 CONFIG_ETH_EL3 */
 extern struct file_operations ee16_fops;    /* 3 CONFIG_ETH_EE16 */
+extern struct file_operations lance_fops;   /* 4 CONFIG_ETH_LANCE */
 
 struct eth eths[MAX_ETHS];
 
@@ -102,16 +103,24 @@ void INITPROC eth_init(void)
     eths[ETH_NE2K].ops = &ne2k_fops;
     ne2k_drv_init();
 #endif
+
 #ifdef CONFIG_ETH_WD
     eths[ETH_WD].ops = &wd_fops;
     wd_drv_init();
 #endif
+
 #ifdef CONFIG_ETH_EL3
     eths[ETH_EL3].ops = &el3_fops;
     el3_drv_init();
 #endif
+
 #ifdef CONFIG_ETH_EE16
     eths[ETH_EE16].ops = &ee16_fops;
     ee16_drv_init();
+#endif
+
+#ifdef CONFIG_ETH_LANCE
+    eths[ETH_LANCE].ops = &lance_fops;
+    lance_drv_init();
 #endif
 }

--- a/tlvc/arch/i86/drivers/net/Makefile
+++ b/tlvc/arch/i86/drivers/net/Makefile
@@ -40,6 +40,9 @@ endif
 ifeq ($(CONFIG_ETH_EE16), y)
 OBJS += ee16-asm.o ee16.o
 endif
+ifeq ($(CONFIG_ETH_LANCE), y)
+OBJS += lance.o
+endif
 
 all: net_drv.a
 

--- a/tlvc/arch/i86/drivers/net/config.in
+++ b/tlvc/arch/i86/drivers/net/config.in
@@ -8,10 +8,10 @@ mainmenu_option next_comment
 	bool 'Ethernet device support' CONFIG_ETH y
 	if [ "$CONFIG_ETH" = "y" ]; then
 		bool 'NE2K'			CONFIG_ETH_NE2K y
-		bool 'WD/SMC8003'	CONFIG_ETH_WD y
-		bool '3C509'		CONFIG_ETH_EL3 y
+		bool 'WD/SMC80x3'	CONFIG_ETH_WD y
+		bool '3Com 3C509'		CONFIG_ETH_EL3 y
 		bool 'Intel EtherExpress 16'		CONFIG_ETH_EE16 y
-		bool 'Lance/79C760'     CONFIG_ETH_LANCE y
+		bool 'AMD Lance/79C760'     CONFIG_ETH_LANCE y
 
 	fi
 endmenu

--- a/tlvc/config.in
+++ b/tlvc/config.in
@@ -16,7 +16,7 @@ mainmenu_option next_comment
 
 		bool 'Compaq DeskPro Hardware (fast mode)' CONFIG_HW_COMPAQFAST n
 		bool 'MK-88 Hardware (IRQ 3 keyboard)' CONFIG_HW_MK88 n
-		bool 'IBM PC/XT or compatible (8bit ISA)' CONFIG_HW_PCXT n
+		bool 'Include IBM PC/XT or compatible (8bit ISA) support' CONFIG_HW_PCXT n
 		bool 'Add calibrated delay for drivers' CONFIG_CALIBRATE_DELAY n
 
 		comment 'Devices'

--- a/tlvc/fs/inode.c
+++ b/tlvc/fs/inode.c
@@ -169,7 +169,7 @@ void finvalidate_inodes(kdev_t dev, int force)
         prev = inode->i_prev;	/* clear_inode() changes the queues.. */
 	if (inode->i_dev != dev) continue;
 	if (!force && (inode->i_count || inode->i_dirt || inode->i_lock))
-	    printk("VFS: inode %04x busy on removed device %D\n", inode, dev);
+	    printk("VFS: inode %lu busy on removed device %D\n", inode->i_ino, dev);
 	else
 	    clear_inode(inode);
     } while ((inode = prev) != NULL);

--- a/tlvc/fs/msdos/inode.c
+++ b/tlvc/fs/msdos/inode.c
@@ -18,11 +18,19 @@
 #ifdef CONFIG_FS_DEV
 /* FAT device table, increase DEVDIR_SIZE and DEVINO_BASE to add entries*/
 struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
+#ifdef CONFIG_BLK_DEV_HD
     { "hda",	S_IFBLK | 0644, MKDEV(5, 0) },
     { "hda1",	S_IFBLK | 0644, MKDEV(5, 1) },
     { "hda2",	S_IFBLK | 0644, MKDEV(5, 2) },
     { "hda3",	S_IFBLK | 0644, MKDEV(5, 3) },
     { "hda4",	S_IFBLK | 0644, MKDEV(5, 4) },
+    { "rhda",	S_IFCHR | 0644, MKDEV(5, 0) },
+    { "rhda1",	S_IFCHR | 0644, MKDEV(5, 1) },
+    { "rhda2",	S_IFCHR | 0644, MKDEV(5, 2) },
+    { "rhda3",	S_IFCHR | 0644, MKDEV(5, 3) },
+    { "rhda4",	S_IFCHR | 0644, MKDEV(5, 4) },
+#endif
+#ifdef CONFIG_BLK_DEV_BHD
     { "hdb",	S_IFBLK | 0644, MKDEV(5, 32)},
     { "bda",	S_IFBLK | 0644, MKDEV(3, 0) },
     { "bda1",	S_IFBLK | 0644, MKDEV(3, 1) },
@@ -34,11 +42,32 @@ struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "bdb2",	S_IFBLK | 0644, MKDEV(3, 34)},
     { "bdb3",	S_IFBLK | 0644, MKDEV(3, 35)},
     { "bdb4",	S_IFBLK | 0644, MKDEV(3, 36)},
+#endif
+#ifdef CONFIG_BLK_DEV_FD
     { "df0",	S_IFBLK | 0644, MKDEV(2,  0)},
     { "df1",	S_IFBLK | 0644, MKDEV(2,  1)},
+    { "rdf0",	S_IFCHR | 0644, MKDEV(2,  0)},
+    { "rdf1",	S_IFCHR | 0644, MKDEV(2,  1)},
+#endif
+#ifdef CONFIG_BLK_DEV_BFD
     { "fd0",	S_IFBLK | 0644, MKDEV(3,128)},
     { "fd1",	S_IFBLK | 0644, MKDEV(3,160)},
+#endif
+#ifdef CONFIG_BLK_DEV_RAM
     { "rd0",	S_IFBLK | 0644, MKDEV(1, 0) },
+#endif
+#ifdef CONFIG_BLK_DEV_XD
+    { "xda",	S_IFBLK | 0644, MKDEV(6, 0) },
+    { "xda1",	S_IFBLK | 0644, MKDEV(6, 1) },
+    { "xda2",	S_IFBLK | 0644, MKDEV(6, 2) },
+    { "xda3",	S_IFBLK | 0644, MKDEV(6, 3) },
+    { "xda4",	S_IFBLK | 0644, MKDEV(6, 4) },
+    { "rxda",	S_IFCHR | 0644, MKDEV(6, 0) },
+    { "rxda1",	S_IFCHR | 0644, MKDEV(6, 1) },
+    { "rxda2",	S_IFCHR | 0644, MKDEV(6, 2) },
+    { "rxda3",	S_IFCHR | 0644, MKDEV(6, 3) },
+    { "rxda4",	S_IFCHR | 0644, MKDEV(6, 4) },
+#endif
     { "kmem",	S_IFCHR | 0644, MKDEV(1, 2) },
     { "null",	S_IFCHR | 0644, MKDEV(1, 3) },
     { "zero",	S_IFCHR | 0644, MKDEV(1, 5) },
@@ -53,11 +82,13 @@ struct msdos_devdir_entry devnods[DEVDIR_SIZE] = {
     { "ptyp0",	S_IFCHR | 0644, MKDEV(11, 8) },
     { "ttyp1",	S_IFCHR | 0644, MKDEV(4, 9) },
     { "ptyp1",	S_IFCHR | 0644, MKDEV(11, 9) },
+#ifdef CONFIG_ETH
     { "tcpdev",	S_IFCHR | 0644, MKDEV(8, 0) },
     { "ne0",	S_IFCHR | 0644, MKDEV(9, 0) },
     { "wd0",	S_IFCHR | 0644, MKDEV(9, 1) },
     { "3c0",	S_IFCHR | 0644, MKDEV(9, 2) },
     { "ee0",	S_IFCHR | 0644, MKDEV(9, 3) },
+#endif
 };
 #endif
 

--- a/tlvccmd/misc_utils/hd.c
+++ b/tlvccmd/misc_utils/hd.c
@@ -39,15 +39,12 @@ printline(long address, int *num, char *chr, int eofflag)
 {
    int   j;
 
-   if (lastaddr >= 0)
-   {
+   if (lastaddr >= 0) {
       for (j = 0; j < 16; j++)
 	 if (num[j] != lastnum[j])
 	    break;
-      if (j == 16 && !eofflag)
-      {
-	 if (lastaddr + 16 == address)
-	 {
+      if (j == 16 && !eofflag) {
+	 if (lastaddr + 16 == address) {
 	    fprintf(ofd, "*\n");
 	    fflush(ofd);
 	 }
@@ -96,7 +93,7 @@ void do_fd(void)
 	 else
 	    buf[j] = '.';
       }
-       if (j) printline(offset, num, buf, ch == EOF);
+      if (j) printline(offset, num, buf, ch == EOF);
    }
 }
 

--- a/tlvccmd/sys_utils/clock.c
+++ b/tlvccmd/sys_utils/clock.c
@@ -178,6 +178,9 @@
 
 #define AST_CHIPTYPE	0x0D	/* Distinguish between Ricoh and NS chip via
 				 * this register */
+#define AST_CHIP_NONE	-1
+#define AST_CHIP_RI	0
+#define AST_CHIP_NS	2
 
 /* Globals */
 int	readit = 0;
@@ -339,7 +342,7 @@ int ast_chiptype(void)
     /* Otherwise (all hw) returns 0xff */
 
     if ((ast_getreg(1) + ast_getreg(2) + ast_getreg(3) + ast_getreg(4)) / 4 == ast_getreg(1))
-	return -1;
+	return AST_CHIP_NONE;
 
     ast_putreg(AST_CHIPTYPE, tmp);
     return (ast_getreg(AST_CHIPTYPE) & 0x2);
@@ -348,7 +351,7 @@ int ast_chiptype(void)
 #ifdef AST_TEST
 void show_astclock(void)
 {
-    if (ast_chiptype()) {
+    if (ast_chiptype() != AST_CHIP_NONE) {
 	printf("AST clock (NS): %d/%d/%d - %02d:%02d:%02d.%d\n", ast_getbcd(AST_NS_DOM), ast_getbcd(AST_NS_MON),
 	       ast_getreg(AST_NS_YEAR) + 1980, ast_getbcd(AST_NS_HRS), ast_getbcd(AST_NS_MIN),
 	       ast_getbcd(AST_NS_SEC), ast_getbcd(AST_NS_MSEC));
@@ -450,7 +453,7 @@ int main(int argc, char **argv)
     }
 
     if (astclock || !cmos_probe()) {	/* don't run cmos_probe() if ASTclock is set */
-	if (ast_chiptype() < 0) {
+	if (ast_chiptype() == AST_CHIP_NONE) {
 	    printf("No RTC found on system, not setting date and time\n");
 	    exit(1);
 	} else {
@@ -590,7 +593,7 @@ void ast_gettime(struct tm *tm)
 {
     int wait = AST_RETRY;
 
-    if (ast_chiptype()) {
+    if (ast_chiptype() == AST_CHIP_NS) {
 
 	do {			/* NS clock chip */
 	    tm->tm_sec = ast_getbcd(AST_NS_SEC);
@@ -634,7 +637,7 @@ void cmos_gettime(struct tm *tm)
 
 void ast_settime(struct tm *tmp)
 {
-    if (ast_chiptype()) {
+    if (ast_chiptype() == AST_CHIP_NS) {
 	ast_putreg(AST_NS_CRST, 0xff);	/* clear counters */
 	ast_putbcd(AST_NS_SEC, tmp->tm_sec);
 	ast_putbcd(AST_NS_MIN, tmp->tm_min);

--- a/tlvccmd/sys_utils/meminfo.c
+++ b/tlvccmd/sys_utils/meminfo.c
@@ -253,10 +253,10 @@ void blk_scan(void)
 	segs[i].end = curend;
 	if (Pflag) return;
 
-	printf("Kernel heap (DS-base %x):\n\t   SEG   OFFS   SIZE\n", ds);
+	printf("Kernel heap:\n\t   SEG   OFFS   SIZE\n");
 	int tot = 0;
 	for (i = 0; heap[i].base; i++) {
-	    printf(" Block %d: %x   %x  %5u bytes\n", i+1, (heap[i].base>>4) + ds, heap[i].base,
+	    printf(" Block %d: %x   %x  %5u bytes\n", i+1, ds, heap[i].base,
 	    	     heap[i].end - heap[i].base);
 	    tot += heap[i].end - heap[i].base;
 	}


### PR DESCRIPTION
Many updates, some fixes, the most important being
- IDE driver - directhd.c: Change boot message identification from `athd%` to `hd%`
- 3C509 driver - el3.c: Changed debug tooling 
- Adjusted some messages in the `menuconfig` files
- Changed the display of heap addressing in `meminfo` to be less confusing: SEG and OFFSET was the same address, the former shifted 4 to the right, so it was unclear what the OFFSET was offset from. Now the kernel DS seg is displayed instead.
- The `clock` utility had a bug in the code detecting which AST chip was in use
- `msdos/inode.c` has been updated with raw devices in the FAT device table