### PR TITLE
[kernel] Fixes and enhancements for HMA usage

### DIFF
--- a/tlvc/arch/i86/boot/setup.S
+++ b/tlvc/arch/i86/boot/setup.S
@@ -84,6 +84,7 @@
 // Relocating loader debug option
 debug_output    =       0       // display various register values during execution
 serial_output   =       0       // use INT 14 serial instead of INT 10 console out
+				// NOTE: Not supported on some/most XT class systems
 debug_loader    =       0       // display relocations
 
 
@@ -514,13 +515,21 @@ sys_hdr_good:
 	xor %di,%di
 
 #ifdef CONFIG_ARCH_IBMPC
-// Check whether relocating .text to HMA is possible
+// If 80286 or higher, check whether relocating .text to HMA is possible
+	push %ds
+	mov $INITSEG,%ax
+	mov %ax,%ds
+	mov cpu_type,%ax
+	cmpb $6,cpu_type
+	jl 2f
 	call checkhma
 	jc 2f		 // no HMA
 	mov $HMA_SEG,%ax
+	pop %ds
 	jmp 1f
+2:	pop %ds
 #endif
-2:	mov $REL_SYSSEG,%ax
+	mov $REL_SYSSEG,%ax
 1:	mov %ax,%es
 	mov %ax,-18(%bp) // save .text segment
 	.ifeq debug_output
@@ -864,7 +873,7 @@ hex4sp: call hex4
 	ret
 
 hello_mess:
-	.ascii "\r\nELKS Setup \0"
+	.ascii "\r\nTLVC Setup \0"
 
 //+++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++++
 // Architecture specific routines for IBM PC
@@ -943,7 +952,11 @@ novga:	mov	%al,14		// CGA 25 rows
 
 // check for hma=kernel in /bootopts, return AX = 0 if not
 hmabootopts:
-	push	%ds
+	cmpb	$6,cpu_type	// ignore if < 80826
+	jae	1f
+	xor	%al,%al
+	ret
+1:	push	%ds
 	push	%es
 
 	push	%cs			// ES = our code segment
@@ -976,10 +989,8 @@ hma_string:
 	.ascii	"\nhma=kernel"		// size = 11
 
 // check whether HMA can be enabled, return NC if so with A20 enabled
+// Assumes DS=INITSEG
 checkhma:
-	push	%ds
-	mov	$INITSEG,%ax
-	mov	%ax,%ds
 	mov	xms_kbytes,%ax		//. must have xms size >= 64k
 	cmp	$64,%ax
 	jl	1f
@@ -992,8 +1003,7 @@ checkhma:
 	clc				// success
 	jmp 	2f
 1:	stc				// fail
-2:	pop	%ds
-	ret
+2:	ret
 
 // Write AL to console, save all registers
 putc:	push %ax

--- a/tlvc/arch/i86/mm/xms.c
+++ b/tlvc/arch/i86/mm/xms.c
@@ -19,6 +19,8 @@
 #ifdef CONFIG_FS_XMS_BUFFER
 
 extern int xms_size;
+extern int xms_avail;
+extern int hma_avail;
 
 /* these used in CONFIG_FS_XMS_INT15 only */
 struct gdt_table;
@@ -53,23 +55,31 @@ void xms_init(void)
 	}
 #else
 	if (kernel_cs == 0xffffU) {
-		printk("Not available with INT15: Kernel in HMA");
+		printk("Not available with INT15 and kernel in HMA");
+		xms_avail = 0;
 		return;
 	} 
 #endif
