### PR TITLE
[kernel] Add the ability to manually set MAC addresses for NICs

### DIFF
--- a/tlvc/arch/i86/drivers/net/ne2k.c
+++ b/tlvc/arch/i86/drivers/net/ne2k.c
@@ -55,6 +55,7 @@ extern int ne2k_next_pk;
 extern word_t ne2k_flags;
 extern word_t ne2k_has_data;
 extern struct eth eths[];
+extern unsigned char macaddr[];
 
 /* Distinguish between buffered and non buffered IO */
 /* Don't change these constants, the asm code is using them literally */
@@ -514,7 +515,7 @@ void INITPROC ne2k_drv_init(void)
 			 * to set the QEMU flag (for ftp). This feature is currently
 			 * unused as there is no way to pass that info up to ftp.
 			 *
-			 * The MAC address occupies the first 6 bytes, followed by a 'card signature'
+			 * The MAC address occupies the first 6 words, followed by a 'card signature'
 			 * which is usually empty except for bytes 28 and 30, which contain
 			 * a 'B' if it's an 8bit card, 'W' if it's a 16bit card.
 			 * If a NIC doesn't implement this feature, 16-bit mode
@@ -572,11 +573,15 @@ void INITPROC ne2k_drv_init(void)
 		netif_stat.if_status |= NETIF_IS_QEMU;
 		running_qemu = 1;
 	}
-	//for (i = 0; i < 16; i++) printk("%02x", cprom[i]);
-	//printk("\n");
+#if 0
+	for (i = 0; i < 16; i++) printk("%02x", cprom[i]);
+	printk("\n");
+#endif
+	if (macaddr[0]+macaddr[1]+macaddr[2])	/* Bootopts mac address takes presedence */
+		cprom = macaddr;
 
 	memcpy(mac_addr, cprom, 6);
-	printk(", (%s) MAC %02x", model_name, mac_addr[0]);
+	printk(", (%s) MAC %02x%s", model_name, mac_addr[0], cprom==macaddr? " (from bootopts)":"");
 	ne2k_addr_set(cprom);   /* Set NIC mac addr now so IOCTL works from ktcp */
 
 	i = 1;

--- a/tlvc/init/main.c
+++ b/tlvc/init/main.c
@@ -81,6 +81,8 @@ int xtideparms[6];		/* config data for xtide controller if present */
 int fdcache = -1;		/* floppy sector cache size(KB), -1: not configured */
 int xms_size, xms_avail, xms_start, hma_avail;	/* descriptions in xms.c */
 int xms_mode;
+unsigned char macaddr[6];
+
 static int boot_console;
 static char bininit[] = "/bin/init";
 static char binshell[] = "/bin/sh";
@@ -98,6 +100,7 @@ static char hasopts;
 static int args = 2;	/* room for argc and av[0] */
 static int envs;
 static int argv_slen;
+
 /* argv_init doubles as sptr data for sys_execv later */
 #ifdef CONFIG_SYS_NO_BININIT
 static char *argv_init[MAX_INIT_SLEN] = { NULL, binshell, NULL };
@@ -502,6 +505,17 @@ static void INITPROC parse_parms(int cnt, char *line, int *nums, int base)
 		l++;
 	}
 }
+static void parse_mac(char *line) {
+	char *c = line;
+	int mac[6];
+
+	while (*c) {
+		if (*c == ':') *c = ',';
+		c++;
+	}
+	parse_parms(6, line, mac, 16);
+	for (int i = 0; i < 6; i++) macaddr[i] = (unsigned char)mac[i];
+}
 
 static void INITPROC comirq(char *line)
 {
@@ -650,6 +664,10 @@ static int INITPROC parse_options(void)
 		}
 		if (!strncmp(line,"le0=", 4)) {
 			parse_nic(line+4, &netif_parms[ETH_LANCE]);
+			continue;
+		}
+		if (!strncmp(line,"mac=", 4)) {
+			parse_mac(line+4);
 			continue;
 		}
 		if (!strncmp(line,"bufs=", 5)) {


### PR DESCRIPTION
Add a new `mac=` setting to `bootopts` to enable the low level Ethernet (MAC) address to be set manually. Currently implemented only by the `ne2k` driver and primarily useful in a debugging setting.

The situation triggering this addition was testing of the ISA PicoMEM 8bit ISA card, which emulates a `ne2k` NIC, but does so erroneously (for now, check https://github.com/FreddyVRetro/ISA-PicoMEM/issues/103#issue-3065248224).

With a manually set MAC address, the RaspberryPI PicoW on the card delivers wireless LAN access to my Compaq Portable Plus. The PicoMEM is still work in progress and a very DOS/BIOS oriented project.  It's also an interesting concept with quite a bit of potential. For now, networking is its only capability to work with TLVC. 

The new `mac=` setting in `bootopts` takes a 6 byte MAC address as parameter, separated by commas or colons. No sanity checking on the values, but the address and the fact that it has been set via bootopts is displays in boot messages.