### PR TITLE
[ktcp] A work-in-progress checkin, lots of enhancements & fixes

### DIFF
--- a/tlvccmd/ktcp/config.h
+++ b/tlvccmd/ktcp/config.h
@@ -10,7 +10,7 @@
 #define DEBUG_TCP	0	/* TCP ops*/
 #define DEBUG_TCPPKT	0	/* TCP packets info*/
 #define DEBUG_TCPDATA	0	/* TCP packet data display*/
-#define DEBUG_TUNE	1	/* tuning options*/
+#define DEBUG_TUNE	0	/* tuning options*/
 #define DEBUG_RETRANS	0	/* TCP retransmissions*/
 #define DEBUG_WINDOW	0	/* TCP window size*/
 #define DEBUG_ACCEPT	0	/* TCP accept*/

--- a/tlvccmd/ktcp/deveth.c
+++ b/tlvccmd/ktcp/deveth.c
@@ -44,7 +44,7 @@ int deveth_init(char *fdev)
     }
 
     /* read mac of nic */
-    if (ioctl (devfd, IOCTL_ETH_ADDR_GET, eth_local_addr) < 0) {
+    if (ioctl(devfd, IOCTL_ETH_ADDR_GET, eth_local_addr) < 0) {
         printf("ktcp: IOCTL_ETH_ADDR_GET fail\n");
 
         /* MAC not available is a fatal error */
@@ -64,9 +64,10 @@ int deveth_init(char *fdev)
 void eth_process(void)
 {
   eth_head_t * eth_head;
-  int len = read (devfd, sbuf, MAX_PACKET_ETH);
+  int len = read(devfd, sbuf, MAX_PACKET_ETH);
   if (len < (int)sizeof(eth_head_t)) {
-	if (len < 0) printf("ktcp: eth_process error %d (errno %d), discarding packet\n", len, errno); //FIXME
+	/* FIXME: Is this really a 'tryagain' situation? It's always non-fatal, do we need the message? */
+	if (len < 0) printf("ktcp: eth_process error %d (errno %d), discarding packet\n", len, errno); 
 	return;
   }
 
@@ -74,8 +75,8 @@ void eth_process(void)
 
 #if 0
   /* Filter on MAC addresses in case of promiscuous mode*/
-  if (memcmp (eth_head->eth_dst, broad_addr, sizeof (eth_addr_t))
-    && memcmp (eth_head->eth_dst, eth_local_addr, sizeof (eth_addr_t)))
+  if (memcmp (eth_head->eth_dst, broad_addr, sizeof(eth_addr_t))
+    && memcmp (eth_head->eth_dst, eth_local_addr, sizeof(eth_addr_t)))
       return;
 #endif
 
@@ -87,7 +88,7 @@ void eth_process(void)
 	  break;
 
   case ETH_TYPE_ARP:
-	  arp_recvpacket (sbuf, len);
+	  arp_recvpacket(sbuf, len);
 	  break;
   }
   netstats.ethrcvcnt++;
@@ -105,7 +106,7 @@ void eth_route(unsigned char *packet, int len, ipaddr_t ip_addr)
 	unsigned char *p;
 
 	/* try to get cached ethernet address and send packet*/
-	if (arp_cache_get (ip_addr, eth_addr, ARP_VALID)) {
+	if (arp_cache_get(ip_addr, eth_addr, ARP_VALID)) {
 		eth_sendpacket(packet, len, eth_addr);
 		return;
 	}

--- a/tlvccmd/ktcp/deveth.h
+++ b/tlvccmd/ktcp/deveth.h
@@ -12,7 +12,7 @@
 
 /* Ethernet header (no VLAN tag) */
 
-typedef __u8 eth_addr_t [6];
+typedef __u8 eth_addr_t[6];
 
 struct eth_head_s {
 	eth_addr_t eth_dst;  /* MAC destination address */

--- a/tlvccmd/ktcp/tcp.h
+++ b/tlvccmd/ktcp/tcp.h
@@ -10,47 +10,58 @@
 #include <arpa/inet.h>
 
 /*
- * /etc/tcpdev max read/write size
- * Must be at least as big as CB_NORMAL_BUFSIZ
- * And at least as big as TCPDEV_INBUFFERSIZE in <linuxmt/tcpdev.h> (currently 1500)
+ * /dev/tcpdev max read/write size
+ * must be at least as big as CB_NORMAL_BUFSIZ
+ * and at least as big as TCPDEV_INBUFFERSIZE in <linuxmt/tcpdev.h> (currently 1500)
  */
 #define TCPDEV_BUFSIZ	(CB_NORMAL_BUFSIZ + sizeof(struct tdb_return_data))
 
-/* max tcp buffer size (no ip header)*/
+/* max tcp buffer size (no ip header) */
 #define TCP_BUFSIZ	(TCPDEV_BUFSIZ + sizeof(tcphdr_t) + TCP_OPT_MSS_LEN)
 
-/* max ip buffer size (with link layer frame)*/
+/* max ip buffer size (with link layer frame) */
 #define IP_BUFSIZ	(TCP_BUFSIZ + sizeof(iphdr_t) + sizeof(struct ip_ll))
 
 /*
  * control block input buffer size - max window size, doesn't have to be power of two
  * default will be (ETH_MTU - IP_HDRSIZ) * 3 = (1500-40) * 3 = 4380
  */
-#define CB_NORMAL_BUFSIZ	4380	/* normal input buffer size*/
-#define USE_SWS			0	/* =1 to use silly window algorithm */
+#define CB_NORMAL_BUFSIZ	4380	/* normal input buffer size */
+#define USE_SWS			0	/* =1 to use silly window avoidance algorithm */
 
-/* max outstanding send window size*/
-#define TCP_SEND_WINDOW_MAX	1536	/* should be less than TCP_RETRANS_MAXMEM*/
-					/* was 1024, then 1536 which works fine */
+/* max outstanding send window size */
+#define TCP_SEND_WINDOW_MAX	1800	/* should be less than TCP_RETRANS_MAXMEM */
+					/* was 1024, 1560 works well, higher is experimental */
+					/* too high is bad for XT type slow systems */
 
 /* threshold to wait before pushing data to application (turned off for now) */
 //#define PUSH_THRESHOLD	512
 
-/* timeout values in 1/16 seconds, or (seconds << 4). Half second = 8 */
-#define TIMEOUT_ENTER_WAIT	(4<<4)	/* TIME_WAIT state (was 30, then 10) */
-#define TIMEOUT_CLOSE_WAIT	(10<<4)	/* CLOSING/LAST_ACK/FIN_WAIT states (was 240) */
-#define TIMEOUT_INITIAL_RTT	(1<<4)	/* initial RTT before retransmit (was 4, then 1<<4) */
-#define TCP_RETRANS_MAXWAIT	(4<<4)	/* max retransmit wait (4 secs) */
-#define TCP_RETRANS_MINWAIT_SLIP 8	/* min retrans timeout for slip/cslip (1/2 sec) */
-#define TCP_RETRANS_MINWAIT_ETH	4	/* min retrans timeout for ethernet (1/4 sec) */
-#define TCP_RETRANS_ADJUST	2	/* retrans timeout multiplicator for slow peers */
+/* timeout values - unit is set by 'Now' in ktcp.c, currently 60ms */
+#define TIMEOUT_ENTER_WAIT     /*4000000*/ (4<<4)	/* TIME_WAIT state (was 30, then 10) */
+#define TIMEOUT_CLOSE_WAIT    /*10000000*/ (10<<4)	/* CLOSING/LAST_ACK/FIN_WAIT states (was 240) */
+							/* Initial RTT & RTO values are not important,
+							 * as they get adjusted automatically as soon
+							 * as the connection is up and running. Recommended
+							 * values per RFC 1122 are RTT=0, RTO=3s */
+#define TIMEOUT_INITIAL_RTT	1			/* Still we set RTT to 1 because the smoothing
+							 * algorithm is (currently) disabled when RTT=0 */
+#define TIMEOUT_INITIAL_RTO	(3<<4)			/* 3 seconds */
+#define TCP_RETRANS_MAXWAIT    /*4000000*/ (4<<4)	/* max retransmit wait (4 secs) */
+#define TCP_RETRANS_MINWAIT_SLIP /*500000*/ 8	/* min retrans timeout for slip/cslip (1/2 sec) */
+#define TCP_RETRANS_MINWAIT_ETH	/*250000*/ 4	/* min retrans timeout for ethernet (1/4 sec) */
+#define TCP_RETRANS_ADJUST 3*TIME_CNV_FACTOR /* retrans timeout multiplier for slow peers */
 
-/* retransmit settings*/
-#define TCP_RTT_ALPHA			90
+/* retransmit settings */
+#define TCP_RTT_ALPHA			40	/* was 90, need much faster convergence for
+						 * slow systems */
 #define TCP_RETRANS_MAXMEM		5120	/* max retransmit total memory (was 4096) */
 #define TCP_RETRANS_MAXTRIES		6	/* max # retransmits (~12 secs total) */
-#define TCP_PEER_INDEX_MAX		20	/* don't let the retrans slowdown get out
-						 *  of hand, use 200 for debugging */
+
+/* Slow start/congestion avoidance */
+#define TCP_INIT_CWND			2	/* initial congestion window, don't set to 1 */
+						/* will cause connection deadlock on slow systems */
+#define TCP_INIT_SSTHRESH		100	/* SS threshold, could be infinity */
 
 #define SEQ_LT(a,b)	((long)((a)-(b)) < 0)
 #define SEQ_LEQ(a,b)	((long)((a)-(b)) <= 0)
@@ -125,13 +136,14 @@ struct tcpcb_s {
 
 	__u8	state;
 	__u8	unaccepted;		/* boolean */
-	__u8	sndwin_loop;		/* consecutive loops while waiting for retrans buffer */
-	__u8	peer_speed;		/* peer speed index, for throttling retrans */
-	timeq_t	rtt;			/* in 1/16 secs*/
-	__u16	retranscnt;		/* # of retranmits for this connection */
+	__u8	retrans_act;		/* set when a retrans has been sent on a connection */
+	__u16	rtt;			/* roundtriptime */
+	__u16	cwnd;			/* congestion window */
+	__u16	inflight;		/* # of unacked packets for this cb */
+	__u16	ssthresh;		/* slow start threshold */
+	__u32	sstimer;		/* concestion avoidance timer EXPERIMENTAL */
 
 	__u32	time_wait_exp;
-	//__u16	wait_data;
 
 	short	bytes_to_push;
 
@@ -158,7 +170,7 @@ struct tcpcb_s {
 	__u8	buf_base[];
 };
 
-/* TCP options*/
+/* TCP options */
 #define TCP_OPT_EOL		0
 #define TCP_OPT_NOP		1
 #define TCP_OPT_MSS		2
@@ -176,7 +188,7 @@ struct	tcp_retrans_list_s {
 	struct tcp_retrans_list_s	*next;
 
 	int				retrans_num;
-	timeq_t 			rto;
+	__u16	 			rto;
 	timeq_t 			next_retrans;
 	timeq_t 			first_trans;
 
@@ -193,21 +205,22 @@ extern int cbs_in_user_timeout;	/* fin_wait/closing/last_ack active, call " */
 extern int tcpcb_need_push;	/* push required, tcpcb_push_data/call notify_data_avail */
 extern int tcp_retrans_memory;	/* total retransmit memory in use */
 
-struct tcpcb_list_s *tcpcb_new(int bufsize);
-struct tcpcb_list_s *tcpcb_find(__u32 addr, __u16 lport, __u16 rport);
-struct tcpcb_list_s *tcpcb_find_by_sock(void *sock);
+struct tcpcb_list_s *tcpcb_new(int);
+struct tcpcb_list_s *tcpcb_find(__u32, __u16, __u16);
+struct tcpcb_list_s *tcpcb_find_by_sock(void *);
+void tcpcb_update_sstimer(void);
 
-__u16 tcp_chksum(struct iptcp_s *h);
-__u16 tcp_chksumraw(struct tcphdr_s *h, __u32 saddr, __u32 daddr, __u16 len);
-void tcp_print(struct iptcp_s *head, int recv, struct tcpcb_s *cb);
-void tcp_output(struct tcpcb_s *cb);
+__u16 tcp_chksum(struct iptcp_s *);
+__u16 tcp_chksumraw(struct tcphdr_s *, __u32, __u32, __u16);
+void tcp_print(struct iptcp_s *, int, struct tcpcb_s *);
+void tcp_output(struct tcpcb_s *);
 int tcp_init(void);
-void tcp_process(struct iphdr_s *iph);
-void tcp_connect(struct tcpcb_s *cb);
-void tcp_send_ack(struct tcpcb_s *cb);
-void tcp_send_fin(struct tcpcb_s *cb);
-void tcp_send_reset(struct tcpcb_s *cb);
-void tcp_reset_connection(struct tcpcb_s *cb);
+void tcp_process(struct iphdr_s *);
+void tcp_connect(struct tcpcb_s *);
+void tcp_send_ack(struct tcpcb_s *);
+void tcp_send_fin(struct tcpcb_s *);
+void tcp_send_reset(struct tcpcb_s *);
+void tcp_reset_connection(struct tcpcb_s *);
 void tcp_reject(struct iphdr_s *);
 
 void hexdump(unsigned char *addr, int count, int summary, char *prefix);

--- a/tlvccmd/ktcp/tcp_output.c
+++ b/tlvccmd/ktcp/tcp_output.c
@@ -236,7 +236,7 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
 
     /* start timeout blocking in main loop*/
     tcp_timeruse++;	/* actually counts the # of packets in the retransmit buffer */
-    //cb->retrns_cnt++;
+    cb->inflight++;	/* ... as does inflight, but for this cb only */
 
     tcp_retrans_memory += len;
     debug_mem("retrans alloc: (cnt %d, mem %u)\n", tcp_timeruse, tcp_retrans_memory);
@@ -245,7 +245,8 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
     memcpy(&n->apair, apair, sizeof(struct addr_pair));
     n->retrans_num = 0;
 
-    n->rto = cb->rtt << 1;			/* set retrans timeout to twice RTT*/
+    //n->rto = cb->rtt << 1;		/* set retrans timeout to twice RTT*/
+    n->rto = TIMEOUT_INITIAL_RTO;		/* should be 3 secs per RFC 1122 */
     if (linkprotocol == LINK_ETHER) {
 	if (n->rto < TCP_RETRANS_MINWAIT_ETH)
 	    n->rto = TCP_RETRANS_MINWAIT_ETH;	/* 1/4 sec min retrans timeout on ethernet*/
@@ -254,20 +255,23 @@ void add_for_retrans(struct tcpcb_s *cb, struct tcphdr_s *th, __u16 len,
 	    n->rto = TCP_RETRANS_MINWAIT_SLIP;	/* 1/2 sec min retrans timeout on slip/cslip*/
     }
     n->first_trans = Now;
-    n->next_retrans = Now + n->rto;
-    //fprintf(stderr, "rtt/rto/tu: %ld/%ld/%d\n", cb->rtt, n->rto, tcp_timeruse);
+    n->next_retrans = Now + (timeq_t)n->rto;
+    //write(1,"S",1);
+    //fprintf(stderr, "rtt/mem/if/cw: %u/%u/%d/%d\n", cb->rtt, tcp_retrans_memory, cb->inflight, cb->cwnd);
+    ////fprintf(stderr, "rtt/rto/if/cw: %u/%u/%d/%d\n", cb->rtt, n->rto, cb->inflight, cb->cwnd);
 }
 
 void tcp_reoutput(struct tcp_retrans_list_s *n)
 {
-    unsigned int datalen = n->len - TCP_DATAOFF(&n->tcphdr[0]);
+    //unsigned int datalen = n->len - TCP_DATAOFF(&n->tcphdr[0]);
 
-    if (datalen < n->cb->rcv_wnd)		/* don't record retry if not in recv window*/
+    //if (datalen < n->cb->rcv_wnd)		/* don't record retry if not in recv window*/
+    /*  I don't understand, a retrans is per definition within the rcv window */
 	n->retrans_num++;
     n->rto <<= 2;				/* quadruple retrans timeout*/
     if (n->rto > TCP_RETRANS_MAXWAIT)		/* limit retransmit timeouts to 4 seconds*/
 	n->rto = TCP_RETRANS_MAXWAIT;
-    n->next_retrans = Now + n->rto;
+    n->next_retrans = Now + (timeq_t)n->rto;
 
 #ifdef VERBOSE
     printf("tcp retrans: seq %lu+%u size %d rcvwnd %u unack %lu rto %ld rtt %ld state %d (RETRY %d cnt %d mem %u)\n",
@@ -278,14 +282,13 @@ void tcp_reoutput(struct tcp_retrans_list_s *n)
 
     ip_sendpacket((unsigned char *)n->tcphdr, n->len, &n->apair, n->cb);
     netstats.tcpretranscnt++;
-    n->cb->retranscnt++;
 }
 
 /* called every ktcp cycle when tcp_timeruse nonzero - check for expired retrans*/
 void tcp_retrans_expire(void)
 {
     struct tcp_retrans_list_s *n;
-    int rtt;
+    __u16 rtt;
     unsigned int datalen;
 
     n = retrans_list;
@@ -303,12 +306,19 @@ void tcp_retrans_expire(void)
 
 	/* calc RTT and remove if seqno was acked*/
 	if (SEQ_LEQ(ntohl(n->tcphdr[0].seqnum) + datalen, n->cb->send_una)) {
-	    if (n->retrans_num == 0) {
-		rtt = Now - n->first_trans;
+	    n->cb->retrans_act = 0;
+	    /* Don't exclude retransmits, they are important for the true picture */
+	    //if (n->retrans_num == 0) {
+		rtt = (unsigned)(Now - n->first_trans);
+		////fprintf(stderr, "r%u;", rtt);
+		/* We may want to change rtt here like this: if (!rtt) rtt++;
+		 * because rtt is often 0 on a LAN, which means that the calculated
+		 * rtt stays high forever, which is not good. 
+		 */
 		if (rtt > 0)
 		    n->cb->rtt = (TCP_RTT_ALPHA * n->cb->rtt + (100 - TCP_RTT_ALPHA) * rtt) / 100;
-		debug_tcp("tcp: rtt %d RTT %ld RTO %ld\n", rtt, n->cb->rtt, n->rto);
-	    }
+		debug_tcp("tcp: rtt %u RTT %u RTO %u\n", rtt, n->cb->rtt, n->rto);
+	    //}
 	    debug_retrans("tcp retrans: remove seq %lu+%u unack %lu\n",
 		ntohl(n->tcphdr[0].seqnum) - n->cb->iss, datalen,
 		n->cb->send_una - n->cb->iss);
@@ -323,7 +333,7 @@ void tcp_retrans_expire(void)
     }
 }
 
-/* called every ktcp cycle when tcp_timeruse nonzero - check for retransmit* required*/
+/* called every ktcp cycle when tcp_timeruse nonzero - check for retransmit required */
 void tcp_retrans_retransmit(void)
 {
     struct tcp_retrans_list_s *n;
@@ -331,10 +341,32 @@ void tcp_retrans_retransmit(void)
     n = retrans_list;
     
     while (n != NULL) {
-	/* check for retrans time up*/
-	if (TIME_GEQ(Now, n->next_retrans + (long)(n->cb->peer_speed * TCP_RETRANS_ADJUST))) {
-    	    //printf("retrans (%d,%d)\n", tcp_timeruse, n->len - TCP_DATAOFF(&n->tcphdr[0]));	/* DEBUG */
+	/* check for retrans time up */
+	/* adding inflight reduces the # of unneccessary retransmits when
+	 * dealing with very slow systems. A general RTO increase would do
+	 * it, but this is more dynamic */
+	if (TIME_GT(Now, n->next_retrans + n->cb->inflight)) {
+	//if (TIME_GT(Now, n->next_retrans + n->cb->rtt)) {
+    	    if (n->cb->retrans_act && !n->retrans_num) {
+	    	/* dumping the entire retrans buffer is counter-productive. 
+		 * We block more retransmits on this connection until the first has
+		 * been acked or times out again. If we get to max retries, the connection
+		 * will be reset anyway */
+	    	////write(1,"%",1);
+		goto next_round;
+	    }
+
+	    /* congestion avoidance adjustments */
+	    if ((n->cb->inflight > 1) && (n->cb->cwnd > TCP_INIT_CWND)) {
+	    	n->cb->ssthresh = n->cb->inflight/2;	/* inflight has current window in packets */
+	    	if (n->cb->ssthresh < 2) n->cb->ssthresh = 2;
+	    }
+	    n->cb->cwnd = TCP_INIT_CWND;	/* EXPERIMENTAL - keep cwnd at 2 while retransmitting */
+    	    ////printf("retrans (%d,%d,%lu)\n", n->cb->inflight, n->len, Now - n->next_retrans);	/* DEBUG */
+	    n->cb->retrans_act++;
 	    tcp_reoutput(n);
+
+	    /* Doesn't make all that sense to first retrans, then kill the connection */
 	    if (n->retrans_num >= TCP_RETRANS_MAXTRIES) {
 		printf("tcp retrans: max retries exceeded seq %lu unack %lu time %ld\n",
 		    ntohl(n->tcphdr[0].seqnum) - n->cb->iss, n->cb->send_una - n->cb->iss,
@@ -344,6 +376,7 @@ void tcp_retrans_retransmit(void)
 		continue;
 	    }
 	}
+next_round:
 	n = n->next;
     }
 }
@@ -360,7 +393,7 @@ static int tcp_calc_rcv_window(struct tcpcb_s *cb)
     len = CB_BUF_SPACE(cb);
     if (len < minwindow)	/* FIXME this results in "shrinking the window" */
 	len = 0;
-    debug_window("tcp output: len %d min sws %u space %u window %u\n",
+    debug_window("[%lu]tcp output: len %d min sws %u space %u window %u\n", *jp,
 	cb->datalen, minwindow, CB_BUF_SPACE(cb), len);
 #else
     /*
@@ -373,7 +406,7 @@ static int tcp_calc_rcv_window(struct tcpcb_s *cb)
      */
     len = CB_BUF_SPACE(cb);
 
-    debug_window("tcp output: len %d space %u window %u\n",
+    debug_window("[%lu]tcp output: len %d space %u window %u\n", *jp,
 	cb->datalen, CB_BUF_SPACE(cb), len);
 #endif
 

--- a/tlvccmd/ktcp/timer.c
+++ b/tlvccmd/ktcp/timer.c
@@ -8,10 +8,19 @@
  *	2 of the License, or (at your option) any later version.
  */
 
-#include <sys/time.h>
+#define __LIBC__	/* to get types for memory.h FIXME */
+//#include <sys/time.h>
+#include <stdio.h>
+#include <unistd.h>
+#include <fcntl.h>
+#include <linuxmt/mem.h>
+#include <linuxmt/types.h>
+#include <linuxmt/memory.h>
+#include <sys/ioctl.h>
 
 #include "timer.h"
 
+#if 0
 timeq_t timer_get_time(void)
 {
     struct timezone	tz;
@@ -20,5 +29,25 @@ timeq_t timer_get_time(void)
     gettimeofday(&tv, &tz);
 
 	/* return 1/16 second ticks, 1,000,000/16 = 62500*/
-    return (tv.tv_sec << 4) | ((unsigned long)tv.tv_usec / 62500U);
+	/* return 1/10000000 second (us) ticks */
+    return (tv.tv_sec << 4) | ((unsigned long)tv.tv_usec/62500L);
+}
+#endif
+
+int timer_init(void)
+{
+    unsigned int kds, jaddr;
+    int fd = open("/dev/kmem", O_RDONLY);
+
+    if (fd < 0) {
+	perror("/dev/kmem");
+	return -1;
+    }
+    if ((ioctl(fd, MEM_GETDS, &kds) < 0) || (ioctl(fd, MEM_GETJIFFADDR, &jaddr)) < 0 )  {
+	perror("ktcp: ioctl error in /dev/kmem");
+	return -1;
+    }
+    jp = _MK_FP(kds, jaddr);
+    close(fd);
+    return 0;
 }

--- a/tlvccmd/ktcp/timer.h
+++ b/tlvccmd/ktcp/timer.h
@@ -3,7 +3,8 @@
 
 #include <sys/types.h>
 
-/* timeq_t is the time type counted in 62.5ms (1/16 sec) quantums */
+/* timeq_t used to be the time type counted in 62.5ms (1/16 sec) quantums */
+/* Now (2025) it's simply jiffies. */
 typedef	__u32 timeq_t;
 
 #define TIME_LT(a,b)		((long)((a)-(b)) < 0)
@@ -12,7 +13,9 @@ typedef	__u32 timeq_t;
 #define TIME_GEQ(a,b)		((long)((a)-(b)) >= 0)
 
 extern timeq_t Now;
+extern unsigned long __far *jp;
 
-timeq_t timer_get_time(void);
+//timeq_t timer_get_time(void);
+int timer_init(void);
 
 #endif


### PR DESCRIPTION
This PR fixes several bugs and long time performance issues with `ktcp`, most importantly its inability to talk to itself reliably on slow hardware. A summary of the changes and the problems solved follows (mostly developer notes).
- The timer (frequent calls to `gettimeofday()`) is now running on kernel jiffies, simpler and much more efficient. The main loop timer is almost unchanged, now at 60ms instead of 62.5. I'm still experimenting with the possible benefits of using a shorter time tick for the main loop. A higher clock resolution may be beneficial in the still ongoing work to improve the retransmission mechanism. 
- The RTT convergence algorithm (in `tcp_output.c`) has been changed (changes in `tcp.h`) to eliminate the need for longs, and is now dramatically smaller and more efficient without changing its functionality.
- A simplified implementation of the (TCP mandatory) 'slow start' and 'congestion avoidance' algorithms is included. A more complete implementation has been evaluated and found useless under the circumstances. What this implementation does is to enable `ktcp` to talk to other really slow (usually `ktcp` based) systems, which didn't work before. That said, the implementation needs more tuning to become better at adapting to 3 orders of magnitude difference in peer speed (which is admittedly somewhat eased by the fact that we're only supporting 10Mbps NICs).
- The handling of retransmits has been improved but the results are not yet satisfactory. The remaining problem is that when a packet in the retransmit queue times out and gets retransmitted, all the other packets belonging to that connection will have timed out too - and will be dumped onto the wire immediately without waiting to see if the first retransmit generates an ack for the entire bunch of packets in the buffer (which is usually the case). In almost all cases when there is a retransmit, it will be `ktcp` that lost an ack. I've been experimenting with various simple algorithms to make sure there is time for a possible incoming ack to be read and processed before we ship off the whole shebang. Work in progress.
- The 'good old' double ack problem (or feature, since it was put there on purpose) has been worked on but its completion has yet to be verified. It's related to the silly window syndrome and needs some smartness because of the rather odd timings involved when slow systems are talking. Stability is not a problem, the challenge is optimization. When the other end is `ktcp`, unnecessary double acks disturbed the flow. For fast peers, it doesn't matter all that much.
- An old ARP problem that caused the ARP table to be filled with unanswered requests and eventually blocking new requests, has been fixed.
- Also fixed is a long time bug that in some cases caused `kcp` to loop in its main loop (while still working) - as if there were more data to process. This usually happened when a transfer failed, and most often an incoming transfer (like running out of space for an incoming file). What would happen was that the connection Wass terminated properly, but the `tcpcp_need_push` didn't get decremented. This now works, but there may still be other situations that cause the same behaviour, so we may not be completely out of the bushes yet.

With the exception of the two bug fixes mentioned above, this code has been running and in use daily for about 12 months, and - with the caveats mentioned below - is considered stable.

Problems pending
- There are still occasional hangs under heavy load, not predictably repeatable (yet) and possibly driver related.
- There are still situations on XT class systems that may cause long waits at seemingly random intervals during a (significant sized) transfer - similar to what we see when the shot is busy syncing to floppy.
- `in_atoi` (really `in_gethostbyname`) has no sanity check on input whatsoever, which means that IP addresses (for example) can be anything and will still be converted into something that ktcp tries to use. The only sanity check at this time is that the first character is a number in `in_gethostbyname`.

This is still work in progress - the code is littered with odd-looking debug statements in addition to the 'regular' ones governed by `config.h`.

Finally - a more detailed discussion about the considerations and and choices made in the implementation of slow start/congestion control will be posted in the developer notes wiki.
