### PR TITLE
[kernel] fd cache was ignored when using xms buffers

### DIFF
--- a/tlvc/arch/i86/drivers/block/directfd.c
+++ b/tlvc/arch/i86/drivers/block/directfd.c
@@ -678,6 +678,7 @@ static void setup_DMA(void)
     struct request *req = CURRENT;
 
 #pragma GCC diagnostic ignored "-Wshift-count-overflow"
+    use_bounce = 0;
     physaddr = (req->rq_seg << 4) + (unsigned int)req->rq_buffer;
     dma_addr = _MK_LINADDR(req->rq_seg, req->rq_buffer);
     count = nr_sectors<<9;


### PR DESCRIPTION
Running a physical system off of floppy disk is really important some times.

While testing/debugging  the `loadall` implementation on the 286, which incidentally runs off of floppy (because the HD is busy with other OSes), it became clear that the floppy bounce buffer was used all the time, not only when it should be. A minimal restructuring of the `setup_DMA` routine was required to get it right.

Running root on floppy introduces delays that influence many parts of the system, including how `kctp` and the network deamons interact and run, which in this case revealed  a couple of problems - to be addressed separately.