### PR TITLE
[kernel] Setup will now find where bootopts is loaded and relocate

### DIFF
--- a/bootblocks/boot_minix.c
+++ b/bootblocks/boot_minix.c
@@ -118,9 +118,9 @@ void load_prog()
 
 static int strcmp(const char *s, const char *d)
 {
-	int c1 , c2;
+	int c1, c2;
 
-	while ((c1 = *s++) == (c2 = *d++) && c1 /* && c2*/);
+	while ((c1 = *s++) == (c2 = *d++) && c1 && c2);
 	return c1 - c2;
 }
 

--- a/bootblocks/boot_minix.c
+++ b/bootblocks/boot_minix.c
@@ -8,10 +8,14 @@
 #include "linuxmt/config.h"
 #include "minix.h"
 
+#define STR(x) #x
+#define STRING(x) STR(x)
+
 // Global constants
 
 #define LOADSEG DEF_INITSEG
-#define OPTSEG	DEF_OPTSEG             // bootopts copied here
+#define OPTSEG	DEF_OPTSEG		// bootopts copied here
+#define BOOTSEG 0x7C0			// Where we run
 
 // Global variables
 
@@ -19,7 +23,7 @@
 // as the context is not a user process
 // but code loaded in uninitialized memory
 
-static byte_t sb_block [BLOCK_SIZE];  // super block block buffer
+static byte_t sb_block[BLOCK_SIZE];  // super block block buffer
 #define sb_data	((struct super_block *)sb_block)
 
 static int i_now;
@@ -27,35 +31,36 @@ static int i_boot;
 static int loadaddr;
 static int ib_first;                 // inode first block
 
-static byte_t i_block [BLOCK_SIZE];  // inode block buffer
-static struct inode_s * i_data;      // current inode structure
+static byte_t i_block[BLOCK_SIZE];  // inode block buffer
+static struct inode_s *i_data;      // current inode structure
 
-static byte_t z_block [LEVEL_MAX] [BLOCK_SIZE];  // zone block buffer
+static byte_t z_block[LEVEL_MAX] [BLOCK_SIZE];  // zone block buffer
 
 static file_pos f_pos;
 
-static byte_t d_dir [BLOCK_SIZE];    // root directory buffer
+static byte_t d_dir[BLOCK_SIZE];    // root directory buffer
 
 
 //------------------------------------------------------------------------------
 
 // Helpers from boot sector
 
-void except (char code);
+void except(char code);
 
-void puts (const char * s);
+void puts(const char * s);
 
-int seg_data ();
+int seg_data();
 
-void disk_read (const int sect, const int count, const byte_t * buf, const int seg);
+void disk_read(const int sect, const int count, const byte_t *buf, const int seg);
 
-void run_prog ();
+void run_prog();
+void linux_ok(void);
 
-static int strcmp (const char * s, const char * d);
-static void load_super ();
-static void load_inode ();
-static void load_zone (int level, zone_nr * z_start, zone_nr * z_end);
-static void load_file ();
+static int strcmp(const char *s, const char *d);
+static void load_super();
+static void load_inode();
+static void load_zone(int level, zone_nr *z_start, zone_nr *z_end);
+static void load_file();
 
 
 //------------------------------------------------------------------------------
