### PR TITLE
[kernel] Fix for enable_unreal_mode

### DIFF
--- a/tlvc/arch/i86/lib/unreal.S
+++ b/tlvc/arch/i86/lib/unreal.S
@@ -95,10 +95,12 @@ enable_unreal_mode:
 
 	lgdt gdt_ptr
 
-	mov %cs,%ax		# self-modifying code, ugh..
-	mov %ax,%ds
-	mov %ax,ur_ret		# set the CS for protected mode return
+	//mov %cs,%ax		# self-modifying code, ugh..
+	//mov %ax,%ds
+	//mov %ax,ur_ret		# set the CS for protected mode return
 
+	push %cs
+	push $unreal
 	movl %cr0, %eax		# CR0.PE=1: enable protected mode
 	orb $1,%al
 	movl %eax, %cr0
@@ -116,9 +118,10 @@ pmode:
 
 	decb %al        # CR0.PE=0: back to (un)real mode
 	movl %eax, %cr0
-	.byte 0xea	# ljmp
-	.word unreal	# address
-ur_ret:	.word 0		# CS, changed by the code above
+	lret
+	//.byte 0xea	# ljmp
+	//.word unreal	# address
+//ur_ret:	.word 0		# CS, changed by the code above
 
 # loading segment registers in (un)real mode changes their base address
 # but not the segment limit; which remains 4GB-1
@@ -412,7 +415,7 @@ code:   .byte 0xff, 0xff, 0, 0, 0, 0b10011011, 0b00001111, 0
 
 # linear data segment descriptor:
 LINEAR_SEL = . - gdt
-        .word 0xFF    # limit 64k - either bytes of 4k pages
+        .word 0xFFFF    # limit 64k - either bytes of 4k pages
         .word 0         # base 0
         .byte 0
         .byte 0x93      # present, ring 0, data, expand-up, writable, accessed

--- a/tlvc/arch/i86/lib/unreal.S
+++ b/tlvc/arch/i86/lib/unreal.S
@@ -31,7 +31,7 @@
 	.global	linear32_fmemcpyb
 	.global	linear32_fmemset
 
-#include "a20.inc"              # A20 gate functions shared with setup.S
+#include "a20.inc"
 
 # Check if unreal mode capable. Currently requires 32-bit CPU (386+)
 # Returns 1 if OK, otherwise error code (-1=not 386, -2=in V86 mode).
@@ -67,40 +67,68 @@ in_vm86mode:
 
 # Put CPU in unreal mode. Requires 32-bit CPU (386+) to call!
 enable_unreal_mode:
-# point gdt_ptr to gdt
+
 	xorl %eax,%eax
 	movw %ds,%ax
 	shll $4,%eax
 
-	addl $gdt, %eax
+	addl $gdt, %eax		# point gdt_ptr to gdt
 	movl %eax, gdt_ptr+2
 
 	pushf			# save interrupt status
 	cli                     # interrupts off
-	pushl %ds
-	pushl %es
-	pushl %fs
-	pushl %gs
-		lgdt gdt_ptr
-		movl %cr0, %eax # CR0.PE=1: enable protected mode
-		orb $1,%al
-		movl %eax, %cr0
+	mov $0x80,%ax
+	out %al,$0x70		# for good measure, turn off RTC NMI
 
-		movw $LINEAR_SEL, %bx # selector to segment with 4GB-1 limit
-		movw %bx,%ds    # set segment limits in descriptor caches
-		movw %bx,%es
-		movw %bx,%fs
-		movw %bx,%gs
+	push %ds
+	push %es
+	push %fs
+	push %gs
 
