### PR TITLE
[kernel] Move bootopts out of low memory, no size restrictions

### DIFF
--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -104,7 +104,7 @@ entry1:
 	// Move to the highest & aligned 64K
 
 	// Some BIOSes are intolerant to unaligned buffer for INT 13h
-	// so the 64K is the safest possible alignement in all cases
+	// so the 64K is the safest possible alignment in all cases
 
 	sub $0x1000,%ax
 	and $0xF000,%ax
@@ -574,7 +574,7 @@ boot_it:
 
 	.global linux_ok
 linux_ok:
-	mov $msg_load,%bx;
+	mov $msg_load,%bx
 	jmp _puts
 
 msg_boot:

--- a/tlvc/arch/i86/boot/setup.S
+++ b/tlvc/arch/i86/boot/setup.S
@@ -940,7 +940,7 @@ novga:	mov	%al,14		// CGA 25 rows
 #ifdef CONFIG_BOOTOPTS
 	call	bootopts	// load /bootopts into DEF_OPTSEG
 	call    hmabootopts	// check /bootopts for hma=kernel
-	mov	%al,hma_kernel
+	//mov	%al,hma_kernel
 #endif
 	ret
 
@@ -958,12 +958,7 @@ hmabootopts:
 	lodsw
 	mov	%ax,%bx			// optseg segment
 	lodsw
-	mov	%ax,%dx			// optseg offset
-	//lodsw
-	//mov	%bx,%ds
-	//mov	%ax,%bx			// optseg size, currently not used
-					// (no space in boot_minix)
-	mov	%dx,%si
+	mov	%ax,%si			// optseg offset
 	mov	%bx,%ds
 #else
 	mov	$DEF_OPTSEG,%ax		// DS:SI = /bootopts in memory
@@ -972,6 +967,7 @@ hmabootopts:
 #endif
 
 	mov	%si,%bx
+	xor	%dx,%dx
 look:	mov	(%si),%al		// done when NUL seen
 	test	%al,%al
 	jz	1f
@@ -984,31 +980,23 @@ look:	mov	(%si),%al		// done when NUL seen
 	inc	%si
 	test	%cx,%cx
 	jnz	look			// NZ = no match
-	add	$11,%si			// match, now get the size of the file
-	push	%si
-	mov	$'H',%ax
+	movb	$1,%dx			// match, set flag
+	mov	$'H',%ax		// ... and notify console
 	call	putc
-	pop	%si
-	mov	$1,%ax			// success return code
-	push	%ax
-3:	mov	(%si),%al
-	inc	%si
-	test	%al,%al
-	jnz	3b
-	jmp	4f
-1:	xor	%ax,%ax
-	push	%ax
-4:			// get the file size, there is no space to get
-			// it (and store it) from the inode in the bootblock 
+	jmp	look			// and continue - to get the file size
+1:	// save file size, there is no space to get
+	// it (and store it) from the inode in the bootblock 
 	mov	%si,%ax
 	sub	%bx,%ax			// size in AX
+	inc	%ax			// include final null byte
 	xor	%bx,%bx
 	mov	%bx,%ds
 	mov	%ax,BDA_IAC_OPTSIZE		// Save size in BDA
 
-	pop	%ax
+	//pop	%ax
 	pop	%es
 	pop	%ds
+	movb	%dl,hma_kernel
 	ret
 
 hma_string:

--- a/tlvc/arch/i86/boot/setup.S
+++ b/tlvc/arch/i86/boot/setup.S
@@ -951,10 +951,27 @@ hmabootopts:
 
 	push	%cs			// ES = our code segment
 	pop	%es
+#ifdef CONFIG_OPTSEG_HIGH
+	xor	%ax,%ax
+	mov	%ax,%ds
+	mov	$BDA_IAC_OPTSEG,%si
+	lodsw
+	mov	%ax,%bx			// optseg segment
+	lodsw
+	mov	%ax,%dx			// optseg offset
+	//lodsw
+	//mov	%bx,%ds
+	//mov	%ax,%bx			// optseg size, currently not used
+					// (no space in boot_minix)
+	mov	%dx,%si
+	mov	%bx,%ds
+#else
 	mov	$DEF_OPTSEG,%ax		// DS:SI = /bootopts in memory
 	mov	%ax,%ds
-
 	xor	%si,%si			// look for hma=kernel in /bootopts segment
+#endif
+
+	mov	%si,%bx
 look:	mov	(%si),%al		// done when NUL seen
 	test	%al,%al
 	jz	1f