@@ -74,18 +79,22 @@ static void load_file ();
 void load_prog()
 {
 	// Avoid reuse of an old copy of /bootopts in memory if we're rebooting w/ no /bootopts */
-	int __far *optseg = _MK_FP(OPTSEG, 0);	/* Expensive, is there a better way? */
-	*optseg = i_boot = i_now = 0;
+	//int __far *optseg = _MK_FP(OPTSEG, 0);	/* Expensive, is there a better way? */
+	i_boot = i_now = 0;
+	//*optseg = i_boot = i_now = 0;
 	//*optseg = 0x1234;	/* no space for this */
 
+	/* use the BDA_IAC location 0(W) (0x4f:0) to store the actual OPTSEG start */
+	asm("xor %ax,%ax; mov %ax,%es; movw $" STRING(OPTSEG) ",%es:(0x4f0)");
 	load_super();
 	load_file ();
 
 	for (int d = 0; d < BLOCK_SIZE /*(int)i_data->i_size*/; d += DIRENT_SIZE) {
-		if (!strcmp ((char *)(d_dir + 2 + d), "linux")) {
+		if (!strcmp((char *)(d_dir + 2 + d), "linux")) {
 			i_boot = i_now = (*(int *)(d_dir + d)) - 1;
 			if (i_boot == -1) continue;
-			puts ("Linux OK");	// shortened message to save space
+			//puts("Linux OK");	// shortened message to save space
+			linux_ok();		// Linux OK message
 			loadaddr = LOADSEG << 4;
 			load_file();
 			continue;
@@ -107,14 +116,11 @@ void load_prog()
 
 //------------------------------------------------------------------------------
 
-static int strcmp (const char * s, const char * d)
+static int strcmp(const char *s, const char *d)
 {
-	const char * p1 = s;
-	const char * p2 = d;
+	int c1 , c2;
 
-	int c1, c2;
-
-	while ((c1 = *p1++) == (c2 = *p2++) && c1 /* && c2*/);
+	while ((c1 = *s++) == (c2 = *d++) && c1 /* && c2*/);
 	return c1 - c2;
 }
 
@@ -168,16 +174,16 @@ static void load_zone (int level, zone_nr * z_start, zone_nr * z_end)
 		if (level == 0) {
 			if (i_now) {
 				long lin_addr = loadaddr + f_pos;
-				disk_read ((*z) << 1, 2, (byte_t *) (unsigned) lin_addr, (unsigned) (lin_addr >> 4) & 0xf000);
+				disk_read ((*z) << 1, 2, (byte_t *)(unsigned)lin_addr, (unsigned)(lin_addr >> 4) & 0xf000);
 			} else {
-				if (!f_pos) disk_read ((*z) << 1, 2, d_dir /*+ f_pos*/, seg_data ());
+				if (!f_pos)disk_read((*z) << 1, 2, d_dir /*+ f_pos*/, seg_data());
 			}
 			f_pos += BLOCK_SIZE;
 			if (f_pos >= i_data->i_size) break;
 		} else {
 			int next = level - 1;
-			disk_read ((*z) << 1, 2, z_block [next], seg_data ());
-			load_zone (next, (zone_nr *) z_block [next], (zone_nr *) (z_block [next] + BLOCK_SIZE));
+			disk_read((*z) << 1, 2, z_block[next], seg_data());
+			load_zone(next, (zone_nr *)z_block[next], (zone_nr *)(z_block[next] + BLOCK_SIZE));
 		}
 	}
 }
@@ -201,7 +207,7 @@ static void load_file ()
 
 	// Indirect zones
 	load_zone (1, &(i_data->i_zone [ZONE_IND_L1]), &(i_data->i_zone [ZONE_IND_L2]));
-	if (f_pos >= i_data->i_size) return;
+	//if (f_pos >= i_data->i_size) return;
 
 	// Double-indirect zones
 	//load_zone (2, &(i_data->i_zone [ZONE_IND_L2]), &(i_data->i_zone [ZONE_IND_END]));

--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -290,7 +290,7 @@ _puts:
 	call _putc
 	inc %bx
 	jmp _puts
-1:  ret
+1:	ret
 
 //------------------------------------------------------------------------------
 
@@ -572,8 +572,16 @@ boot_it:
 
 //------------------------------------------------------------------------------
 
+	.global linux_ok
+linux_ok:
+	mov $msg_load,%bx;
+	jmp _puts
+
 msg_boot:
 	.asciz "TLVC"
+
+msg_load:
+	.asciz "Linux OK"
 
 msg_error:
 	.ascii "!\r\n"

--- a/tlvc/arch/i86/boot/setup.S
+++ b/tlvc/arch/i86/boot/setup.S
@@ -96,6 +96,7 @@ debug_loader    =       0       // display relocations
 #define MINIX_SPLITID_LOW 0x0301L
 #define KERNEL_MAGICNUMBER MINIX_SPLITID_LOW
 #define HMA_SEG 0xffff
+BOOTSEG=0x7C0			// The bootopts load address is stored here
 
 #ifndef CONFIG_ROMCODE
   INITSEG  = DEF_INITSEG	// initial setup data seg and initial Image load address
@@ -1043,6 +1044,8 @@ putc:	push %ax
 #ifdef CONFIG_BOOTOPTS
 //
 // load /bootopts file for FAT filesystem boot
+//	[NOTE: If we're booting a minix FS, /bootopts - if it exists, 
+//	is already loaded.]
 //      If size > 512 bytes, both sectors must be contiguous.
 //      This is currently guaranteed by providing a 1K /bootopts in
 //      distribution images, so later edits will remain contiguous.
@@ -1116,13 +1119,58 @@ pc98_int1b:
 #endif
 
 	jnc	1f
-0:	mov	$'F',%al
-	jmp	2f
+0:	mov	$'F',%al	// Fail, not FAT bootopts
+	call	putc
+	xor	%ax,%ax
+	mov	%ax,%es
+	movw	$DEF_OPTSEG,%es:((BDA_IAC_SEG<<4)+2)  // DEBUG
+	mov	%es:(BDA_IAC_SEG<<4),%ax
+	//call	hex4
+	cmp	$DEF_OPTSEG,%ax
+	jz	3f
+	call	reloc_opts
+	mov	$'R',%al	// Indicate relocated bootopts
+	call	putc
+	jmp	3f
 1:	mov	$' ',%al
 2:	call	putc
-	pop	%es
+3:	pop	%es
 	pop	%ds
 	ret
+
+# relocate the bootopts contents if the minix bootblock loaded it
+# in the wrong place, which may happen if the kernel at the bootblock
+# were compiled at different times with different CONFIG settings.
+#
+# AX = actual (current) start of bootopts.
+# FLAGS = set by caller
+# If moving down -> move from the bottom, if moving up -> move from the top.
+#
+reloc_opts:
+	push	%si
+	push	%di
+	mov	$512,%cx	# words to move
+	xor	%di,%di
+	xor	%si,%si
+	ja	reloc_up	# flags already set in the caller
+	mov	%ax,%ds
+	mov	$DEF_OPTSEG,%ax
+	mov	%ax,%es
+	cld
+1:	rep
+	movsw
+	pop	%di
+	pop	%si
+	ret
+reloc_up:
+	add	$1024,%ax
+	mov	%ax,%ds
+	mov	$DEF_OPTSEG+1024,%ax
+	mov	%ax,%es
+	std
+	jmp	1b
+#----
+
 
 // BPB offsets in boot sector already in high memory
 sec_per_clus	= 13

--- a/tlvc/include/linuxmt/config.h
+++ b/tlvc/include/linuxmt/config.h
@@ -167,6 +167,12 @@
 #define HAS_FDCACHE 0
 #endif
 
+#define BDA_IAC_SEG		0x4F	/* BDA 'Intra-Applications Communications Area' */
+					/* 16 bytes, the first (0x4f:0) (W) holds the */
+					/* actual OPTSEG location used by the minix */
+					/* bootloader */
+#define BDA_IAC_OPTSEG		0x0
+
 // NOTE: for accomodating the LOADALL 0x80:0 seg (0x80:0-0x87:0),
 // leave OPTSEG in place (its use is over before LOADALL needs it)
 // and move REL_INITSEG above LOADALL (0x87 or 0x90)


### PR DESCRIPTION
This PR fixes the problem described in #166: In a development setting, when OPTSEG changes, the bootblock and the kernel may be out of sync with regards to where `bootopts` (loaded by the bootblock) is located.

The fix is to have the bootblock code save the DEF_OPTSEG address used in a location where the kernel setup code can find it later. Not trivial since the SETUP_DATA address may also have changed. The solution is to use the unused top 16 bytes of the BIOS Data Area (BDA). Normally described as 'Intra-Applications Communications Area', this block is rarely if ever used, end definitely not used when TLVC is running. As such, these 16 bytes make up a convenient place to pass data during boot, possibly other settings too.

 The DEF_OPTSEG address occupies the first word of this block, at 0x4f:0.

`setup.S` checks this location - conveniently called BDA_IAC_SEG, compares to its own DEF_OPTSEG, and relocates `bootopts` if they don't match.

Also included some source cleanups (coding style) in `boot_minix.c` and - given the space constraints in said file, a few bytes were moved to `boot_block.S` instead. It is now possible to revert to the old 'Linux found' message during boot, but the current version is deemed good enough. With more space available, the `strcmp` implementation now has the end-of-string test of the second parameter reinstated: The function now works as expected in the rare case that the second string parameter is shorter than the first.