### PR TITLE
[kernel] Add support for loading kernel in HMA

### DIFF
--- a/tlvc/arch/i86/boot/crt0.S
+++ b/tlvc/arch/i86/boot/crt0.S
@@ -10,10 +10,9 @@
         .extern start_kernel
         .global early_putchar
 
-#define HMA_KERNEL
-#ifdef HMA_KERNEL
-	jmp	_start
-	.word	0,0,0,0,0,0,0
+#ifdef CONFIG_HMA_KERNEL
+	jmp	_start		// 16byte filler to move entry point to the
+	.word	0,0,0,0,0,0,0	// ... start of the HMA
 #endif
 _start:
 

--- a/tlvc/arch/i86/boot/crt0.S
+++ b/tlvc/arch/i86/boot/crt0.S
@@ -10,10 +10,8 @@
         .extern start_kernel
         .global early_putchar
 
-#ifdef CONFIG_HMA_KERNEL
 	jmp	_start		// 16byte filler to move entry point to the
 	.word	0,0,0,0,0,0,0	// ... start of the HMA
-#endif
 _start:
 
 /*

--- a/tlvc/arch/i86/boot/setup.S
+++ b/tlvc/arch/i86/boot/setup.S
@@ -62,6 +62,7 @@
 !	...
 !	0x1e2:	part_offset	long Sector offset of booted MBR partition
 !	0x1e6:	elks_magic	long "ELKS", written by build tool
+|	0x1ea:	xms_kbytes	word Size of XMS memory in Kbytes
 !	0x1ea-0x1ee:		5 bytes UNUSED
 !	0x1ef:	SETUPSEG	word UNUSED
 !	0x1f1:	setup_sects	byte in 512-byte sectors, written by build tool
@@ -512,10 +513,15 @@ sys_hdr_good:
 	mov %ax,%ds
 	xor %si,%si
 
-#ifdef CONFIG_HMA_KERNEL
+	push %ds
+	mov $SETUP_DATA,%ax
+	mov %ax,%ds
 	mov $0x8800,%ax
 	int $0x15	// get xms size
 	jc  no_xms
+	mov %ax,(xms_kbytes)
+	pop %ds
+#ifdef CONFIG_HMA_KERNEL
 	cmp $64,%ax
 	jl  no_xms
 	mov $0x2401,%ax
@@ -527,8 +533,10 @@ sys_hdr_good:
 2:
 	mov $HMA_SEG,%ax
 	jmp 1f
-no_xms:
 #endif
+no_xms:
+	movw $0,(xms_kbytes)
+	pop %ds
 	mov $REL_SYSSEG,%ax
 1:
 	mov %ax,%es
@@ -727,6 +735,8 @@ data_reloc:
 	.hex4sp	%cx,"entry:"
 	.if debug_output
 	.ifeq serial_output // if not serial output
+	mov $debug_prompt, %ax
+	call csputs
 	xor %ah,%ah         // read key press
 	int $0x16
 	.endif
@@ -874,6 +884,10 @@ hex4sp: call hex4
 
 hello_mess:
 	.ascii "\r\nTLVC Setup \0"
+.if debug_output
+debug_prompt:
+	.ascii "\r\nPress key to boot: \0"
+.endif
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Architecture specific routines for IBM PC
@@ -892,7 +906,7 @@ arch_get_mem:
 #endif
 	ret
 
-// A20 handlers - from unrteal.c
+// A20 handlers - from unreal.c
 // Even quite modern BIOSes don't support the A20 INT15 calls (QEMU does)
 // set_a20: Attempt to set the A20 line on 286 and higher
 // verify_a20: Check that a20 is set/working

--- a/tlvc/arch/i86/boot/setup.S
+++ b/tlvc/arch/i86/boot/setup.S
@@ -62,8 +62,9 @@
 !	...
 !	0x1e2:	part_offset	long Sector offset of booted MBR partition
 !	0x1e6:	elks_magic	long "ELKS", written by build tool
-|	0x1ea:	xms_kbytes	word Size of XMS memory in Kbytes
-!	0x1ea-0x1ee:		5 bytes UNUSED
+!	0x1ea:	xms_kbytes	word size of xms memory in kbytes
+!	0x1ec:	hma_kernel	byte hma=kernel seen in /bootopts
+!	0x1ed-0x1ee:		2 bytes UNUSED
 !	0x1ef:	SETUPSEG	word UNUSED
 !	0x1f1:	setup_sects	byte in 512-byte sectors, written by build tool
 !	0x1f2:	ROOTFLAGS	word UNUSED
@@ -81,8 +82,6 @@
 #include <linuxmt/boot.h>
 
 // Relocating loader debug option
-// NOTE: If running the kernel in HMA, setup hangs when jumping to the kernel if
-// debug_output is active and serial_output is NOT active.
 debug_output    =       0       // display various register values during execution
 serial_output   =       0       // use INT 14 serial instead of INT 10 console out
 debug_loader    =       0       // display relocations
@@ -481,11 +480,11 @@ sys_hdr_msg:
 
 sys_hdr_good:
 	mov %sp,%bp
-	mov 8,%dx     // -2(%bp) code (text) size
+	mov 8,%dx     // -2(%bp) .text code size
 	push %dx
 	add $15,%dx   // align on next paragraph (issue #209)
 	mov $4,%cl
-	shr %cl,%dx   // DX = code size in paragraph
+	shr %cl,%dx   // DX = code size in paragraphs
 	shr %cl,%bx   // BX = header size in paragraphs
 
 	mov 12,%ax    // -4(%bp) data size
@@ -512,49 +511,31 @@ sys_hdr_good:
 	add %bx,%ax      // skip header
 	mov %ax,%ds
 	xor %si,%si
+	xor %di,%di
 
-	push %ds
-	mov $SETUP_DATA,%ax
-	mov %ax,%ds
-	mov $0x8800,%ax
-	int $0x15	// get xms size
-	jc  no_xms
-	mov %ax,(xms_kbytes)
-	pop %ds
-#ifdef CONFIG_HMA_KERNEL
-	cmp $64,%ax
-	jl  no_xms
-	mov $0x2401,%ax
-	int $0x15	// Set a20
-	jnc 2f
-	call set_a20
-	call verify_a20
-	jc no_xms
-2:
+#ifdef CONFIG_ARCH_IBMPC
+// Check whether relocating .text to HMA is possible
+	call checkhma
+	jc 2f		 // no HMA
 	mov $HMA_SEG,%ax
 	jmp 1f
 #endif
-no_xms:
-	movw $0,(xms_kbytes)
-	pop %ds
-	mov $REL_SYSSEG,%ax
-1:
-	mov %ax,%es
+2:	mov $REL_SYSSEG,%ax
+1:	mov %ax,%es
 	mov %ax,-18(%bp) // save .text segment
 	.ifeq debug_output
 	call hex4sp
 	.endif
 
-	add %dx,%ax	// add code paragraphs = .fartext start
-#ifdef CONFIG_HMA_KERNEL
-	jnc 1f		// skip if it didn't overflow (no HMA) 
-	movw $REL_SYSSEG,%ax	// .fartext start here
-1:
-#endif
-	mov %ax,-20(%bp) // save .data start in case no .fartext
-	xor %di,%di
-
 	mov -2(%bp),%cx  // code size in bytes
+	add %dx,%ax      // add code paragraphs = .fartext start
+	jnc 1f		 // skip if didn't overflow (no HMA)
+	mov $REL_SYSSEG,%ax // .fartext starts at normal .text location
+	add $16,%si	 // skip first paragraph at FFFF:0000
+	add $16,%di
+	sub $16,%cx
+1:	mov %ax,-20(%bp) // save .data start in case no .fartext
+
 	.hex4sp	%ds,"\nCopy DEF_SYSSEG .text to  REL_SYSSEG DS:"
 	.hex4sp	%si,"SI:"
 	.hex4sp	%es,"ES:"
@@ -594,12 +575,9 @@ no_xms:
 
 	mov -18(%bp),%ax  // kernel .text segment
 	add %dx,%ax       // skip code paragraphs
-#ifdef CONFIG_HMA_KERNEL
 	jnc 1f
-	mov $REL_SYSSEG,%ax	// if text in HMA, start fartext here
-#endif
-1:
-	mov %ax,%es
+	mov $REL_SYSSEG,%ax // if text in HMA, start fartext here
+1:	mov %ax,%es
 	mov %ax,-20(%bp)  // save .fartext segment
 	xor %di,%di
 
@@ -735,7 +713,7 @@ data_reloc:
 	.hex4sp	%cx,"entry:"
 	.if debug_output
 	.ifeq serial_output // if not serial output
-	mov $debug_prompt, %ax
+	mov $debug_prompt,%ax
 	call csputs
 	xor %ah,%ah         // read key press
 	int $0x16
@@ -839,6 +817,9 @@ csputs:	push	%bx
 	jmp	1b
 2:	pop	%bx
 	ret
+
+debug_prompt:
+	.ascii	"\r\nPress key to boot: \0"
 .endif
 
 // Output hex nibble, byte and word. All registers saved.
@@ -883,11 +864,7 @@ hex4sp: call hex4
 	ret
 
 hello_mess:
-	.ascii "\r\nTLVC Setup \0"
-.if debug_output
-debug_prompt:
-	.ascii "\r\nPress key to boot: \0"
-.endif
+	.ascii "\r\nELKS Setup \0"
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Architecture specific routines for IBM PC
@@ -905,89 +882,6 @@ arch_get_mem:
 	int $0x12   // AX in KB
 #endif
 	ret
-
-// A20 handlers - from unreal.c
-// Even quite modern BIOSes don't support the A20 INT15 calls (QEMU does)
-// set_a20: Attempt to set the A20 line on 286 and higher
-// verify_a20: Check that a20 is set/working
-
-#ifdef CONFIG_HMA_KERNEL
-set_a20:
-	pushf			# save interrupt status
-	cli			# interrupts off
-	call	empty_8042
-	mov	$0xD0,%al	# 8042 command byte to read output port
-	out	%al,$0x64
-1:	in	$0x64,%al
-	test	$1,%al		# output buffer (data _from_ keyboard) full?
-	jz	1b		# no, loop
-
-	in	$0x60,%al	# read output port
-	or	%ah,%ah
-	jne	2f
-	and	$0xFD,%al	# AND ~2 to disable
-	jmp	3f
-2:	or	$2,%al		# OR 2 to enable
-3:	mov	%al,%ah
-
-	call	empty_8042
-	mov	$0xD1,%al	# 8042 command byte to write output port
-	out	%al,$0x64
-
-	call	empty_8042
-	mov	%ah,%al		# the value to write
-	out	%al,$0x60
-
-	call	empty_8042
-	popf			# restore interrupt status
-	ret
-
-0:	jmp	1f		# a delay (probably not effective nor necessary)
-1:	jmp	2f
-2:	in	$0x60,%al	# read and discard data/status from 8042
-empty_8042:
-	jmp	1f
-1:	jmp	2f		# delay
-2:	in	$0x64,%al
-	test	$1,%al		# output buffer (data _from_ keyboard) full?
-	jnz	0b		# yes, read and discard
-	test	$2,%al		# input buffer (data _to_ keyboard) empty?
-	jnz	empty_8042	# no, loop
-	ret
-
-// verify if A20 gate is enabled, return 0 if disabled
-verify_a20:
-	push	%ds
-	push	%es
-
-	xor	%ax,%ax
-	mov	%ax,%ds
-	dec	%ax
-	mov	%ax,%es
-
-	pushf			# save interrupt status
-	cli			# interrupts off
-
-	mov	%es:0x10,%ax	# read word at FFFF:0010 (1 meg)
-	not	%ax		# 1's complement
-	pushw	0		# save word at 0000:0000 (0)
-
-	mov	%ax,0		# word at 0 = ~(word at 1 meg)
-	mov	0,%ax		# read it back
-	cmp	%es:0x10,%ax	# fail if word at 0 == word at 1 meg
-
-	popw	0
-
-	jz	1f		# if ZF=1, the A20 gate is NOT enabled
-	clc			# no carry: OK
-9:	popf			# restore interrupt status
-	pop	%es
-	pop	%ds
-	ret
-1:	stc			# Carry - error
-	jmp	9b
-
-#endif
 
 // Set INITSEG values for IBM PC
 // Determine display type using INT 10h AH=12 and INT 10h AH=1A
@@ -1035,10 +929,70 @@ novga:	mov	%al,14		// CGA 25 rows
 	mov	%ax,%ds
 	call	arch_get_mem	// save base memory size
 	mov	%ax,mem_kbytes
+	mov	$0x8800,%ax	// get xms size
+	int	$0x15
+	jc	1f
+	mov	%ax,xms_kbytes
 
 #ifdef CONFIG_BOOTOPTS
 	call	bootopts	// load /bootopts into DEF_OPTSEG (0050:0000)
+	call    hmabootopts	// check /bootopts for hma=kernel
+	mov	%al,hma_kernel
 #endif
+	ret
+
+// check for hma=kernel in /bootopts, return AX = 0 if not
+hmabootopts:
+	push	%ds
+	push	%es
+
+	push	%cs			// ES = our code segment
+	pop	%es
+	mov	$DEF_OPTSEG,%ax		// DS:SI = /bootopts in memory
+	mov	%ax,%ds
+
+	xor	%si,%si			// look for hma=kernel in /bootopts segment
+look:	mov	(%si),%al		// done when NUL seen
+	test	%al,%al
+	jz	1f
+	mov	$hma_string,%di
+	mov	$11,%cx
+	push	%si
+	repz
+	cmpsb				// %ds:(%si) with %es:(%di)
+	pop	%si
+	inc	%si
+	test	%cx,%cx
+	jnz	look			// NZ = no match
+	mov	$'H',%ax
+	call	putc
+	jmp	2f
+1:	xor	%ax,%ax			// no HMA
+2:	pop	%es
+	pop	%ds
+	ret
+
+hma_string:
+	.ascii	"\nhma=kernel"		// size = 11
+
+// check whether HMA can be enabled, return NC if so with A20 enabled
+checkhma:
+	push	%ds
+	mov	$INITSEG,%ax
+	mov	%ax,%ds
+	mov	xms_kbytes,%ax		//. must have xms size >= 64k
+	cmp	$64,%ax
+	jl	1f
+	mov	hma_kernel,%al		// and hma=kernel in /bootopts
+	test	%al,%al
+	jz	1f
+	call	enable_a20_gate		// and A20 enabled
+	test	%ax,%ax
+	jz	1f
+	clc				// success
+	jmp 	2f
+1:	stc				// fail
+2:	pop	%ds
 	ret
 
 // Write AL to console, save all registers
@@ -1067,6 +1021,9 @@ putc:	push %ax
 // needed for guessing system capabilities (sys_caps) for XT vs AT BIOS
 // TODO: remove and use alternate mechanism for XT vs AT BIOS capabilities
 #include "cputype.S"
+
+// include code to enable/verify A20 address gate
+#include "../lib/a20.inc"
 
 #endif /* CONFIG_ARCH_IBMPC*/
 

