### PR TITLE
[boot] Allow bootsector to handle soft errors

### DIFF
--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -453,7 +453,7 @@ pc98_1b:
 #endif
 	pop %es
 	jnc dr_cont
-	cmp $0x11,%al	// accept soft errors (MFM drives)
+	cmp $0x11,%ah	// accept soft errors (MFM drives)
 	jz dr_cont
 	//mov %ah,%al	// Print error code, comment out the '*' putc
 	//add $0x20,%al	// below to make space
@@ -464,8 +464,8 @@ pc98_1b:
 	int $0x13
 #endif
 	// PATCH: failure trace
-	// Early Compaqs return 0xC1 every 12th block when reading 360k floppies
-	// First retry is fine
+	// Note: Early Compaqs return timeout every 12th block
+	// when reading 360k floppies using FAST_READ
 
 	mov $'*',%al
 	call _putc

--- a/bootblocks/boot_sect.S
+++ b/bootblocks/boot_sect.S
@@ -453,12 +453,19 @@ pc98_1b:
 #endif
 	pop %es
 	jnc dr_cont
+	cmp $0x11,%al	// accept soft errors (MFM drives)
+	jz dr_cont
+	//mov %ah,%al	// Print error code, comment out the '*' putc
+	//add $0x20,%al	// below to make space
+	//call _putc
 
 #ifndef CONFIG_ARCH_PC98
 	xor %ah,%ah       // BIOS reset disk
 	int $0x13
 #endif
 	// PATCH: failure trace
+	// Early Compaqs return 0xC1 every 12th block when reading 360k floppies
+	// First retry is fine
 
 	mov $'*',%al
 	call _putc


### PR DESCRIPTION
The boot sector would treat any error code from disk/floppy read as an error condition. However, old style MFM drives report soft (recovered) errors as errors which means that boot will fail if such 'errors' are encountered. This update fixes that.

While in the issue, there is a related issue with early Compaqs and 360k floppies: Every 12th block read returns and error (CF bit set) and error code C1 in %ah. There is, however, no 'real' error and a retry fixes it, which is good: There is no space for handling it in the boot sector code. So this note is for the record. 

In the picture below, the '*' normally denoting a read error during boot has been replaced with the error code from `%al` plus 0x20.

![IMG_0913](https://github.com/user-attachments/assets/7d032ac7-793b-49bd-9da3-3df873c5c0d7)

The presence of the 'H' before the 't' in the output from Setup.S is possibly confusing since there is no HMA, but really a reminder that the 'H' is about what's in `bootopts`, not what's actually done in Setup. The text segment address tells that story anyway.