-		decb %al        # CR0.PE=0: back to (un)real mode
-		movl %eax, %cr0
+	xorl %eax,%eax
+	mov %cs,%ax		# set up the GDT entry for the code seg
+	shll $4,%eax
+	mov %ax,code+2
+	ror $16,%eax
+	mov %al,code+4
+	mov %ah,code+7
+
+	lgdt gdt_ptr
+
+	mov %cs,%ax		# self-modifying code, ugh..
+	mov %ax,%ds
+	mov %ax,ur_ret		# set the CS for protected mode return
+
+	movl %cr0, %eax		# CR0.PE=1: enable protected mode
+	orb $1,%al
+	movl %eax, %cr0
+
+	ljmp $code-gdt,$pmode
+	//.byte 0xea
+	//.word pmode,code-gdt
+	
+pmode:
+	movw $LINEAR_SEL, %bx # selector to segment with 4GB-1 limit
+	movw %bx,%ds    # set segment limits in descriptor caches
+	movw %bx,%es
+	movw %bx,%fs
+	movw %bx,%gs
+
+	decb %al        # CR0.PE=0: back to (un)real mode
+	movl %eax, %cr0
+	.byte 0xea	# ljmp
+	.word unreal	# address
+ur_ret:	.word 0		# CS, changed by the code above
 
 # loading segment registers in (un)real mode changes their base address
 # but not the segment limit; which remains 4GB-1
-	popl %gs
-	popl %fs
-	popl %es
-	popl %ds
+unreal:
+	pop %gs
+	pop %fs
+	pop %es
+	pop %ds
+	xor %al,%al
+	out %al,$0x70
 	popf			# restore interrupt status
 
 	mov	$1,%ax		# system is in unreal mode, return 1
@@ -117,8 +145,7 @@ linear32_peekw:
 	call   setgpf
 	mov    %si,%dx
 
-	//pushf               // save interrupt status
-	//cli                 // uncomment if extended registers used in interrupt routines
+	//cli			// uncomment if extended registers used in interrupt routines
 	xorl   %esi,%esi
 	mov    %sp,%si
 
@@ -132,7 +159,7 @@ linear32_peekw:
 
 	cld
 	addr32 lodsw          // AX = [DS:ESI++]
-	//popf                // restore interrupt status
+	//sti			// restore interrupt status
 
 	mov    %dx,%si
 	mov    %ss,%bx
@@ -151,7 +178,6 @@ linear32_fmemcpyw:
 	mov    %si,%ax
 	mov    %di,%dx
 
-	//pushf               // save interrupt status
 	//cli                 // uncomment if extended registers used in interrupt routines
 	xorl   %esi,%esi
 	mov    %sp,%si
@@ -177,7 +203,7 @@ linear32_fmemcpyw:
 	addr32 rep movsw      // word [ES:EDI++] <- [DS:ESI++], ECX times
 	addr32 nop            // 80386 B1 step chip bug on address size mixing
 
-	//popf                // restore interrupt status
+	//sti		      // restore interrupt status
 
 	mov    %ax,%si
 	mov    %dx,%di
@@ -197,8 +223,7 @@ linear32_fmemcpyb:
 	mov    %si,%ax
 	mov    %di,%dx
 
-	//pushf               // save interrupt status
-	//cli                 // uncomment if extended registers used in interrupt routines
+	//cli		      // uncomment if extended registers used in interrupt routines
 	xorl   %esi,%esi
 	mov    %sp,%si
 
@@ -228,7 +253,7 @@ linear32_fmemcpyb:
 	addr32 rep movsb      // byte [ES:EDI++] <- [DS:ESI++], ECX times
 	addr32 nop            // 80386 B1 step chip bug on address size mixing
 
-	//popf                // restore interrupt status
+	//sti		      // restore interrupt status
 
 	mov    %ax,%si
 	mov    %dx,%di
@@ -247,7 +272,6 @@ linear32_fmemset:
 	push   %es
 	mov    %di,%dx
 
-	//pushf               // save interrupt status
 	//cli                 // uncomment if extended registers used in interrupt routines
 	xorl   %esi,%esi
 	mov    %sp,%si
@@ -277,7 +301,7 @@ linear32_fmemset:
 	addr32 rep stosb      // byte [ES:EDI++] <- AL, ECX times
 	addr32 nop            // 80386 B1 step chip bug on address size mixing
 
-	//popf                // restore interrupt status
+	//sti		      // restore interrupt status
 
 	mov    %dx,%di
 	mov    %ss,%ax