--- a/tlvc/arch/i86/boot/setup.S
+++ b/tlvc/arch/i86/boot/setup.S
@@ -80,6 +80,8 @@
 #include <linuxmt/boot.h>
 
 // Relocating loader debug option
+// NOTE: If running the kernel in HMA, setup hangs when jumping to the kernel if
+// debug_output is active and serial_output is NOT active.
 debug_output    =       0       // display various register values during execution
 serial_output   =       0       // use INT 14 serial instead of INT 10 console out
 debug_loader    =       0       // display relocations
@@ -91,6 +93,7 @@ debug_loader    =       0       // display relocations
 
 #define MINIX_SPLITID_LOW 0x0301L
 #define KERNEL_MAGICNUMBER MINIX_SPLITID_LOW
+#define HMA_SEG 0xffff
 
 #ifndef CONFIG_ROMCODE
   INITSEG  = DEF_INITSEG	// initial setup data seg and initial Image load address
@@ -173,7 +176,7 @@ no_sig:	lea	no_sig_mess,%si
 1:                             // And halt
 	jmp	1b
 
-no_sig_mess:	.ascii	"No TLVC setup signature found ...\0"
+no_sig_mess:	.ascii	"No ELKS setup signature found ...\0"
 
 // If setup and kernel were loaded as a blob, we need to separate them out,
 // then move to our own stack
