### PR TITLE
[kernel] replaced fmemcpyw and xms_fmemcpyw with equally fast byte versions

### DIFF
--- a/tlvc/arch/i86/drivers/block/bioshd.c
+++ b/tlvc/arch/i86/drivers/block/bioshd.c
@@ -986,7 +986,7 @@ static int do_bios_readwrite(struct drive_infot *drivep, sector_t start, char *b
 		segment = FD_BOUNCESEG;
 		offset = 0;
 		if (cmd == WRITE)	/* copy xms buffer down before write */
-		    xms_fmemcpyw(0, FD_BOUNCESEG, buf, seg, this_pass*(drivep->sector_size >> 1));
+		    xms_fmemcpyb(0, FD_BOUNCESEG, buf, seg, this_pass*drivep->sector_size);
 		set_cache_invalid();
 	    } else {
 		segment = (seg_t)seg;
@@ -1014,7 +1014,7 @@ static int do_bios_readwrite(struct drive_infot *drivep, sector_t start, char *b
 	if (error) return 0;
 	if (use_bounce) {
 		if (cmd == READ)	/* copy DMASEG up to xms*/
-			xms_fmemcpyw(buf, seg, 0, FD_BOUNCESEG, this_pass*(drivep->sector_size >> 1));
+			xms_fmemcpyb(buf, seg, 0, FD_BOUNCESEG, this_pass*drivep->sector_size);
 		set_cache_invalid();
 	}
 	return this_pass;
@@ -1081,7 +1081,7 @@ static int cache_valid(struct drive_infot *drivep, sector_t start, unsigned char
 
 	offset = (int)(start - cache_startsector) * drivep->sector_size;
 	debug_biosio("bioshd(%d): cache hit lba %ld\n", hd_drive_map[drivep-drive_info], start);
-	xms_fmemcpyw(buf, seg, (void *)offset, DMASEG, drivep->sector_size >> 1);
+	xms_fmemcpyb(buf, seg, (void *)offset, DMASEG, drivep->sector_size);
 	return 1;
 }
 

--- a/tlvc/arch/i86/drivers/block/directfd.c
+++ b/tlvc/arch/i86/drivers/block/directfd.c
@@ -733,7 +733,7 @@ static void setup_DMA(void)
     } else
 #endif
     if (use_bounce && command == FD_WRITE)
-	xms_fmemcpyw(0, FD_BOUNCESEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
+	xms_fmemcpyb(0, FD_BOUNCESEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE);
 
     DEBUG("%d/%lx/%x;", count, dma_addr, physaddr);
     clr_irq();
@@ -1004,8 +1004,7 @@ static void rw_interrupt(void)
     }
     if (raw) CURRENT->rq_nr_sectors = nr_sectors;
     if (use_bounce && command == FD_READ) {
-	xms_fmemcpyw(req->rq_buffer, req->rq_seg, NULL, FD_BOUNCESEG, nr_sectors << (9-1));
-									       /* words ^ */
+	xms_fmemcpyb(req->rq_buffer, req->rq_seg, NULL, FD_BOUNCESEG, nr_sectors << (9));
     } else {
 #if CONFIG_FLOPPY_CACHE
 	if (use_cache) {
@@ -1013,7 +1012,7 @@ static void rw_interrupt(void)
 	    cache_start = CURRENT->rq_blocknr;
 	    DEBUG("rd:%04x:0->%04lx:%04x;", FD_CACHESEG,
 		(unsigned long)req->rq_seg, req->rq_buffer);
-	    xms_fmemcpyw(req->rq_buffer, req->rq_seg, 0, FD_CACHESEG, BLOCK_SIZE/2);
+	    xms_fmemcpyb(req->rq_buffer, req->rq_seg, 0, FD_CACHESEG, BLOCK_SIZE);
 	}
 #endif
     }
@@ -1511,11 +1510,11 @@ static void redo_fd_request(void)
 
 	if (command == FD_READ) {	/* requested data is in cache */
 //	    cache_hits++;
-	    xms_fmemcpyw(req->rq_buffer, req->rq_seg, buf_ptr, FD_CACHESEG, BLOCK_SIZE/2);
+	    xms_fmemcpyb(req->rq_buffer, req->rq_seg, buf_ptr, FD_CACHESEG, BLOCK_SIZE);
 	    request_done(1);
 	    goto repeat;
     	} else if (command == FD_WRITE)	/* update track cache */
-	    xms_fmemcpyw(buf_ptr, FD_CACHESEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
+	    xms_fmemcpyb(buf_ptr, FD_CACHESEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE);
     } 
 #endif
 

--- a/tlvc/arch/i86/drivers/block/directhd.c
+++ b/tlvc/arch/i86/drivers/block/directhd.c
@@ -261,7 +261,7 @@ void read_data(unsigned int port, ramdesc_t seg, word_t *buffer, int count, int 
 	insw(port, (word_t *)localbuf, count);
 	debug_blkdrv("insw %d %x:%04x %lx:%04x %04x;", count, kernel_ds, localbuf,
 		(unsigned long)seg, buffer, *(word_t *)localbuf);
-	xms_fmemcpyw(buffer, seg, localbuf, kernel_ds, count/2);
+	xms_fmemcpyb(buffer, seg, localbuf, kernel_ds, count);
     } else
 #endif
     {
@@ -316,7 +316,7 @@ void write_data(unsigned int port, ramdesc_t seg, word_t *buffer, int count, int
 #if defined(CONFIG_FS_XMS_BUFFER) || defined(USE_LOCALBUF)
 
     if (!raw) {
-	xms_fmemcpyw(localbuf, kernel_ds, buffer, seg, count/2);
+	xms_fmemcpyb(localbuf, kernel_ds, buffer, seg, count);
 	outsw(port, (word_t *)localbuf, count);
     } else 
 #endif

--- a/tlvc/arch/i86/drivers/block/rd.c
+++ b/tlvc/arch/i86/drivers/block/rd.c
@@ -176,9 +176,9 @@ static int rd_ioctl(register struct inode *inode, struct file *file,
 		debug("RD: index %d set to %d sectors, %ld bytes\n",
 		       j, rd_segment[j].sectors, size);
 
-		debug("RD: fmemsetw(0, 0x%x, 0, 0x%x)\n",
-			rd_segment[j].seg, (size_t) (size >> 1));
-		fmemsetw(0, rd_segment[j].seg, 0, (size_t) (size >> 1));
+		debug("RD: fmemsetb(0, 0x%x, 0, 0x%x)\n",
+			rd_segment[j].seg, (size_t) size);
+		fmemsetb(0, rd_segment[j].seg, 0, (size_t)size);
 
 		if (k != -1)
 		    rd_segment[k].next = j;	/* set link to next index */
@@ -242,11 +242,11 @@ static void do_rd_request(void)
 	debug("entry %d, seg %x, offset %d\n", index, rd_segment[index].seg, offset);
 
 	if (req->rq_cmd == WRITE) {
-	    xms_fmemcpyw((char *) (offset * RD_SECTOR_SIZE), rd_segment[index].seg,
-		buff, req->rq_seg, 1024/2);
+	    xms_fmemcpyb((char *) (offset * RD_SECTOR_SIZE), rd_segment[index].seg,
+		buff, req->rq_seg, 1024);
 	} else {
-	    xms_fmemcpyw(buff, req->rq_seg,
-		(byte_t *) (offset * RD_SECTOR_SIZE), rd_segment[index].seg, 1024/2);
+	    xms_fmemcpyb(buff, req->rq_seg,
+		(byte_t *) (offset * RD_SECTOR_SIZE), rd_segment[index].seg, 1024);
 	}
 	end_request(1);
     }

--- a/tlvc/arch/i86/drivers/block/xd.c
+++ b/tlvc/arch/i86/drivers/block/xd.c
@@ -453,7 +453,7 @@ static void setup_DMA(void)
     debug_xd("setupDMA ");
 
     if (use_bounce && req->rq_cmd == WRITE)
-	xms_fmemcpyw(0, XD_BOUNCESEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE/2);
+	xms_fmemcpyb(0, XD_BOUNCESEG, req->rq_buffer, req->rq_seg, BLOCK_SIZE);
 
     debug_xd("%d/%lx;", count, dma_addr);
     clr_irq();
@@ -526,9 +526,9 @@ static void do_xdintr(int irq, struct pt_regs *regs)
 			    deverror(drive, sense);
 
 			if (j != 0x18) {	/* check for correctable error */
-			        //xd_recal(drive); 	/* LATER */
-				i = 0;		/* indicate error */
-				goto done;
+			    //xd_recal(drive); 	/* LATER */
+			    i = 0;		/* indicate error */
+			    goto done;
 			}
 		}
 		if (raw) CURRENT->rq_nr_sectors = nr_sectors;
@@ -536,8 +536,8 @@ static void do_xdintr(int irq, struct pt_regs *regs)
 		 * Finished with this transfer ?
 		 */
 		if (use_bounce && CURRENT->rq_cmd == READ)
-			xms_fmemcpyw(CURRENT->rq_buffer, CURRENT->rq_seg, 0,
-					XD_BOUNCESEG, BLOCK_SIZE/2);
+			xms_fmemcpyb(CURRENT->rq_buffer, CURRENT->rq_seg, 0,
+					XD_BOUNCESEG, BLOCK_SIZE);
 		i = 1;	/* iodone */
 			
 done:

--- a/tlvc/arch/i86/lib/fmemory.S
+++ b/tlvc/arch/i86/lib/fmemory.S
@@ -26,7 +26,7 @@
 //		size_t count)
 
 fmemcpyb:
-	clc
+	or     $1,%al		// clear ZF
 2:	mov    %si,%ax
 	mov    %di,%dx
 	mov    %sp,%si
@@ -35,7 +35,7 @@ fmemcpyb:
 	les    ARG0(%si),%di  // far destination pointer
 	lds    ARG2(%si),%si  // far source pointer
 	cld
-	jc     3f
+	jz     3f
 	shr    $1,%cx         // copy words
 3:	rep
 	movsw
@@ -53,8 +53,8 @@ fmemcpyb:
 //		size_t count)
 
 fmemcpyw:
-	stc
-	jmp    2b
+	xor	%al,%al		// Set ZF
+	jmp	2b
 
 // void fmemsetb (void * off, seg_t seg, byte_t val, size_t count)
 // compiler pushes byte_t as word_t
@@ -162,20 +162,36 @@ fmemcmpw_exit:
 #
 # int FARPROC loadall_block_move(addr_t src, addr_t dst, size_t bytes)
 #
-# Prepare a loadall register block which changes the DS cache entry to
-# point to the source address of the move, while the ES cache entry 
-# points to the destination address. Either can be anywhere in the 16M
-# address space. Filling the other two segment register caches (CS, SS)
-# is also required since this is what the processor will be running on
-# after the LOADALL instruction has been executed. 
-# The segment caches in the processor will be individually reset to 
+# This function prepares a complete processor register block which is 
+# loaded by the LOADALL instruction and immediately takes effect.
+# The magic is in the loading of the segment register caches with values 
+# pointing anywhere in the 16M processor address range.
+#
+# We set the DS cache entry to point to the source address of the move, 
+# while the ES cache entry points to the destination address, both may 
+# be anywhere in the address range. 
+# Filling the other two segment register caches (CS, SS)
+# is also required since this is what the processor will be using
+# immediately after the structure has been loaded by the LOADALL instruction.
+#
+# The segment caches will be individually reset to 
 # 'normal' real mode values (high 4 bits clear) whenever the 
 # corresponding register is changed by the running code. 
+#
 # Since this method copies the current SS and CS values into the corresponding
-# caches, resetting them after is not critical. What's needed is
+# caches, resetting them after is not critical. What's important is
 # that the DS and ES registers get updated (restored) before we exit.
 #
 # The return value is usually ignored, but may be useful for debugging.
+#
+# The LOADALL data structure is 'hardwired' to address 0x80:0, size 102 bytes
+# which are zeroed out before use. The word immediately following the structure,
+# at address 0x80:0 + 0x66 is used as an initialization flag to avoid repeating
+# initialization of the structure in every call. The rest of the 128 bytes set
+# aside for the structure is available. 
+# Keep in mind though that unless CONFIG_FS_XMS_LOADALL is set, this area in
+# low memory is used for other purposes.
+#
 
 loadall_block_move:
 
@@ -190,11 +206,14 @@ loadall_block_move:
 	cld
 	mov	$0x80,%cx
 	mov	%cx,%es		# ES=0080h segment
-	mov	$0x33,%cx	# 102 bytes
+	mov	$0xa5a5,%bx
+	cmp	%bx,%es:(0x66)
+	jz	2f
+	mov	$0x34,%cx	# 102+2 bytes
 	xor	%ax,%ax
-	cli
 	rep
 	stosw
+	mov	%bx,%es:(0x66)	# set the 'initialized' flag
 
 	xor	%di,%di
 	dec	%ax		# limit is always 0xffff
@@ -206,7 +225,8 @@ loadall_block_move:
 
 	# if highword(src) = 0xffff, do memset 
 # Prepare src (DS)
-	xor	%bx,%bx
+2:	xor	%bx,%bx
+	cli
 	mov	12(%bp),%ax	#src addr low16
 	mov	%ax,%es:(0x48)	#new DS low16
 	mov	14(%bp),%ax	#src addr high8

--- a/tlvc/arch/i86/lib/fmemory.S
+++ b/tlvc/arch/i86/lib/fmemory.S
@@ -26,16 +26,18 @@
 //		size_t count)
 
 fmemcpyb:
-	mov    %si,%ax
+	clc
+2:	mov    %si,%ax
 	mov    %di,%dx
 	mov    %sp,%si
 	mov    %es,%bx
 	mov    ARG4(%si),%cx  // byte count
-	les    ARG0(%si),%di  // far destination pointer
+1:	les    ARG0(%si),%di  // far destination pointer
 	lds    ARG2(%si),%si  // far source pointer
 	cld
+	jc     3f
 	shr    $1,%cx         // copy words
-	rep
+3:	rep
 	movsw
 	rcl    $1,%cx         // then possibly final byte
 	rep
@@ -51,11 +53,16 @@ fmemcpyb:
 //		size_t count)
 
 fmemcpyw:
+	stc
+	jmp    2b
 	mov    %es,%bx
 	mov    %si,%ax
 	mov    %di,%dx
 	mov    %sp,%si
 	mov    ARG4(%si),%cx  // word count
+	shl    $1,%cx	      // make bytes
+	jmp    1b
+#if 0
 	les    ARG0(%si),%di  // far destination pointer
 	lds    ARG2(%si),%si  // far source pointer
 	cld
@@ -67,6 +74,7 @@ fmemcpyw:
 	mov    %ax,%ds
 	mov    %bx,%es
 	ret
+#endif
 
 // void fmemsetb (void * off, seg_t seg, byte_t val, size_t count)
 // compiler pushes byte_t as word_t

--- a/tlvc/arch/i86/lib/fmemory.S
+++ b/tlvc/arch/i86/lib/fmemory.S
@@ -32,7 +32,7 @@ fmemcpyb:
 	mov    %sp,%si
 	mov    %es,%bx
 	mov    ARG4(%si),%cx  // byte count
-1:	les    ARG0(%si),%di  // far destination pointer
+	les    ARG0(%si),%di  // far destination pointer
 	lds    ARG2(%si),%si  // far source pointer
 	cld
 	jc     3f
@@ -55,26 +55,6 @@ fmemcpyb:
 fmemcpyw:
 	stc
 	jmp    2b
-	mov    %es,%bx
-	mov    %si,%ax
-	mov    %di,%dx
-	mov    %sp,%si
-	mov    ARG4(%si),%cx  // word count
-	shl    $1,%cx	      // make bytes
-	jmp    1b
-#if 0
-	les    ARG0(%si),%di  // far destination pointer
-	lds    ARG2(%si),%si  // far source pointer
-	cld
-	rep
-	movsw
-	mov    %ax,%si
-	mov    %dx,%di
-	mov    %ss,%ax
-	mov    %ax,%ds
-	mov    %bx,%es
-	ret
-#endif
 
 // void fmemsetb (void * off, seg_t seg, byte_t val, size_t count)
 // compiler pushes byte_t as word_t

--- a/tlvc/arch/i86/lib/unreal.S
+++ b/tlvc/arch/i86/lib/unreal.S
@@ -184,6 +184,8 @@ linear32_pokew:
 	pop	%es
 	ret
 #endif
+
+#ifdef UNUSED
 #
 # void linear32_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 #		size_t count)
@@ -225,6 +227,8 @@ linear32_fmemcpyw:
 	mov    %ax,%ds
 	pop    %es
 	ret
+
+#endif
 
 #
 # void linear32_fmemcpyb(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,

--- a/tlvc/arch/i86/lib/unreal.S
+++ b/tlvc/arch/i86/lib/unreal.S
@@ -185,51 +185,6 @@ linear32_pokew:
 	ret
 #endif
 
-#ifdef UNUSED
-#
-# void linear32_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
-#		size_t count)
-# WARNING: Requires 32-bit CPU, with unreal mode and A20 gate enabled!
-#          Trashes EBX, ECX, ESI and EDI without saving.
-#
-linear32_fmemcpyw:
-	push   %es
-	mov    %si,%ax
-	mov    %di,%dx
-
-	xorl   %esi,%esi
-	mov    %sp,%si
-
-	xorl   %ecx,%ecx
-	mov    16(%si),%cx    // word count -> ECX
-
-	xorl   %ebx,%ebx
-	mov    4(%si),%bx     // word dest offset -> EBX
-	movl   6(%esi),%edi   // long dest address -> EDI
-	addl   %ebx,%edi      // EDI is linear destination
-
-	xorl   %ebx,%ebx
-	mov    10(%si),%bx    // word src offset -> EBX
-	movl   12(%esi),%esi  // long src address -> ESI
-	addl   %ebx,%esi      // ESI is linear source
-
-	xor    %bx,%bx        // ES = DS = 0 for 32-bit linear addressing
-	mov    %bx,%es
-	mov    %bx,%ds
-
-	cld
-	addr32 rep movsw      // word [ES:EDI++] <- [DS:ESI++], ECX times
-	addr32 nop            // 80386 B1 step chip bug on address size mixing
-
-	mov    %ax,%si
-	mov    %dx,%di
-	mov    %ss,%ax
-	mov    %ax,%ds
-	pop    %es
-	ret
-
-#endif
-
 #
 # void linear32_fmemcpyb(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 #		size_t count)

--- a/tlvc/arch/i86/mm/xms.c
+++ b/tlvc/arch/i86/mm/xms.c
@@ -130,44 +130,6 @@ ramdesc_t xms_alloc(int size)
 	return 0;
 }
 
-#ifdef UNUSED
-/* copy words between XMS and far memory */
-void xms_fmemcpyw(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src_seg,
-		size_t count)
-{
-	int	need_xms_src = src_seg >> 16;
-	int	need_xms_dst = dst_seg >> 16;
-
-	if (need_xms_src || need_xms_dst) {
-		if (!xms_avail) panic("xms_fmemcpyw");
-		if (!need_xms_src) src_seg <<= 4;
-		if (!need_xms_dst) dst_seg <<= 4;
-		//printk("FM: S:%lx/%x -> D:%lx/%x C:%d\n", src_seg, src_off, dst_seg, dst_off, count);  
-		if (xms_mode == XMS_UNREAL)
-		    linear32_fmemcpyw(dst_off, dst_seg, src_off, src_seg, count);
-#ifdef CONFIG_FS_XMS_LOADALL
-		else if (xms_mode == XMS_LOADALL) {
-		    src_seg += (word_t)src_off;
-		    dst_seg += (word_t)dst_off;
-#ifdef LOADALL_DEBUG
-		    if (loadall_block_move(src_seg, dst_seg, count<<1)) {
-			xms_mode = XMS_INT15;
-		    	int15_fmemcpyw(dst_off, dst_seg, src_off, src_seg, count);
-			printk("DEBUG: switching to INT15\n");
-		    }
-#else
-		    loadall_block_move(src_seg, dst_seg, count<<1);
-		}
-#endif /* LOADALL_DEBUG */
-#endif /* CONFIG_FS_XMS_LOADALL */
-		else
-		    int15_fmemcpyw(dst_off, dst_seg, src_off, src_seg, count);
-		return;
-	}
-	fmemcpyw(dst_off, (seg_t)dst_seg, src_off, (seg_t)src_seg, count);
-}
-#endif
-
 /* copy bytes between XMS and far memory */
 void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src_seg,
 		size_t count)

