### PR TITLE
[boot] Reinstated validation of bootopts presence before using

### DIFF
--- a/bootblocks/boot_minix.c
+++ b/bootblocks/boot_minix.c
@@ -79,10 +79,8 @@ static void load_file();
 void load_prog()
 {
 	// Avoid reuse of an old copy of /bootopts in memory if we're rebooting w/ no /bootopts */
-	//int __far *optseg = _MK_FP(OPTSEG, 0);	/* Expensive, is there a better way? */
-	i_boot = i_now = 0;
-	//*optseg = i_boot = i_now = 0;
-	//*optseg = 0x1234;	/* no space for this */
+	int __far *optseg = _MK_FP(OPTSEG, 0);	/* Expensive, is there a better way? */
+	*optseg = i_boot = i_now = 0;
 
 	/* use the BDA_IAC location 0(W) (0x4f:0) to store the actual OPTSEG start */
 	asm("xor %ax,%ax; mov %ax,%es; movw $" STRING(OPTSEG) ",%es:(0x4f0)");


### PR DESCRIPTION
Added in #16, the 'cancellation' of a previous in-ram copy of bootopts was temporarily removed for space reasons in #167.  The code snippet prevents a previous copy of `bootopts` from being reused in the odd case that the next boot does now have a `bootopts`file. As it turns out, the final changes in #167 opens up exactly enough room to put it back in. Thanks @ghaerr.