### PR TITLE
[kernel] Copy pre-boot messages to serial console

### DIFF
--- a/tlvc/init/main.c
+++ b/tlvc/init/main.c
@@ -246,6 +246,27 @@ static void INITPROC early_kernel_init(void)
 
 }
 
+#define LINES 24
+#define COLS 80
+
+/* copy pre-boot and early boot system messages from physical to serial console */
+void INITPROC copycon(void)
+{
+    unsigned short __far *conchar = _MK_FP(0xb800, 0);
+    unsigned char buf[80];
+    int i;
+
+    for (i = 0; i < LINES; i++) {
+    	int j;
+	for (j = 0; j < COLS; j++)
+	    buf[j] = *conchar++;
+	while (buf[--j] == 0x20 && j) buf[j] = 0;
+	if (!j) break;
+	printk("\n%s", buf);
+    }
+    printk("\n\n");
+}
+
 void INITPROC kernel_init(void)
 {
     int i;
@@ -266,6 +287,7 @@ void INITPROC kernel_init(void)
 
     /* set console from /bootopts console= or 0=default */
     set_console(boot_console);
+    if (boot_console) copycon();
     console_init();	/* init direct, bios or headless console */
 
 #ifdef CONFIG_CHAR_DEV_RS


### PR DESCRIPTION
Serial console has always had the drawback of not showing initial BIOS/pre-boot messages which appear before the serial line has been initialized. This simple addition to `init/main.c` fixes that by copying whatever is in the console buffer to the serial console - if enabled - before anything else, thereby maintaining the sequence of messages. 

Very valuable for headless systems and when running systems remotely via serial. 

Sample from QEMU:

```

SeaBIOS (version rel-1.16.1-0-g3208b098f51a-prebuilt.qemu.org)
Booting from Floppy...
TLVC............................................................................
................................................................................
...........................
TLVC Setup ....L0610C2BH00S05L0612C2BH00S07 HtFFFF f0250 d0695
moving bootopts (size 1505) from 8080:0 to 695:41ce

Direct console, scan kbd 80x25 emulating ANSI (3 virtual consoles)
ttyS0 at 0x3f8, irq 4 is a 16550A
64 ext buffers (base @ 0x8fc0), 8K L1-cache, 20 req hdrs
eth: ne0 at 0x300, irq 12, (ne2k) MAC 52:54:00:12:34:56 (QEMU), flags 0x80, bufs 0r/0t
eth: wd0 at 0x280, irq 2, ram 0xcc00 not found
hd0: AT/IDE controller at 0x1f0
...
```