### PR TITLE
[kernel] Add limited HMA support

### DIFF
--- a/tlvc/arch/i86/lib/unreal.S
+++ b/tlvc/arch/i86/lib/unreal.S
@@ -119,8 +119,8 @@ enable_unreal_mode:
 
 # Get XMS size from BIOS; may or may not be reliable
 get_xms_size:
-	mov     $0x8800,%ax     # BIOS enable A20
-	int     $0x15           # CF clear on success
+	mov     $0x8800,%ax
+	int     $0x15		# CF clear on success
 	jnc	1f
 	xor	%ax,%ax		# just return zero 
 1:

--- a/tlvc/arch/i86/lib/unreal.S
+++ b/tlvc/arch/i86/lib/unreal.S
@@ -39,6 +39,7 @@
 	.global	enable_a20_gate
 	.global	verify_a20
 	.global	set_a20
+	.global get_xms_size
 	.global	linear32_fmemcpyw
 	.global	linear32_fmemcpyb
 	.global	linear32_fmemset
@@ -114,6 +115,15 @@ enable_unreal_mode:
 	popf			# restore interrupt status
 
 	mov	$1,%ax		# system is in unreal mode, return 1
+	ret
+
+# Get XMS size from BIOS; may or may not be reliable
+get_xms_size:
+	mov     $0x8800,%ax     # BIOS enable A20
+	int     $0x15           # CF clear on success
+	jnc	1f
+	xor	%ax,%ax		# just return zero 
+1:
 	ret
 
 # Attempt to enable A20 address gate, return 0 on fail

--- a/tlvc/arch/i86/lib/unreal.S
+++ b/tlvc/arch/i86/lib/unreal.S
@@ -27,6 +27,7 @@
 #   USE_A20ASM		- use Chris Giese A20.ASM method (send D0, read, OR 2, D1, write)
 #   USE_HIMEM_AT	- use himem.sys PC AT method (send D1,DF,FF)
 #define USE_A20ASM
+#define USE_BIOS
 //#define USE_HIMEM_AT
 
 	.arch	i386,nojumps
@@ -118,11 +119,13 @@ enable_unreal_mode:
 # Attempt to enable A20 address gate, return 0 on fail
 enable_a20_gate:
 	mov	$1,%ah		# enable A20
+#ifdef USE_BIOS
 	call	bios_set_a20	# try BIOS first
 	call	verify_a20	# returns 1 if enabled, 0 if disabled
 	and	%ax,%ax
 	jnz	1f
 	mov	$1,%ah		# enable A20
+#endif
 	call	set_a20		# call configurable A20 handler
 	call	verify_a20	# returns 1 if enabled, 0 if disabled
 1:	ret
@@ -161,6 +164,7 @@ verify_a20:
 
 #
 # enable/disable A20 gate using keyboard port/controller, entry AH=0 disable
+#ifdef USE_BIOS
 bios_set_a20:
 	or	%ah,%ah
 	jz	bios_reset_a20
@@ -171,6 +175,7 @@ bios_reset_a20:
 	mov	$0x2400,%ax	# BIOS disable A20
 	int	$0x15
 	ret
+#endif
 
 #ifdef USE_A20ASM
 set_a20:

--- a/tlvc/arch/i86/mm/xms.c
+++ b/tlvc/arch/i86/mm/xms.c
@@ -35,7 +35,7 @@ extern void int15_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t 
  *     in linear32_fmemcypw.
  */
 
-int xms_size;		/* set in buffer.c */
+int xms_size;
 static long_t xms_alloc_ptr = XMS_START_ADDR;
 
 /* try to enable unreal mode and A20 gate. Return 1 if successful */
