### PR TITLE
[kernel] Bugfixes in heap code

### DIFF
--- a/tlvc/lib/heap.c
+++ b/tlvc/lib/heap.c
@@ -101,7 +101,7 @@ static heap_s *free_get(word_t size0, byte_t tag)
 		}
 
 		n = h->free.next;
-	};
+	}
 
 	// Then allocate that free block
 


### PR DESCRIPTION
Even old and heavily used code sometimes have bugs and weaknesses.

- `heap_alloc` has been updated so that zero sized requests have no effect and return NULL. Such requests would allocate empty headers in the heap, typically when drivers make buffer allocations that have been set to size zero by (say) `bootopts` or some other configuration.
- Similarly, `heap_free` will return immediately if the parameter is zero, which may happen for the same reason as above.
- A bug in `heap_free` prevented the first heap entry from being freed if the next entry on the list was in use. Why this has never been caught may seem like mystery, but isn't. The first heap allocation is usually a segment descriptor for the L1 buffers - it will never be freed.