@@ -477,11 +480,11 @@ sys_hdr_msg:
 
 sys_hdr_good:
 	mov %sp,%bp
-	mov 8,%dx     // -2(%bp) code size
+	mov 8,%dx     // -2(%bp) code (text) size
 	push %dx
 	add $15,%dx   // align on next paragraph (issue #209)
 	mov $4,%cl
-	shr %cl,%dx   // DX = code segment size in paragraph
+	shr %cl,%dx   // DX = code size in paragraph
 	shr %cl,%bx   // BX = header size in paragraphs
 
 	mov 12,%ax    // -4(%bp) data size
@@ -509,13 +512,37 @@ sys_hdr_good:
 	mov %ax,%ds
 	xor %si,%si
 
+#ifdef CONFIG_HMA_KERNEL
+	mov $0x8800,%ax
+	int $0x15	// get xms size
+	jc  no_xms
+	cmp $64,%ax
+	jl  no_xms
+	mov $0x2401,%ax
+	int $0x15	// Set a20
+	jnc 2f
+	call set_a20
+	call verify_a20
+	jc no_xms
+2:
+	mov $HMA_SEG,%ax
+	jmp 1f
+no_xms:
+#endif
 	mov $REL_SYSSEG,%ax
+1:
 	mov %ax,%es
 	mov %ax,-18(%bp) // save .text segment
 	.ifeq debug_output
 	call hex4sp
 	.endif
-	add %dx,%ax      // add code paragraphs
+
+	add %dx,%ax	// add code paragraphs = .fartext start
+#ifdef CONFIG_HMA_KERNEL
+	jnc 1f		// skip if it didn't overflow (no HMA) 
+	movw $REL_SYSSEG,%ax	// .fartext start here
+1:
+#endif
 	mov %ax,-20(%bp) // save .data start in case no .fartext
 	xor %di,%di
 
@@ -559,6 +586,11 @@ sys_hdr_good:
 
 	mov -18(%bp),%ax  // kernel .text segment
 	add %dx,%ax       // skip code paragraphs