-	if (!xms_size) {
+	if (!xms_avail) {
 		printk("not available\n");
 		return;
 	}
-	printk("%uk available, ", xms_size);
+	printk("%uk available, ", xms_avail);
+#ifdef NOT_REQUIRED_ANYMORE
 	debug("A20 was %s", verify_a20()? "on" : "off");
 	enable_a20_gate();
 	enabled = verify_a20();
 	debug(" now %s, ", enabled? "on" : "off");
 	if (!enabled) {
-		xms_size = 0;
+		xms_size = 0;		/* No xms, no HMA */
+		xms_avail = 0;
 		printk("disabled, A20 error\n");
 	} else {
+#else
+	if (!hma_avail)  {
+		printk("disabled, A20 error\n");
+	} else {
+#endif
 #ifdef CONFIG_FS_XMS_INT15
 		printk("using int 15/1F");
 #else

--- a/tlvc/fs/buffer.c
+++ b/tlvc/fs/buffer.c
@@ -83,6 +83,8 @@ static struct wait_queue L1wait;                  /* Wait for a free L1 buffer a
 static int lastL1map;
 #endif
 extern int xms_size;		/* kbytes, 0 if not present */
+extern int xms_avail;		/* kbytes, usually xms_size - HMA */
+extern int hma_avail;
 static int map_count, remap_count, unmap_count;
 
 static int nr_free_bh, nr_bh;
@@ -137,7 +139,7 @@ static void INITPROC add_buffers(int nbufs, char *buf, ramdesc_t seg)
 	size_t offset;
 
         /* segment adjusted to require no offset to buffer */
-        offset = xms_size? ((n & 63) << BLOCK_SIZE_BITS) :
+        offset = xms_avail? ((n & 63) << BLOCK_SIZE_BITS) :
                               ((n & 63) << (BLOCK_SIZE_BITS - 4));
         ebh->b_L2seg = seg + offset;
 #else
@@ -196,8 +198,8 @@ int INITPROC buffer_init(void)
 #ifdef CONFIG_FS_XMS_BUFFER
     if (nr_xms_bufs)
         xms_init();       /* try to enable unreal mode and A20 gate*/
-    if (xms_size)
-        bufs_to_alloc = (nr_xms_bufs > (xms_size-64)) ? (xms_size-64) : nr_xms_bufs;
+    if (xms_avail)
+        bufs_to_alloc = (nr_xms_bufs > xms_avail) ? xms_avail : nr_xms_bufs;
 #endif
 #ifdef CONFIG_FAR_BUFHEADS
     if (bufs_to_alloc > 2975) bufs_to_alloc = 2975; /* max 64K far bufheads @22 bytes*/
@@ -222,17 +224,24 @@ int INITPROC buffer_init(void)
     if (!buffer_heads) return 1;
 #ifdef CONFIG_FAR_BUFHEADS
     size_t size = bufs_to_alloc * sizeof(ext_buffer_head);
-    seg_t hma_seg = 0xFFFFU; 
-    if (xms_size && kernel_cs != hma_seg) {		/* HMA available for ext headers */
+    seg_t hma_seg = 0xffffU; 
+    //printk("HMA space available: %u, need %u\n", 0xfff0 - (unsigned)_endtext, size); 
+    if (hma_avail && kernel_cs != hma_seg) {		/* HMA available for ext headers */
 	fmemsetw((void *)0x10, hma_seg, 0, size >> 1);
 	ext_buffer_heads = _MK_FP(hma_seg, 0x10);
 	printk(", HMA bufheads\n     ");
+    } else if (kernel_cs == hma_seg && (size < (hma_seg - (unsigned)_endtext))) {
+	/* kernel is loaded high, but there is still enough space for the buffer headers */
+	/* compact this later */
+	fmemsetw((void *)_endtext, hma_seg, 0, size >> 1);
+	ext_buffer_heads = _MK_FP(hma_seg, (unsigned)_endtext);
+	printk(", bufheads in high HMA\n     ");
     } else {
 	segment_s *seg = seg_alloc((size + 15) >> 4, SEG_FLAG_BUFHEAD);
 	if (!seg) return 1;
 	fmemsetw(0, seg->base, 0, size >> 1);
 	ext_buffer_heads = _MK_FP(seg->base, 0);
-	printk(", EXT bufheads\n     ");
+	if (xms_size) printk(", EXT bufheads\n     ");
     }
 #endif
     bh_next = bh_lru = bh_llru = buffer_heads;
@@ -248,7 +257,7 @@ int INITPROC buffer_init(void)
             nbufs = 64;
         bufs_to_alloc -= nbufs;
 #ifdef CONFIG_FS_XMS_BUFFER
-        if (xms_size) {
+        if (xms_avail) {
 	    ramdesc_t xmsseg = xms_alloc((long_t)nbufs << BLOCK_SIZE_BITS);
 	    add_buffers(nbufs, 0, xmsseg);
 	    if (!b_base) b_base = xmsseg;
@@ -263,7 +272,7 @@ int INITPROC buffer_init(void)
         }
     } while (bufs_to_alloc > 0);
     printk("%d %s buffers (base @ 0x%lx), %dK L1-cache, %d req hdrs\n", abufs,
-        xms_size? "xms": "ext", (unsigned long)b_base, nr_map_bufs, NR_REQUEST);
+        xms_avail? "xms": "ext", (unsigned long)b_base, nr_map_bufs, NR_REQUEST);
 #else
     /* no EXT or XMS buffers, internal L1 only */
     add_buffers(nr_map_bufs, L1buf, kernel_ds);

--- a/tlvc/init/main.c
+++ b/tlvc/init/main.c
@@ -74,7 +74,7 @@ int netbufs[2] = {-1,-1};	/* # of network buffers to allocate by the driver */
 int xt_floppy[2];		/* XT floppy types, needed if XT has 720k drive(s) */
 int xtideparms[6];		/* config data for xtide controller if present */
 int fdcache = -1;		/* floppy sector cache size(KB), -1: not configured */
-int xms_size;
+int xms_size, xms_avail, hma_avail;
 static int boot_console;
 static char bininit[] = "/bin/init";
 static char binshell[] = "/bin/sh";
@@ -188,7 +188,9 @@ static void INITPROC early_kernel_init(void)
 void INITPROC kernel_init(void)
 {
     irq_init();		/* Install timer and DIV fault handlers */
-    xms_size = SETUP_XMS_SIZE;
+    xms_size = xms_avail = SETUP_XMS_SIZE;
+    if (xms_size) hma_avail = enable_a20_gate();
+    if (hma_avail) xms_avail = xms_size - 64;
 
     /* set console from /bootopts console= or 0=default */
     set_console(boot_console);


### PR DESCRIPTION
As we're getting more experience with HMA usage, problems and opportunities arise. This PR addresses some of them:

- Fix boot failure on XT class systems when HMA support is CONFIGured in (setup.S) -  by checking cpu type before accessing some functions
- Allow external bufheads to use the HMA memory not occupied by the kernel, if possible. The ideal number of buffers for a practical system is between 128 and 256, which in many cases allows the bufheads to sneak in on top of the kernel.
- Simplify the selection logic: This  new functionality allows for many combinations and scenarios and equally many boot message combinations, even without thinking XMS ramdisk. 

What's really missing still, is a simple way to check whether `unreal mode` works without hanging the system if it doesn't. With that, all the `CONFIG_` stuff could be eliminated and everything autoconfigured.