--- a/tlvc/arch/i86/mm/xms.c
+++ b/tlvc/arch/i86/mm/xms.c
@@ -130,6 +130,7 @@ ramdesc_t xms_alloc(int size)
 	return 0;
 }
 
+#ifdef UNUSED
 /* copy words between XMS and far memory */
 void xms_fmemcpyw(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src_seg,
 		size_t count)
@@ -165,6 +166,7 @@ void xms_fmemcpyw(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src
 	}
 	fmemcpyw(dst_off, (seg_t)dst_seg, src_off, (seg_t)src_seg, count);
 }
+#endif
 
 /* copy bytes between XMS and far memory */
 void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src_seg,

--- a/tlvc/fs/buffer.c
+++ b/tlvc/fs/buffer.c
@@ -670,7 +670,7 @@ void zero_buffer(struct buffer_head *bh, size_t offset, int count)
 #define FORCEMAP 0
 #endif
     /* xms int15 doesn't support a memset function, so map into L1 */
-    if (FORCEMAP || bh->b_data || xms_mode == XMS_INT15) {	// DANGEROUS!!!
+    if (FORCEMAP || bh->b_data || xms_mode == XMS_INT15) {
         map_buffer(bh);
         memset(bh->b_data + offset, 0, count);
         unmap_buffer(bh);
@@ -748,7 +748,7 @@ void map_buffer(struct buffer_head *bh)
     L1map[i] = bh;
     bh->b_data = L1buf + (i << BLOCK_SIZE_BITS);
     if (ebh->b_uptodate)
-        xms_fmemcpyw(bh->b_data, kernel_ds, 0, ebh->b_L2seg, BLOCK_SIZE/2);
+        xms_fmemcpyb(bh->b_data, kernel_ds, 0, ebh->b_L2seg, BLOCK_SIZE);
     map_count++;
     debug_map("MAP:   L%02d block %ld\n", i+1, ebh->b_blocknr);
     debug_map("data %04x L2s %lx kds 0%04x\n", bh->b_data, (unsigned long)ebh->b_L2seg, kernel_ds);
@@ -797,7 +797,7 @@ void brelseL1_index(int i, int copyout)
     if (ebh->b_mapcount || ebh->b_locked)
         return;
     if (copyout && ebh->b_uptodate && bh->b_data) {
-        xms_fmemcpyw(0, ebh->b_L2seg, bh->b_data, kernel_ds, BLOCK_SIZE/2);
+        xms_fmemcpyb(0, ebh->b_L2seg, bh->b_data, kernel_ds, BLOCK_SIZE);
         unmap_count++;
     }
     bh->b_data = 0;

--- a/tlvc/include/linuxmt/memory.h
+++ b/tlvc/include/linuxmt/memory.h
@@ -42,12 +42,12 @@ int FARPROC block_move(struct gdt_table *gdtp, size_t words); /* use INT 15/1F *
 int FARPROC loadall_block_move(addr_t ssrc, addr_t dst, size_t words); /* use loadall */
 
 /* XMS memory management */
+extern int xms_mode;
 /* possible values for xms_mode */
 #define XMS_DISABLED	0	/* Off */
 #define XMS_UNREAL	1	/* using unreal mode and linear32_fmemcpy for block moves */
 #define XMS_INT15	2	/* using BIOS INT 15 block move */
 #define XMS_LOADALL	3	/* Using LOADALL on 286 system */
-extern int xms_mode;
 
 #ifdef CONFIG_FS_XMS_BUFFER
 typedef __u32 ramdesc_t;	/* special physical ram descriptor */
@@ -57,15 +57,11 @@ void xms_init(void);		/* enables xms and A20 gate if present */
 ramdesc_t xms_alloc(int size);
 
 /* copy to/from XMS or far memory - XMS requires unreal mode and A20 gate enabled */
-void xms_fmemcpyw(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src_seg,
-		size_t count);
 void xms_fmemcpyb(void *dst_off, ramdesc_t dst_seg, void *src_off, ramdesc_t src_seg,
 		size_t count);
 void xms_fmemset(void *dst_off, ramdesc_t dst_seg, byte_t val, size_t count);
 
 /* low level copy - must have 386 CPU and xms_enabled before calling! */
-void linear32_fmemcpyw(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
-		size_t count);
 void linear32_fmemcpyb(void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 		size_t count);
 void linear32_fmemset(void *dst_off, addr_t dst_seg, byte_t val, size_t count);
@@ -74,7 +70,6 @@ void linear32_pokew(void *, addr_t, unsigned);
 #else
 
 typedef seg_t ramdesc_t;	/* ramdesc_t is just a regular segment descriptor */
-#define xms_fmemcpyw	fmemcpyw
 #define xms_fmemcpyb	fmemcpyb
 #define xms_fmemset     fmemsetb
 


### PR DESCRIPTION
Originally discussed in  https://github.com/Mellvik/TLVC/pull/165#issuecomment-2848625138, this PR removes word size memory copy routines for xms and far memory, instead using the byte versions of the same routines, which happens to use word size whenever possible. So there is no performance difference between the two, and eliminating the word-routines saves an estimated  500+ bytes of code space.

While the entry point for `fmemcpyw` has been kept (no code), the `xms_fmemcpyw` and `linear32_fmemcpyw` entries have been completely removed (commented out).

In a separate commit, the source code will be removed.

Thanks for the discussion, @ghaerr.