@@ -967,12 +984,30 @@ look:	mov	(%si),%al		// done when NUL seen
 	inc	%si
 	test	%cx,%cx
 	jnz	look			// NZ = no match
+	add	$11,%si			// match, now get the size of the file
+	push	%si
 	mov	$'H',%ax
 	call	putc
-	mov	$1,%ax			// return success
-	jmp	2f
-1:	xor	%ax,%ax			// no HMA
-2:	pop	%es
+	pop	%si
+	mov	$1,%ax			// success return code
+	push	%ax
+3:	mov	(%si),%al
+	inc	%si
+	test	%al,%al
+	jnz	3b
+	jmp	4f
+1:	xor	%ax,%ax
+	push	%ax
+4:			// get the file size, there is no space to get
+			// it (and store it) from the inode in the bootblock 
+	mov	%si,%ax
+	sub	%bx,%ax			// size in AX
+	xor	%bx,%bx
+	mov	%bx,%ds
+	mov	%ax,BDA_IAC_OPTSIZE		// Save size in BDA
+
+	pop	%ax
+	pop	%es
 	pop	%ds
 	ret
 
@@ -1120,17 +1155,19 @@ pc98_int1b:
 	jnc	1f
 0:	mov	$'F',%al	// Fail, not FAT bootopts
 	call	putc
+#ifndef CONFIG_OPTSEG_HIGH	/* Do low mem relocation if needed */
 	xor	%ax,%ax
 	mov	%ax,%es
-	//movw	$DEF_OPTSEG,%es:((BDA_IAC_SEG<<4)+2)  // DEBUG
-	mov	%es:(BDA_IAC_SEG<<4),%ax
+	mov	%es:(BDA_IAC_OPTSEG),%ax
 	//call	hex4
 	cmp	$DEF_OPTSEG,%ax
 	jz	3f
 	call	reloc_opts
 	mov	$'R',%al	// Indicate relocated bootopts
-	call	putc
+	jmp	2f
+#else
 	jmp	3f
+#endif
 1:	mov	$' ',%al
 2:	call	putc
 3:	pop	%es
@@ -1145,6 +1182,7 @@ pc98_int1b:
 # FLAGS = set by caller
 # If moving down -> move from the bottom, if moving up -> move from the top.
 #
+#ifndef CONFIG_OPTSEG_HIGH
 reloc_opts:
 	push	%si
 	push	%di
@@ -1168,6 +1206,7 @@ reloc_up:
 	mov	%ax,%es
 	std
 	jmp	1b
+#endif
 #----
 
 

--- a/tlvc/include/linuxmt/config.h
+++ b/tlvc/include/linuxmt/config.h
@@ -8,6 +8,8 @@
  * Compile-time configuration
  */
 
+#define CONFIG_OPTSEG_HIGH	/* Load /bootopts (of any size) into high memory */
+				/* Not currently working on FAT boot devices */
 #ifdef CONFIG_ARCH_IBMPC
 #define MAX_SERIAL		4		/* max number of serial tty devices */
 #define MAX_XMS_SIZE		0x7fff		/* Caps XMS-size to 32M (mask - setup.S) */
@@ -105,6 +107,7 @@
 #define DEF_SYSSEG	0x1400		/* kernel copied here by setup.S code */
 #define DEF_SETUPSEG	(DEF_INITSEG + 0x20)
 #define DEF_SYSMAX	0x2F00
+#define DEF_MINHEAP	0x8000		/* minimal kernel heap */
 
 #ifdef CONFIG_ROMCODE
 #if defined(CONFIG_BLK_DEV_BHD) || defined(CONFIG_BLK_DEV_BFD)
@@ -168,10 +171,10 @@
 #endif
 
 #define BDA_IAC_SEG		0x4F	/* BDA 'Intra-Applications Communications Area' */
-					/* 16 bytes, the first (0x4f:0) (W) holds the */
-					/* actual OPTSEG location used by the minix */
-					/* bootloader */
-#define BDA_IAC_OPTSEG		0x0	/* Offset where boot's DEF_OPTSEG is saved */
+					/* 16 bytes */
+#define BDA_IAC_OPTSEG		0x4F0	/* Seg where boot loads /bootopts */
+#define BDA_IAC_OPTOFFS		0x4F2	/* Offset */
+#define BDA_IAC_OPTSIZE		0x4F4	/* Size */
 
 // NOTE: for accomodating the LOADALL 0x80:0 seg (0x80:0-0x87:0),
 // leave OPTSEG in place (its use is over before LOADALL needs it)