@@ -383,16 +407,19 @@ gdt:    .word 0         # limit 15:0
         .byte 0         # b7-4=flags, b3-0=limit 19:16
         .byte 0         # base 31:24
         
+code:   .byte 0xff, 0xff, 0, 0, 0, 0b10011011, 0b00001111, 0
+//flat:   .byte 0xff, 0xff, 0, 0, 0, 0b10010010, 0b11001111, 0
+
 # linear data segment descriptor:
 LINEAR_SEL = . - gdt
-        .word 0xFFFF    # limit 0xFFFFF
+        .word 0xFF    # limit 64k - either bytes of 4k pages
         .word 0         # base 0
         .byte 0
         .byte 0x93      # present, ring 0, data, expand-up, writable, accessed
 # putting a zero byte here (instead of 0xCF) effectively disables unreal mode:
 #       .byte 0         # byte-granular, 16-bit, limit=64K-1
-        .byte 0xCF      # page-granular, 32-bit, limit=4GB-1
-        .byte 0
+        .byte 0xCF      # page-granular, 32-bit, limit=4GB-1 (was CF)
+        .byte 0		# upper (4th) byte of base address, not used
 gdt_len = . - gdt
 
 gdt_ptr:.word gdt_len - 1

--- a/tlvc/arch/i86/lib/unreal.S
+++ b/tlvc/arch/i86/lib/unreal.S
@@ -94,21 +94,13 @@ enable_unreal_mode:
 	mov %ah,code+7
 
 	lgdt gdt_ptr
-
-	//mov %cs,%ax		# self-modifying code, ugh..
-	//mov %ax,%ds
-	//mov %ax,ur_ret		# set the CS for protected mode return
-
-	push %cs
+	push %cs		# prepare for return to real mode
 	push $unreal
 	movl %cr0, %eax		# CR0.PE=1: enable protected mode
 	orb $1,%al
 	movl %eax, %cr0
 
-	ljmp $code-gdt,$pmode
-	//.byte 0xea
-	//.word pmode,code-gdt
-	
+	ljmp $code-gdt,$pmode	# Set the CS to enter protected mode
 pmode:
 	movw $LINEAR_SEL, %bx # selector to segment with 4GB-1 limit
 	movw %bx,%ds    # set segment limits in descriptor caches
@@ -118,10 +110,8 @@ pmode:
 
 	decb %al        # CR0.PE=0: back to (un)real mode
 	movl %eax, %cr0
-	lret
-	//.byte 0xea	# ljmp
-	//.word unreal	# address
-//ur_ret:	.word 0		# CS, changed by the code above
+	lret		# Effectively an ljmp to the next line
+			# to set the CS
 
 # loading segment registers in (un)real mode changes their base address
 # but not the segment limit; which remains 4GB-1


### PR DESCRIPTION
This PR fixes a long time problem with `enable_unreal_mode`, as discussed in #160 and https://github.com/ghaerr/elks/pull/2274#issuecomment-2804893775. A clip from the latter describes to changes:

> The problem is this: As is, the enable_unreal_mode() routine does nothing. As it turns out, flipping the PE bit does enable, but not turn on protected mode. Until the prefetch queue has been emptied and most importantly, the CS changed, the processor stays in real mode. This is why we never - in the BIOS sources for example - see a switch to/from protected mode without an ljmp immediately following it. The ljmp takes care of both. And the ljmp was missing from our enable_unreal_mode routine.

> The question is: Why does this work in some cases, like on QEMU and my AMI386SX system? The answer seems to be lucky circumstances. QEMU is easy. I commented out the calls to enable_unreal_mode completely, and xms still works just fine. What's presumably happening is that the SEA BIOS is using a full, flat GDT entry for DS and ES, and leaves those in the segment descriptor cache. Since our memory transfer routines expect that simple mapping, everything is fine. And A20 is always on anyway on QEMU.
The explanation for the AMI386 system is likely similar, but on this system behaviour without calling enable_unreal was different, and before I figured out why, I got the new enable_unreal working, so I left it.

> IOW, getting the long jumps into place, the Compaq 386 runs unreal like a charm. I have yet to demonstrate it with HMA kernel, but there is not reason it should not work.