### PR TITLE
[cmd] Improved error/info messages in mkfat,mkfs

### DIFF
--- a/tlvccmd/Applications
+++ b/tlvccmd/Applications
@@ -147,7 +147,7 @@ minix2/remsync					:other
 minix2/synctree					:other
 #minix2/tget					:minix2							:1440k
 #minix2/man					:minix2				:1200k	:1440k
-minix3/sed					:minix3			:360
+minix3/sed					:minix3			:360k
 minix3/file					:minix3			:720k
 minix3/head					:minix3			:720k
 minix3/sort					:minix3			:720k

--- a/tlvccmd/disk_utils/mkfat.c
+++ b/tlvccmd/disk_utils/mkfat.c
@@ -608,7 +608,7 @@ usage:
 	}
 	/* allow image files and raw devices */
 	if (!S_ISREG(sbuf.st_mode) && !S_ISCHR(sbuf.st_mode)) {
-		printf("Must be image file or raw device");
+		printf("Must be image file or raw device\n");
 		exit(1);
 	}
 	blocks = atol(av[2]);

--- a/tlvccmd/disk_utils/mkfs.c
+++ b/tlvccmd/disk_utils/mkfs.c
@@ -318,8 +318,8 @@ int main(int argc, char ** argv)
 	if (!(buf = malloc(512))) 
 		die("Cannot malloc buffer memory"); 
 	if (((BLOCKS -1)<<10) > statbuf.st_size) {
-		printf("Requested blockcount (%lu) exceeds device size (%lu)\n", 
-			BLOCKS, statbuf.st_size);
+		printf("Requested blockcount (%lu) exceeds device size (%luk)\n", 
+			BLOCKS, statbuf.st_size>>10);
 		exit(-1);
 	}
 


### PR DESCRIPTION
Also fixes a typo in `tlvccmd/Applications` preventing `sed` from appearing on 360k images. 