+#ifdef CONFIG_HMA_KERNEL
+	jnc 1f
+	mov $REL_SYSSEG,%ax	// if text in HMA, start fartext here
+#endif
+1:
 	mov %ax,%es
 	mov %ax,-20(%bp)  // save .fartext segment
 	xor %di,%di
@@ -859,6 +891,89 @@ arch_get_mem:
 	int $0x12   // AX in KB
 #endif
 	ret
+
+// A20 handlers - from unrteal.c
+// Even quite modern BIOSes don't support the A20 INT15 calls (QEMU does)
+// set_a20: Attempt to set the A20 line on 286 and higher
+// verify_a20: Check that a20 is set/working
+
+#ifdef CONFIG_HMA_KERNEL
+set_a20:
+	pushf			# save interrupt status
+	cli			# interrupts off
+	call	empty_8042
+	mov	$0xD0,%al	# 8042 command byte to read output port
+	out	%al,$0x64
+1:	in	$0x64,%al
+	test	$1,%al		# output buffer (data _from_ keyboard) full?
+	jz	1b		# no, loop
+
+	in	$0x60,%al	# read output port
+	or	%ah,%ah
+	jne	2f
+	and	$0xFD,%al	# AND ~2 to disable
+	jmp	3f
+2:	or	$2,%al		# OR 2 to enable
+3:	mov	%al,%ah
+
+	call	empty_8042
+	mov	$0xD1,%al	# 8042 command byte to write output port
+	out	%al,$0x64
+
+	call	empty_8042
+	mov	%ah,%al		# the value to write
+	out	%al,$0x60
+
+	call	empty_8042
+	popf			# restore interrupt status
+	ret
+
+0:	jmp	1f		# a delay (probably not effective nor necessary)
+1:	jmp	2f
+2:	in	$0x60,%al	# read and discard data/status from 8042
+empty_8042:
+	jmp	1f
+1:	jmp	2f		# delay
+2:	in	$0x64,%al
+	test	$1,%al		# output buffer (data _from_ keyboard) full?
+	jnz	0b		# yes, read and discard
+	test	$2,%al		# input buffer (data _to_ keyboard) empty?
+	jnz	empty_8042	# no, loop
+	ret
+
+// verify if A20 gate is enabled, return 0 if disabled
+verify_a20:
+	push	%ds
+	push	%es
+
+	xor	%ax,%ax
+	mov	%ax,%ds
+	dec	%ax
+	mov	%ax,%es
+
+	pushf			# save interrupt status
+	cli			# interrupts off
+
+	mov	%es:0x10,%ax	# read word at FFFF:0010 (1 meg)
+	not	%ax		# 1's complement
+	pushw	0		# save word at 0000:0000 (0)
+
+	mov	%ax,0		# word at 0 = ~(word at 1 meg)
+	mov	0,%ax		# read it back
+	cmp	%es:0x10,%ax	# fail if word at 0 == word at 1 meg
+
+	popw	0
+
+	jz	1f		# if ZF=1, the A20 gate is NOT enabled
+	clc			# no carry: OK
+9:	popf			# restore interrupt status
+	pop	%es
+	pop	%ds
+	ret
+1:	stc			# Carry - error
+	jmp	9b
+
+#endif
 
 // Set INITSEG values for IBM PC
 // Determine display type using INT 10h AH=12 and INT 10h AH=1A

