### PR TITLE
[kernel] Allow floppy DMA to/frm XMS memory, probe fixes

### DIFF
--- a/tlvc/include/linuxmt/memory.h
+++ b/tlvc/include/linuxmt/memory.h
@@ -31,6 +31,7 @@ word_t fmemcmpw (void * dst_off, seg_t dst_seg, void * src_off, seg_t src_seg, s
 #define _FP_OFF(fp)     ((unsigned)(unsigned long)(void __far *)(fp))
 #define _MK_FP(seg,off)	((void __far *)((((unsigned long)(seg)) << 16) | (off)))
 #define _MK_LINADDR(seg, offs) ((unsigned long)((((unsigned long)(seg)) << 4) + (unsigned)(offs)))
+#define _MK_XMSADDR(seg, offs) ((unsigned long)(((unsigned long)(seg)) + (unsigned)(offs)))
 
 /* unreal mode, A20 gate management */
 int check_unreal_mode(void);	/* check if unreal mode capable, returns > 0 on success */


### PR DESCRIPTION
Adds floppy DMA to/from XMS memory as discussed in #164 and in ELKS https://github.com/ghaerr/elks/pull/2339#issue-3084933312. Floppy IO no longer needs to pass via the bounce buffer when XMS buffers are involved.

Also included a bug fix (and some cleanups, optimizations) in the probe code that in some cases prevented probes to succeed after diskette changes.