--- a/tlvc/include/linuxmt/heap.h
+++ b/tlvc/include/linuxmt/heap.h
@@ -27,6 +27,7 @@
 #define HEAP_TAG_FILE	 0x08
 #define HEAP_TAG_CACHE	 0x09
 #define HEAP_TAG_NETWORK 0x0A	/* packet buffer allocations */
+#define HEAP_TAG_OPTSEG	 0x0B
 
 
 // TODO: move free list node from header to body

--- a/tlvccmd/rootfs_template/bootopts
+++ b/tlvccmd/rootfs_template/bootopts
@@ -1,33 +1,49 @@
-## max 1023 bytes, details in wiki
+## On FAT: max 1023 bytes, minix-fs: no restriction, details in wiki
 console=ttyS0,57600 3	# serial console, init-level (3)
-debug=2
-NET=ne0 		# start netw @ boot w/this interface
-#root=hda1
+debug=2			# Enable misc debug functionality in kernel
+#root=hda1		# make any drive or partition root
+#ro rw			# rootfs rdonly or rw, override config
 #TZ=MDT7
+
+# networking
+NET=ne0 		# start netw @ boot w/this interface
 LOCALIP=10.0.2.15
 GATEWAY=10.0.2.1
 HOSTNAME=tlvc15
-ne0=12,0x300,,0x80
+
+ne0=12,0x300,,0x80	# defaults in ports.h
 wd0=2,0x280,0xCC00,0x80
 #3c0=11,0x330,,0x80
 #ee0=11,0x360,,0x80
+#le0=
+#mac=			# set MAC addr, ne2k only
+netbufs=0,0	# net buffers, recv/trans, ne2k only, def 2,0
+
 comirq=,,7,10	# IRQ for com ports, max 4
+
+# kernel tuning
 #cache=8	# L1 cache
-#bufs=40	# L2 buffers
+#bufs=40	# L2 buffers (usually 64)
+#heap=30	# max heap (kB), def ca. 50k
+#mem=640	# memsize kB
+#umb=000011111	# enable UMBs, 1 digit per 32k starting @ A000
+#tasks=18	# max tasks, default 16, max ~24
+#files=64 inodes=96 # must match tasks
+#sync=30	# autosync buffers (secs)
+#strace		# enable system call tracing
+#kstack		# enable kernel stack tracing
+
+# XMS - 286 and up
 xms=on
 xmsbufs=256	# if supported
-hma=kernel
-#umb=000011111
-#heap=30	# max heap (kB)
-#mem=640	# memsize kB
-#mac=
-#files=64 inodes=96
+hma=kernel	# load kernel in HMA if available
+
+# mass storage
 #hdparms=823,4,38,-1,63,16,63,-1 # CHSW for 2 drives, overrides CMOS & BIOS
-netbufs=0,0	# netw buffers, recv/trans, ne2k only
-#tasks=18	# max tasks, default 16, max 20
-#sync=30		# autosync secs
 #xtflpy=3,1	# meaningful for XT systems w/720k type 3 drive(s)
 fdcache=5	# floppy read cache for slow systems <= 286
 #xtide=0x300,5,1,,, # addr, IRQ, flgs for 2 XT-IDE controllers
+
+#system startup
 #init=/bin/init 3 n	# multiuser serial no /etc/rc.sys
 #init=/bin/sh		# singleuser shell

--- a/tlvccmd/sys_utils/meminfo.c
+++ b/tlvccmd/sys_utils/meminfo.c
@@ -397,7 +397,7 @@ void mem_map(void)
 	    p_subdiv(heap[1].base, "", 1);
 	    p_block(1, (long_t)(heap[1].base - (heap[0].base - bss_size)), "Kernel bss", "");
 	} else
-	    p_block(2, (long_t)bss_size, "Kernel bss", "");
+	    p_block(1, (long_t)bss_size, "Kernel bss", "");
 
 	p_subdiv(heap[0].base - bss_size, "BSS start", 1);
 	p_block(1, (long_t)heap[0].base - bss_size, "Kernel data", "");