--- a/tlvc/arch/i86/lib/a20.inc
+++ b/tlvc/arch/i86/lib/a20.inc
@@ -1,0 +1,198 @@
+####################################################################################
+# A20 line management routines
+# derived from UNREAL.ASM and A20.ASM code by Chris Giese
+# 8 Nov 2021 Greg Haerr
+#
+# int enable_a20_gate(void)	- Enable A20 gate, return 0 on fail
+# int verify_a20		- Verify A20 gate status, return 0 if disabled
+# void set_a20			- ASM routine: enable (AH=1) or disable (AH=0) A20 gate
+#
+# This file is #included into unreal.S and setup.S
+
+# configurable options for A20 gate
+#   USE_BIOS		- use BIOS AX=2401h INT 15h method (always tried first)
+#   USE_A20ASM		- use Chris Giese A20.ASM method (send D0, read, OR 2, D1, write)
+#   USE_HIMEM_AT	- use himem.sys PC AT method (send D1,DF,FF)
+#define USE_BIOS
+#define USE_A20ASM
+//#define USE_HIMEM_AT
+
+	.global	enable_a20_gate
+	.global	disable_a20_gate
+	.global	verify_a20
+	.global	set_a20
+
+# Attempt to enable A20 address gate, return 0 on fail
+enable_a20_gate:
+#ifdef USE_BIOS
+	mov	$1,%ah		# enable A20
+	call	bios_set_a20	# try BIOS first
+	call	verify_a20	# returns 1 if enabled, 0 if disabled
+	and	%ax,%ax
+	jnz	1f
+#endif
+	mov	$1,%ah		# enable A20
+	call	set_a20		# call configurable A20 handler
+	call	verify_a20	# returns 1 if enabled, 0 if disabled
+1:	ret
+
+disable_a20_gate:
+#ifdef USE_BIOS
+	xor	%ah,%ah		# disable A20
+	call	bios_set_a20	# try BIOS first
+	call	verify_a20	# returns 1 if enabled, 0 if disabled
+	and	%ax,%ax
+	jnz	1f
+#endif
+	xor	%ah,%ah		# disable A20
+	call	set_a20		# call configurable A20 handler
+1:	ret
+
+# verify if A20 gate is enabled, return 0 if disabled
+verify_a20:
+	push	%ds
+	push	%es
+
+	xor	%ax,%ax
+	mov	%ax,%ds
+	dec	%ax
+	mov	%ax,%es
+
+	pushf			# save interrupt status
+	cli			# interrupts off
+
+	mov	%es:0x10,%ax	# read word at FFFF:0010 (1 meg)
+	not	%ax		# 1's complement
+	pushw	0		# save word at 0000:0000 (0)
+
+	mov	%ax,0		# word at 0 = ~(word at 1 meg)
+	mov	0,%ax		# read it back
+	cmp	%es:0x10,%ax	# fail if word at 0 == word at 1 meg
+
+	popw	0
+
+	jz	1f		# if ZF=1, the A20 gate is NOT enabled
+	mov	$1,%ax		# return 1 if enabled
+9:	popf			# restore interrupt status
+	pop	%es
+	pop	%ds
+	ret
+1:	mov	$0,%ax		# return 0 if disabled
+	jmp	9b
+
+#ifdef USE_BIOS
+#
+# enable/disable A20 gate using keyboard port/controller, entry AH=0 disable
+bios_set_a20:
+	or	%ah,%ah
+	jz	bios_reset_a20
+	mov	$0x2401,%ax	# BIOS enable A20
+	int	$0x15		# CF clear on success
+	ret
+bios_reset_a20:
+	mov	$0x2400,%ax	# BIOS disable A20
+	int	$0x15
+	ret
+#endif
+
+#ifdef USE_A20ASM
+set_a20:
+	pushf			# save interrupt status
+	cli			# interrupts off
+	call	empty_8042
+	mov	$0xD0,%al	# 8042 command byte to read output port
+	out	%al,$0x64
+1:	in	$0x64,%al
+	test	$1,%al		# output buffer (data _from_ keyboard) full?
+	jz	1b		# no, loop
+
+	in	$0x60,%al	# read output port
+	or	%ah,%ah
+	jne	2f
+	and	$0xFD,%al	# AND ~2 to disable
+	jmp	3f
+2:	or	$2,%al		# OR 2 to enable
+3:	mov	%al,%ah
+
+	call	empty_8042
+	mov	$0xD1,%al	# 8042 command byte to write output port
+	out	%al,$0x64
+
+	call	empty_8042
+	mov	%ah,%al		# the value to write
+	out	%al,$0x60
+
+	call	empty_8042
+	popf			# restore interrupt status
+	ret
+
+0:	jmp	1f		# a delay (probably not effective nor necessary)
+1:	jmp	2f
+2:	in	$0x60,%al	# read and discard data/status from 8042
+empty_8042:
+	jmp	1f
+1:	jmp	2f		# delay
+2:	in	$0x64,%al
+	test	$1,%al		# output buffer (data _from_ keyboard) full?
+	jnz	0b		# yes, read and discard
+	test	$2,%al		# input buffer (data _to_ keyboard) empty?
+	jnz	empty_8042	# no, loop
+	ret
+#endif
+
+#ifdef USE_HIMEM_AT
+set_a20:
+	pushf			# save interrupt status
+	cli			# interrupts off
+	xor	%ah,%ah
+	jz	reset_a20
+
+	call	sync_8042
+	jnz	a20_err
+
+	mov	$0xD1,%al	# send D1h (write output)
+	out	%al,$0x64
+	call	sync_8042
+	jnz	a20_err
+
+	mov	$0xDF,%al	# send DFh
+	out	%al,$0x60
+	call	sync_8042
+	jnz	a20_err
+
+	# wait for A20 line to settle down (up to 20 usecs)
+	mov	$0xFF,%al	# send FFh (pulse output port NULL)
+	out	%al,$0x64
+	call	sync_8042
+a20_err:
+	popf			# restore interrupt status
+	ret
+reset_a20:
+	call	sync_8042
+	jnz	a20_err
+
+	mov	$0xD1,%al	# send D1h (write output)
+	out	%al,$0x64
+	call	sync_8042
+	jnz	a20_err
+
+	mov	$0xDD,%al	# send DDh
+	out	%al,$0x60
+	call	sync_8042
+	jnz	a20_err
+
+
+	# wait for A20 line to settle down (up to 20 usecs)
+	mov	$0xFF,%al	# send FFh (pulse output port NULL)
+	out	%al,$0x64
+	call	sync_8042
+	popf			# restore interrupt status
+	ret
+
+sync_8042:
+	xor	%cx,%cx
+1:	in	$0x64,%al
+	and	$2,%al
+	loopnz	1b
+	ret
+#endif

--- a/tlvc/arch/i86/lib/unreal.S
+++ b/tlvc/arch/i86/lib/unreal.S
@@ -21,28 +21,17 @@
 #  like fast serial ports. Further, no other routines should be written that use
 #  the 32-bit register set without coordinating with the functions in this file.
 #
-
-# configurable options for A20 gate
-#   USE_BIOS		- use BIOS AX=2401h INT 15h method (always tried first)
-#   USE_A20ASM		- use Chris Giese A20.ASM method (send D0, read, OR 2, D1, write)
-#   USE_HIMEM_AT	- use himem.sys PC AT method (send D1,DF,FF)
-#define USE_A20ASM
-#define USE_BIOS
-//#define USE_HIMEM_AT
-
 	.arch	i386,nojumps
 	.code16
 	.text
 
 	.global	check_unreal_mode
 	.global	enable_unreal_mode
-	.global	enable_a20_gate
-	.global	verify_a20
-	.global	set_a20
-	.global get_xms_size
 	.global	linear32_fmemcpyw
 	.global	linear32_fmemcpyb
 	.global	linear32_fmemset
+
+#include "a20.inc"              # A20 gate functions shared with setup.S
 
 # Check if unreal mode capable. Currently requires 32-bit CPU (386+)
 # Returns 1 if OK, otherwise error code (-1=not 386, -2=in V86 mode).
@@ -117,179 +106,7 @@ enable_unreal_mode:
 	mov	$1,%ax		# system is in unreal mode, return 1
 	ret
 