@@ -63,7 +63,7 @@ void xms_init(void)
 	debug(" now %s, ", enabled? "on" : "off");
 	if (!enabled) {
 		xms_size = 0;
-		printk("disabled, A20 error, ");
+		printk("disabled, A20 error\n");
 	} else {
 #ifdef CONFIG_FS_XMS_INT15
 		printk("using int 15/1F");

--- a/tlvc/fs/buffer.c
+++ b/tlvc/fs/buffer.c
@@ -80,7 +80,7 @@ static struct buffer_head *L1map[MAX_NR_MAPBUFS]; /* L1 indexed pointer to L2 bu
 static struct wait_queue L1wait;                  /* Wait for a free L1 buffer area */
 static int lastL1map;
 #endif
-int xms_enabled;
+extern int xms_size;		/* kbytes, 0 if not present */
 static int map_count, remap_count, unmap_count;
 
 static int nr_free_bh, nr_bh;
@@ -135,7 +135,7 @@ static void INITPROC add_buffers(int nbufs, char *buf, ramdesc_t seg)
 	size_t offset;
 
         /* segment adjusted to require no offset to buffer */
-        offset = xms_enabled? ((n & 63) << BLOCK_SIZE_BITS) :
+        offset = xms_size? ((n & 63) << BLOCK_SIZE_BITS) :
                               ((n & 63) << (BLOCK_SIZE_BITS - 4));
         ebh->b_L2seg = seg + offset;
 #else
@@ -193,9 +193,9 @@ int INITPROC buffer_init(void)
 
 #ifdef CONFIG_FS_XMS_BUFFER
     if (nr_xms_bufs)
-        xms_enabled = xms_init();       /* try to enable unreal mode and A20 gate*/
-    if (xms_enabled)
-        bufs_to_alloc = nr_xms_bufs;
+        xms_init();       /* try to enable unreal mode and A20 gate*/
+    if (xms_size)	  /* set in xms_init() */
+        bufs_to_alloc = (nr_xms_bufs > (xms_size-64)) ? (xms_size-64) : nr_xms_bufs;
 #endif
 #ifdef CONFIG_FAR_BUFHEADS
     if (bufs_to_alloc > 2975) bufs_to_alloc = 2975; /* max 64K far bufheads @22 bytes*/
@@ -220,10 +220,11 @@ int INITPROC buffer_init(void)
     if (!buffer_heads) return 1;
 #ifdef CONFIG_FAR_BUFHEADS
     size_t size = bufs_to_alloc * sizeof(ext_buffer_head);
-    if (xms_enabled) {		/* use HMA for ext headers */
-	unsigned int hma_seg = 0xFFFF; 
-	fmemsetw(0x10, hma_seg, 0, size >> 1);
+    if (xms_size) {		/* use HMA for ext headers */
+	seg_t hma_seg = 0xFFFF; 
+	fmemsetw((void *)0x10, hma_seg, 0, size >> 1);
 	ext_buffer_heads = _MK_FP(hma_seg, 0x10);
+	printk(", HMA available\n     ");
     } else {
 	segment_s *seg = seg_alloc((size + 15) >> 4, SEG_FLAG_BUFHEAD);
 	if (!seg) return 1;
@@ -244,7 +245,7 @@ int INITPROC buffer_init(void)
             nbufs = 64;
         bufs_to_alloc -= nbufs;
 #ifdef CONFIG_FS_XMS_BUFFER
-        if (xms_enabled) {
+        if (xms_size) {
 	    ramdesc_t xmsseg = xms_alloc((long_t)nbufs << BLOCK_SIZE_BITS);
 	    add_buffers(nbufs, 0, xmsseg);
 	    if (!b_base) b_base = xmsseg;
@@ -259,7 +260,7 @@ int INITPROC buffer_init(void)
         }
     } while (bufs_to_alloc > 0);
     printk("%d %s buffers (base @ 0x%lx), %dK L1-cache, %d req hdrs\n", abufs,
-        xms_enabled? "xms": "ext", (unsigned long)b_base, nr_map_bufs, NR_REQUEST);
+        xms_size? "xms": "ext", (unsigned long)b_base, nr_map_bufs, NR_REQUEST);
 #else
     /* no EXT or XMS buffers, internal L1 only */
     add_buffers(nr_map_bufs, L1buf, kernel_ds);

--- a/tlvc/fs/buffer.c
+++ b/tlvc/fs/buffer.c
@@ -70,7 +70,9 @@ static struct buffer_head *bh_next;
  *   extended/xms memory will be used and CONFIG_FS_NR_EXT_BUFFERS ignored.
  * Total extended/xms memory would be (BLOCK_SIZE * CONFIG_FS_NR_XMS_BUFFERS).
  * Otherwise, total main memory used is (BLOCK_SIZE * CONFIG_FS_NR_EXT_BUFFERS),
- * each main memory segment being up to 64K in size for segment register addressing
+ * each main memory segment being up to 64K in size for segment register addressing.
+ * Buffer headers are allocated in main memory unless xms memory is used, in which
+ * case the HMA segment is used.
  *
  * Number of external/main (L2) buffers specified in config by CONFIG_FS_NR_EXT_BUFFERS
  * Number of extended/xms  (L2) buffers specified in config by CONFIG_FS_NR_XMS_BUFFERS
@@ -200,7 +202,7 @@ int INITPROC buffer_init(void)
 #ifdef CONFIG_FAR_BUFHEADS
     if (bufs_to_alloc > 2975) bufs_to_alloc = 2975; /* max 64K far bufheads @22 bytes*/
 #else
-    if (bufs_to_alloc > 256) bufs_to_alloc = 256; /* protect against high XMS value*/
+    if (bufs_to_alloc > 256) bufs_to_alloc = 256;   /* protect against high XMS value*/
 #endif
 
 #else

--- a/tlvc/include/linuxmt/fs.h
+++ b/tlvc/include/linuxmt/fs.h
@@ -116,7 +116,7 @@
 #define IS_IMMUTABLE(inode) ((inode)->i_flags & S_IMMUTABLE)
 
 #ifdef CONFIG_FS_XMS_BUFFER
-#define CONFIG_FAR_BUFHEADS	/* split buffer_head and move to far memory */
+#define CONFIG_FAR_BUFHEADS	/* split buffer_head and move to far memory/HMA  */
 #endif
 
 /* allow for reduced stack usage when not using async IO */
@@ -133,20 +133,18 @@ struct buffer_head {
 /* a little tricky here - buffer_head is split into near and far components */
 struct ext_buffer_head_s {
 #endif
-    block32_t			b_blocknr;	/* 32-bit block numbers required for FAT */
-    kdev_t			b_dev;
-    struct buffer_head		*b_next_lru;
-    struct buffer_head		*b_prev_lru;
-    unsigned char		b_count;
-    unsigned char		b_locked;
-    unsigned char		b_dirty;
-    unsigned char		b_uptodate;
-//#ifdef CONFIG_FS_EXTERNAL_BUFFER
-    ramdesc_t			b_L2seg;	/* L2 buffer address @ seg:0 */
-				/* Also used in raw drivers to hold the user process data seg */
-    char			b_mapcount;	/* Count of L2 buffer mapped into L1 */
-    char			b_nr_sectors;	/* Used in raw drivers only */
-//#endif
+    block32_t		b_blocknr;	/* 32-bit block numbers required for FAT */
+    kdev_t		b_dev;
+    struct buffer_head	*b_next_lru;
+    struct buffer_head	*b_prev_lru;
+    unsigned char	b_count;
+    unsigned char	b_locked;
+    unsigned char	b_dirty;
+    unsigned char	b_uptodate;
+    ramdesc_t		b_L2seg;	/* L2 buffer address @ seg:0 */
+			/* Also used in raw drivers to hold the user process data seg */
+    char		b_mapcount;	/* Count of L2 buffer mapped into L1 */
+    char		b_nr_sectors;	/* Used in raw drivers only */
 };
 
 #ifdef CONFIG_FAR_BUFHEADS

--- a/tlvc/include/linuxmt/memory.h
+++ b/tlvc/include/linuxmt/memory.h
@@ -36,13 +36,14 @@ int check_unreal_mode(void);	/* check if unreal mode capable, returns > 0 on suc
 void enable_unreal_mode(void);	/* requires 386+ CPU to call */
 int enable_a20_gate(void);	/* returns 0 on fail */
 int verify_a20(void);		/* returns 0 if a20 disabled */
+int get_xms_size(void);		/* returns 0 if none or error, else KB above 1M */
 
 /* XMS memory management */
 #ifdef CONFIG_FS_XMS_BUFFER
 typedef __u32 ramdesc_t;	/* special physical ram descriptor */
 
 /* allocate from XMS memory */
-int xms_init(void);		/* enables unreal mode and A20 gate */
+void xms_init(void);		/* enables xms and A20 gate if present */
 ramdesc_t xms_alloc(long_t size);
 
 /* copy to/from XMS or far memory - XMS requires unreal mode and A20 gate enabled */


### PR DESCRIPTION
This PR adds limited HMA support for 286 and higher systems with extended memory (XMS).

This first cut simply uses the HMA to store the XMS buffer headers, freeing up up to 64k bytes of lower memory for applications.

The case was really simple for systems supporting unreal mode. For the Compaqs, even the 386, which don't,  I hit a wall - until I realized that A20 get turned off every time a BIOS XMS block move is called. A single statement fixed it.

There is more potential to this -to be investigated. For now - freeing up the external buffer header space is great.