@@ -495,7 +495,7 @@ void dump_heap(void)
 	word_t total_size = 0;
 	word_t total_free = 0;
 	static char *heaptype[] = { "free", "MEM ", "DRVR", "TTY ", "TASK", "BUFH", "PIPE",
-				    "INOD", "FILE", "CACH", "NETB" };
+				    "INOD", "FILE", "CACH", "NETB", "OPTS" };
 
 	printf("  HEAP   TYPE  SIZE    SEG   STYPE   SSIZE CNT  NAME\n");
 


### PR DESCRIPTION
In a classic 'one change enables another' sequence, this commit completes the `bootopts` disconnect from low memory and thus its size limitation. `bootopts` can now have any (reasonable) size with no need to make any changes to the system. 

Currently this applies to minix filesystems only. The new CONFIG_OPTSEG_HIGH must be enabled (currently in config.h) and must be disabled when creating a system expected to boot off of a FAT volume, where the traditional 1k size limitation and low memory location still apply.

Notes about the changes:
- The minix bootblock reads `bootopts` into a buffer in its own bss area, typically at seg 0x8000 on a 640k system. The buffer is the last bss declaration and thus not size restricted by the declared size.
- The bootblock saves the segment and offset of the buffer in the same locations as before (the BDA IAC), except now both seg and offset are stored because there is no code space to merge them into a single seg value.
- Ideally the size (from the inode) should also be saved (in the 3rd word of the BDA IAC segment), but it has been impossible to squeeze enough space out of the minix boot code to manage that. Instead the size is 'measured' manually in `setup.S` while looking for the `hma=kernel` statement, and saved at the appropriate location.
- Using the bootblock bss for to buffer `bootopts` means there is no longer any need to check the location of - and potentially relocate - bootopts in `setup.S`. The location is always set (and saved in the BDA) at boot time.
- Re. the discussion above, `init/main.c` now copies `bootopts` to an allocated heap buffer instead of making assumptions about the availability of the upper heap area. This is achieved by defining a minimum heap size (currently 32k) in config.h and initializing the heap before allocating the `bootopts` buffer. After `bootopts` processing, the rest of the heap, if any, is added - immediately followed by a 'fake' alloc/free pair to effectively merge the two. This avoids fragmentation caused by the heap 'split' - see below.
- The heap allocation for `bootopts` is released at the end of kernel init, and immediately becomes a 'magnet' for small heap allocations - with the effect that most small allocations (obviously dependent on the size of the `bootopts` file) end up at the beginning of the heap automagically.
- There are several interesting observations to be made about the heap in this context (and a couple of bug fixes submitted separately in #183):
    - The 'two-step (split heap) creation' opens up some interesting capabilities. Like: When the 2nd part of the heap is added, that part will be the smaller (in terms of available bytes) of the two even though some significant allocations have been made from the first part. In turn this means that most new allocations will come from the 2nd (upper and smaller) section. This may be desirable - in fact defining the DEF_MINHEAP size provides the ability to steer this 'split point' to wherever convenient (above the obvious minimum required to boot the system): Small allocations above, large allocations below. Whether this has any practical effect, remains to be seen, but the capability is there.
    - Similarly, but at the opposite end of the heap: Since small allocations naturally gravitate to the smallest available free block, the void left by the freed bootopts segment will become host to the many segment descriptors typically populating the heap, keeping them away from the larger part(s) of the heap and thereby optimizing usage in the same way as the former 'gravitate north' mechanism and the release bss optseg buffer.
    - Since the size of bootopts now has effect on heap disposition, it becomes a debugging/performance measurement tool in itself, along with `meminfo` which has been indispensable in the process. The combination of bootopts size and DEF_MINHEAP provides ample opportunity for tuning and optimization for the so inclined.
    - Obviously, a very big (like 10+k) `bootopts` may cause boot failure, depending on the configuration. Just like various `bootopts` settings may have similar effect if set unwisely. For any reasonable size `bootopts`, the 32k minimal heap setting should be just fine.

More testing is needed. And then a closer look at what it will take to implement similar capability for FAT boot volumes.

For now, having an unrestricted `bootopts` on minix volumes is a big improvement, and eliminates the need for a separate bootopts.txt to explain the options and provide examples. Apropos `bootopts.txt`: As a temporary measure, it's an option to include a bootopts-filtering mechanism in the image build process to reduce the size of bootopts when building FAT bootables, keeping the original bootopts as bootopts.txt for reference.

Eventually  the CONFIG_OPTSEG_HIGH will be become superfluous and gone - simplifying the source significantly.

This PR also includes an updated `meminfo` with the new OPTSEG heap allocation type.
