### PR TITLE
[daemons] getty and ftpd must disconnect from parent's process group

### DIFF
--- a/tlvccmd/inet/ftp/ftpd.c
+++ b/tlvccmd/inet/ftp/ftpd.c
@@ -739,7 +739,7 @@ int main(int argc, char **argv) {
 		dup2(ret, STDERR_FILENO);
 		if (ret > STDERR_FILENO)
 			close(ret);
-		//setsid();
+		setsid();
 	} else
 		printf("Debug: Not disconnecting from terminal.\n");
 

--- a/tlvccmd/sys_utils/getty.c
+++ b/tlvccmd/sys_utils/getty.c
@@ -242,6 +242,7 @@ int main(int argc, char **argv)
 		exit(5);
 	}
 	close(tty);
+	setsid();	/* if the parent exits, keep going */
     }
 
     /* setup tty termios state*/


### PR DESCRIPTION
Fixes the problem with `getty` and `ftpd` reported in #175: If started from the shell they would terminate with the shell. They now create their own process group via `setsid()` like the other daemons, and keep going until killed explicitly.