-# Get XMS size from BIOS; may or may not be reliable
-get_xms_size:
-	mov     $0x8800,%ax
-	int     $0x15		# CF clear on success
-	jnc	1f
-	xor	%ax,%ax		# just return zero 
-1:
-	ret
-
-# Attempt to enable A20 address gate, return 0 on fail
-enable_a20_gate:
-	mov	$1,%ah		# enable A20
-#ifdef USE_BIOS
-	call	bios_set_a20	# try BIOS first
-	call	verify_a20	# returns 1 if enabled, 0 if disabled
-	and	%ax,%ax
-	jnz	1f
-	mov	$1,%ah		# enable A20
-#endif
-	call	set_a20		# call configurable A20 handler
-	call	verify_a20	# returns 1 if enabled, 0 if disabled
-1:	ret
-
-# verify if A20 gate is enabled, return 0 if disabled
-verify_a20:
-	push	%ds
-	push	%es
-
-	xor	%ax,%ax
-	mov	%ax,%ds
-	dec	%ax
-	mov	%ax,%es
-
-	pushf			# save interrupt status
-	cli			# interrupts off
-
-	mov	%es:0x10,%ax	# read word at FFFF:0010 (1 meg)
-	not	%ax		# 1's complement
-	pushw	0		# save word at 0000:0000 (0)
-
-	mov	%ax,0		# word at 0 = ~(word at 1 meg)
-	mov	0,%ax		# read it back
-	cmp	%es:0x10,%ax	# fail if word at 0 == word at 1 meg
-
-	popw	0
-
-	jz	1f		# if ZF=1, the A20 gate is NOT enabled
-	mov	$1,%ax		# return 1 if enabled
-9:	popf			# restore interrupt status
-	pop	%es
-	pop	%ds
-	ret
-1:	mov	$0,%ax		# return 0 if disabled
-	jmp	9b
-
-#
-# enable/disable A20 gate using keyboard port/controller, entry AH=0 disable
-#ifdef USE_BIOS
-bios_set_a20:
-	or	%ah,%ah
-	jz	bios_reset_a20
-	mov	$0x2401,%ax	# BIOS enable A20
-	int	$0x15		# CF clear on success
-	ret
-bios_reset_a20:
-	mov	$0x2400,%ax	# BIOS disable A20
-	int	$0x15
-	ret
-#endif
-
-#ifdef USE_A20ASM
-set_a20:
-	pushf			# save interrupt status
-	cli			# interrupts off
-	call	empty_8042
-	mov	$0xD0,%al	# 8042 command byte to read output port
-	out	%al,$0x64
-1:	in	$0x64,%al
-	test	$1,%al		# output buffer (data _from_ keyboard) full?
-	jz	1b		# no, loop
-
-	in	$0x60,%al	# read output port
-	or	%ah,%ah
-	jne	2f
-	and	$0xFD,%al	# AND ~2 to disable
-	jmp	3f
-2:	or	$2,%al		# OR 2 to enable
-3:	mov	%al,%ah
-
-	call	empty_8042
-	mov	$0xD1,%al	# 8042 command byte to write output port
-	out	%al,$0x64
-
-	call	empty_8042
-	mov	%ah,%al		# the value to write
-	out	%al,$0x60
-
-	call	empty_8042
-	popf			# restore interrupt status
-	ret
-
-0:	jmp	1f		# a delay (probably not effective nor necessary)
-1:	jmp	2f
-2:	in	$0x60,%al	# read and discard data/status from 8042
-empty_8042:
-	jmp	1f
-1:	jmp	2f		# delay
-2:	in	$0x64,%al
-	test	$1,%al		# output buffer (data _from_ keyboard) full?
-	jnz	0b		# yes, read and discard
-	test	$2,%al		# input buffer (data _to_ keyboard) empty?
-	jnz	empty_8042	# no, loop
-	ret
-#endif
-
-#ifdef USE_HIMEM_AT
-set_a20:
-	pushf			# save interrupt status
-	cli			# interrupts off
-	xor	%ah,%ah
-	jz	reset_a20
-
-	call	sync_8042
-	jnz	a20_err
-
-	mov	$0xD1,%al	# send D1h (write output)
-	out	%al,$0x64
-	call	sync_8042
-	jnz	a20_err
-
-	mov	$0xDF,%al	# send DFh
-	out	%al,$0x60
-	call	sync_8042
-	jnz	a20_err
-
-	# wait for A20 line to settle down (up to 20 usecs)
-	mov	$0xFF,%al	# send FFh (pulse output port NULL)
-	out	%al,$0x64
-	call	sync_8042
-a20_err:
-	popf			# restore interrupt status
-	ret
-reset_a20:
-	call	sync_8042
-	jnz	a20_err
-
-	mov	$0xD1,%al	# send D1h (write output)
-	out	%al,$0x64
-	call	sync_8042
-	jnz	a20_err
-
-	mov	$0xDD,%al	# send DDh
-	out	%al,$0x60
-	call	sync_8042
-	jnz	a20_err
-
-
-	# wait for A20 line to settle down (up to 20 usecs)
-	mov	$0xFF,%al	# send FFh (pulse output port NULL)
-	out	%al,$0x64
-	call	sync_8042
-	popf			# restore interrupt status
-	ret
-
-sync_8042:
-	xor	%cx,%cx
-1:	in	$0x64,%al
-	and	$2,%al
-	loopnz	1b
-	ret
-#endif
-
-#if 0
+#if UNUSED
 #
 # word_t linear32_peekw(void *src_off, addr_t src_seg)
 # WARNING: Requires 32-bit CPU, with unreal mode and A20 gate enabled!

--- a/tlvc/arch/i86/mm/xms.c
+++ b/tlvc/arch/i86/mm/xms.c
@@ -53,11 +53,10 @@ void xms_init(void)
 	}
 #else
 	if (kernel_cs == 0xffffU) {
-		printk("Not available with INT15: Kernel in HMA, ");
+		printk("Not available with INT15: Kernel in HMA");
 		return;
 	} 
 #endif
-	xms_size = get_xms_size();
 	if (!xms_size) {
 		printk("not available\n");
 		return;

--- a/tlvc/arch/i86/mm/xms.c
+++ b/tlvc/arch/i86/mm/xms.c
@@ -51,6 +51,11 @@ void xms_init(void)
 		printk("disabled, requires 386, ");
 		return;
 	}
+#else
+	if (kernel_cs == 0xffffU) {
+		printk("Not available with INT15: Kernel in HMA, ");
+		return;
+	} 
 #endif
 	xms_size = get_xms_size();
 	if (!xms_size) {

--- a/tlvc/config.in
+++ b/tlvc/config.in
@@ -59,6 +59,7 @@ mainmenu_option next_comment
 	bool 'Enable tracing (set on for development)' CONFIG_TRACE   n
 	bool 'Use INT 0Fh in idle loop for timer' CONFIG_TIMER_INT0F  n
 	bool 'Use INT 1Ch from BIOS for timer'    CONFIG_TIMER_INT1C  n
+	bool 'Use HMA memory for kernel if available' CONFIG_HMA_KERNEL n
 
 	if [ "$CONFIG_ARCH_IBMPC" = "y" ] || [ "$CONFIG_ARCH_8018X" = "y" ]; then
 		bool 'Build kernel as ROM-bootable'   CONFIG_ROMCODE      n

--- a/tlvc/config.in
+++ b/tlvc/config.in
@@ -59,7 +59,6 @@ mainmenu_option next_comment
 	bool 'Enable tracing (set on for development)' CONFIG_TRACE   n
 	bool 'Use INT 0Fh in idle loop for timer' CONFIG_TIMER_INT0F  n
 	bool 'Use INT 1Ch from BIOS for timer'    CONFIG_TIMER_INT1C  n
-	bool 'Use HMA memory for kernel if available' CONFIG_HMA_KERNEL n
 
 	if [ "$CONFIG_ARCH_IBMPC" = "y" ] || [ "$CONFIG_ARCH_8018X" = "y" ]; then
 		bool 'Build kernel as ROM-bootable'   CONFIG_ROMCODE      n

--- a/tlvc/fs/buffer.c
+++ b/tlvc/fs/buffer.c
@@ -222,16 +222,17 @@ int INITPROC buffer_init(void)
     if (!buffer_heads) return 1;
 #ifdef CONFIG_FAR_BUFHEADS
     size_t size = bufs_to_alloc * sizeof(ext_buffer_head);
-    if (xms_size) {		/* use HMA for ext headers */
+    if (xms_size && kernel_cs != 0xffffU) {		/* HMA available for ext headers */
 	seg_t hma_seg = 0xFFFF; 
 	fmemsetw((void *)0x10, hma_seg, 0, size >> 1);
 	ext_buffer_heads = _MK_FP(hma_seg, 0x10);
-	//printk(", HMA available\n     ");
+	printk(", HMA bufheads\n     ");
     } else {
 	segment_s *seg = seg_alloc((size + 15) >> 4, SEG_FLAG_BUFHEAD);
 	if (!seg) return 1;
 	fmemsetw(0, seg->base, 0, size >> 1);
 	ext_buffer_heads = _MK_FP(seg->base, 0);
+	printk(", EXT bufheads\n     ");
     }
 #endif
     bh_next = bh_lru = bh_llru = buffer_heads;

--- a/tlvc/fs/buffer.c
+++ b/tlvc/fs/buffer.c
@@ -82,7 +82,7 @@ static struct buffer_head *L1map[MAX_NR_MAPBUFS]; /* L1 indexed pointer to L2 bu
 static struct wait_queue L1wait;                  /* Wait for a free L1 buffer area */
 static int lastL1map;
 #endif
-int xms_size;		/* kbytes, 0 if not present */
+extern int xms_size;		/* kbytes, 0 if not present */
 static int map_count, remap_count, unmap_count;
 
 static int nr_free_bh, nr_bh;
@@ -196,7 +196,7 @@ int INITPROC buffer_init(void)
 #ifdef CONFIG_FS_XMS_BUFFER
     if (nr_xms_bufs)
         xms_init();       /* try to enable unreal mode and A20 gate*/
-    if (xms_size)	  /* set in xms_init() */
+    if (xms_size)
         bufs_to_alloc = (nr_xms_bufs > (xms_size-64)) ? (xms_size-64) : nr_xms_bufs;
 #endif
 #ifdef CONFIG_FAR_BUFHEADS
@@ -222,8 +222,8 @@ int INITPROC buffer_init(void)
     if (!buffer_heads) return 1;
 #ifdef CONFIG_FAR_BUFHEADS
     size_t size = bufs_to_alloc * sizeof(ext_buffer_head);
-    if (xms_size && kernel_cs != 0xffffU) {		/* HMA available for ext headers */
-	seg_t hma_seg = 0xFFFF; 
+    seg_t hma_seg = 0xFFFFU; 
+    if (xms_size && kernel_cs != hma_seg) {		/* HMA available for ext headers */
 	fmemsetw((void *)0x10, hma_seg, 0, size >> 1);
 	ext_buffer_heads = _MK_FP(hma_seg, 0x10);
 	printk(", HMA bufheads\n     ");

--- a/tlvc/include/linuxmt/boot.h
+++ b/tlvc/include/linuxmt/boot.h
@@ -52,10 +52,11 @@
 #define cpu_id          0x50            /* 13 bytes cpu id string*/
 #define part_offset     0x1e2           /* long sector offset of booted partition*/
 #define elks_magic      0x1e6           /* long "ELKS" (45 4c 4b 53) checked by boot sector*/
+#define	xms_kbytes	0x1ea		/* word Kbytes of XMS available */
+#define hma_kernel	0x1ec		/* byte hma=kernel seen in /bootopts*/
 #define setup_sects     0x1f1           /* byte 512-byte sectors used by setup.S*/
 #define syssize         0x1f4           /* word paragraph kernel size used by setup.S*/
 #define elks_flags      0x1f6           /* byte ELKS flags, BLOB and BIOS_DRV*/
-#define	xms_kbytes	0x1ea		/* word TLVC Kbytes of XMS available */
 #define root_dev        0x1fc           /* word BIOS drive or kdev_t ROOT_DEV*/
 #define boot_flag       0x1fe           /* word constant AA55h checked by boot sector*/
 #endif

--- a/tlvc/include/linuxmt/boot.h
+++ b/tlvc/include/linuxmt/boot.h
@@ -41,7 +41,7 @@
 
    The fields in /linux are mainly based on an old version of the Linux/x86
    Boot Protocol (https://www.kernel.org/doc/html/latest/x86/boot.html).
-   Fields which are specific to ELKS are indicated below.  */
+   Fields which are specific to ELKS and/or TLVC are indicated below.  */
 
 #ifndef DUMMYBOOT
 #define screen_cols     7               /* byte screen width*/
@@ -55,6 +55,7 @@
 #define setup_sects     0x1f1           /* byte 512-byte sectors used by setup.S*/
 #define syssize         0x1f4           /* word paragraph kernel size used by setup.S*/
 #define elks_flags      0x1f6           /* byte ELKS flags, BLOB and BIOS_DRV*/
+#define	xms_kbytes	0x1ea		/* word TLVC Kbytes of XMS available */
 #define root_dev        0x1fc           /* word BIOS drive or kdev_t ROOT_DEV*/
 #define boot_flag       0x1fe           /* word constant AA55h checked by boot sector*/
 #endif

--- a/tlvc/include/linuxmt/config.h
+++ b/tlvc/include/linuxmt/config.h
@@ -28,6 +28,7 @@
 #define SETUP_ELKS_FLAGS	setupb(0x1f6)	/* flags for root device type */
 #define SETUP_PART_OFFSETLO	setupw(0x1e2)	/* partition offset low word */
 #define SETUP_PART_OFFSETHI	setupw(0x1e4)	/* partition offset high word */
+#define SETUP_XMS_SIZE		setupw(0x1ea)	/* xms size in kbytes */
 #ifdef CONFIG_ROMCODE
 #define SYS_CAPS	(CAP_PC_AT|CAP_DRIVE_PARMS)
 #endif

--- a/tlvc/include/linuxmt/memory.h
+++ b/tlvc/include/linuxmt/memory.h
@@ -36,7 +36,6 @@ int check_unreal_mode(void);	/* check if unreal mode capable, returns > 0 on suc
 void enable_unreal_mode(void);	/* requires 386+ CPU to call */
 int enable_a20_gate(void);	/* returns 0 on fail */
 int verify_a20(void);		/* returns 0 if a20 disabled */
-int get_xms_size(void);		/* returns 0 if none or error, else KB above 1M */
 
 /* XMS memory management */
 #ifdef CONFIG_FS_XMS_BUFFER

--- a/tlvc/init/main.c
+++ b/tlvc/init/main.c
@@ -74,6 +74,7 @@ int netbufs[2] = {-1,-1};	/* # of network buffers to allocate by the driver */
 int xt_floppy[2];		/* XT floppy types, needed if XT has 720k drive(s) */
 int xtideparms[6];		/* config data for xtide controller if present */
 int fdcache = -1;		/* floppy sector cache size(KB), -1: not configured */
+int xms_size;
 static int boot_console;
 static char bininit[] = "/bin/init";
 static char binshell[] = "/bin/sh";
@@ -187,6 +188,7 @@ static void INITPROC early_kernel_init(void)
 void INITPROC kernel_init(void)
 {
     irq_init();		/* Install timer and DIV fault handlers */
+    xms_size = SETUP_XMS_SIZE;
 
     /* set console from /bootopts console= or 0=default */
     set_console(boot_console);


### PR DESCRIPTION
This update expands on the Limited HMA Support introduced on #155 and enables the TLVC kernel to run in HMA when available. 

The problem (challenge) with HMA is that the segment register cannot change. The entire 64k block must be utilised by something that adheres to this limitation. Thus the first candidate, the external buffer headers, which when maxed pout with XMS buffers occupies a full segment. The next candidate is the kernel - bulging at the seams these days and easily occupying a full segment.

Given that 2975 buffers isn't really useful and that a 10th of that is more like it, kernel HMA would free up more application memory. Thus thus this capability, which indeed does improve the memory situation significantly. There are some caveats - and things to be aware of.

- Kernel in HMA cannot be selected in /bootopts for obvious reasons. So if compiled with `CONFIG_HMA_KERNEL`, setup will load the kernel high if possible. 
- 'Possible' means that the A20 line can be reliably turned on, which required the a20 handlers from `unreal.S` to be copied into `setup.S`.
- If the system cannot use unreal mode to access XMS, a HMA kernel prevents XMS buffers from being used: XMS via the BIOS turns off A20 after every access and the kernel is suddenly out of reach. So in such situations it's a choice - what's most beneficial, XMS buffers (and HMA bufheads) or HMA kernel?
- Setup will detect if XMS or A20 support is not available and load the kernel normally
- Likewise `buffer_init()` will check for a HMA loaded kernel before attempting to use high bufheads
- BIOS A20 manipulation turns out to be a rare thing, thus the code from @ghaerr's XMS buffer implementation in `unreal.S`.

```
ttyS0 at 0x3f8, irq 4 is a 16550A80x25 emulating ANSI (3 virtual consoles)
ttyS1 at 0x2f8, irq 3 is a 16550A
ttyS2 at 0x3e8, irq 7 is a 16550A
ttyS3 at 0x2e8, irq 10 is a 16550A
xms: 19456k available, using unreal mode, EXT bufheads
     128 xms buffers (base @ 0x110000), 8K L1-cache, 20 req hdrs
eth: ne0 at 0x340, irq 9 not found
eth: wd0 at 0x320, irq 15, ram 0xcc00, (wd8013) MAC 00:00:C0:BC:8F:4B, flags 0x0
eth: ee0 at 0x360, irq 11, (ee16) MAC 00:aa:00:55:e8:f5 (HWconf: IRQ 11, TP, 16-bit bus)
	 32k RAM (shmem 0xd000), flags 0x80
hd0: AT/IDE controller at 0x1f0
hda: IDE CHS: 993/16/63, Multisector I/O, max 4 sects
df: Floppy controller, FDC 8272A @ irq 6, DMA 2
df0: 1.44M (type 4), df1: 1.2M (type 2) [CMOS]
Floppy cache 5k, available 5k
Partitions: hda:(0,1000944)  hda1:(63,131985)  hda2:(132048,133056)  hda3:(265104,133056)  hda4:(398160,601776) 
PC/AT class, cpu 7, syscaps 0xff, 640K base ram, 16 tasks, 64 files, 96 inodes
TLVC 0.6.0 (64208 text, 17344 ftext, 11072 data, 7712 bss, 46750 heap)
Kernel text 0xffff, ftext 0x1d0, init 0x385, data 0x60c, top 0xa000, 551K free
MINIX: inodes 21845 imap 3 zmap 8, first data 696
VFS: Mounted root 0x0503 (minix filesystem).
Running /etc/rc.sys script
fsck -a /dev/hda3: /dev/rhda3 is clean, no check.
Starting networking on ee0
ktcp -b -p ee0 10.0.2.17 10.0.2.1 255.255.255.0
ktcp: ip 10.0.2.17, gateway 10.0.2.1, netmask 255.255.255.0
ktcp: /dev/ee0 mac 00.aa.00.55.e8.f5 mtu 1500
Starting daemons 'telnetd' 'ftpd -d' 
Mon Mar 24 19:53:17 2025


[tlvc17] TLVC 0.6.0

login:
```

