### PR TITLE
[kernel, net] Bugfixes and enhancements in the ne2k and wd drivers

### DIFF
--- a/tlvc/arch/i86/drivers/net/ee16.c
+++ b/tlvc/arch/i86/drivers/net/ee16.c
@@ -815,20 +815,19 @@ static int ee16_open(struct inode *inode, struct file *file)
 	if (!found) 
 		return -ENODEV;
 
-	if (usecount != 0)
-		return 0;		// Already open, success
-
-	err = request_irq(net_irq, ee16_int, INT_GENERIC);
-	if (err) {
-		printk(EMSG_IRQERR, model_name, net_irq, err);
-		return err;
+	if (!usecount) {
+		err = request_irq(net_irq, ee16_int, INT_GENERIC);
+		if (err) {
+			printk(EMSG_IRQERR, model_name, net_irq, err);
+			return err;
+		}
+		if ((err = ee16_hw_init586(net_port))) {
+			free_irq(net_irq);
+			printk("%s: initialization failed (%d)\n", dev_name, err);
+			return -ENODEV;
+		}
+ 		ee16_hw_set_interface();	/* set conn type from flags	*/
 	}
-	if ((err = ee16_hw_init586(net_port))) {
-		free_irq(net_irq);
-		printk("%s: initialization failed (%d)\n", dev_name, err);
-		return -ENODEV;
-	}
- 	ee16_hw_set_interface();	/* set conn type from flags	*/
 	usecount++;
 	return 0;
 }

--- a/tlvc/arch/i86/drivers/net/ne2k-asm.S
+++ b/tlvc/arch/i86/drivers/net/ne2k-asm.S
@@ -5,12 +5,9 @@
 //	. pick up MAC address from prom
 //	. fixed read ring buffer wrap around errors
 //	. added ring buffer overflow handling
-//	. use word I/O
-// oct-2021: Pick up I/O port # from init/bootopts (HS)
-// Updated by Santiago Hormazabal on Dec 2021:
-//  . 8 bit access if CONFIG_ETH_BYTE_ACCESS is set, using a ne1k patch from
-//    NCommander.
-// apr-2022 (HS) : Support auto detection of 8bit mode, set 8k buffer size when in 8bit mode.
+//	. use word I/O when possible
+// oct-2021 (HS): Pick up I/O port # from init/bootopts 
+// apr-2022 (HS): Support auto detection of 8bit mode, set 8k buffer size when in 8bit mode.
 //	     Rewrote overflow handler, added direct access to many registers from C code
 //	     Cleaned up initialization code, optimized 8bit I/O
 //
@@ -28,8 +25,6 @@
 //
 //-----------------------------------------------------------------------------
 
-//#include <linuxmt/config.h>
-//#include "arch/ports.h"
 #include <arch/asm-offsets.h>
 #include <linuxmt/netstat.h>
 #include "netbuf.h"
@@ -62,9 +57,9 @@ io_ne2k_tx_conf    = 0x0D  // page 0 - write
 io_ne2k_data_conf  = 0x0E  // page 0 - write
 io_ne2k_int_mask   = 0x0F  // page 0 - write
 
-io_ne2k_frame_errs = 0x0D	// page 0 read - Frame Alignment Error counter
-io_ne2k_crc_errs   = 0x0E	// page 0 read - CRC error counter
-io_ne2k_lost_pkts  = 0x0F	// page 0 read - Lost packet counter
+io_ne2k_frame_errs = 0x0D  // page 0 read - Frame Alignment Error counter
+io_ne2k_crc_errs   = 0x0E  // page 0 read - CRC error counter
+io_ne2k_lost_pkts  = 0x0F  // page 0 read - Lost packet counter
 
 io_ne2k_unicast    = 0x01  // page 1 - 6 bytes
 io_ne2k_rx_put     = 0x07  // page 1
@@ -72,7 +67,7 @@ io_ne2k_multicast  = 0x08  // page 1 - 8 bytes
 
 io_ne2k_data_io    = 0x10  // 2 bytes
 
-io_ne2k_reset      = 0x1F	// Really a port, not a register, force HW reset of the chip
+io_ne2k_reset      = 0x1F  // Really a port, not a register, force HW reset of the chip
 
 
 // Ring segmentation
@@ -80,7 +75,7 @@ io_ne2k_reset      = 0x1F	// Really a port, not a register, force HW reset of th
 tx_head		   = 0x40
 rx_head		   = 0x46
 rx_last_16	   = 0x80
-rx_last_8	   = 0x60	// For 8k buffer in 8 bit mode - per spec. 
+rx_last_8	   = 0x60  // For 8k buffer in 8 bit mode - per spec. 
 
 // Flags
 
@@ -1004,9 +999,10 @@ ne2k_get_hw_addr:
 
 	// Effectively a soft reset of the NIC, required in order to get access to the
 	// address PROM. The PROM is 16 or 32 bytes depending on the bus width. We read
-	// it in word mode and always get 32 back.
-	// The MAC address is in the first 6 bytes.
-	// The remaining 10 bytes sometimes identify the card type. The PROM content from 
+	// it in word mode and always return 16 words. Whether the upper byte of each 
+	// word has any content of value is card dependent.
+	// The MAC address is in the first 6 words.
+	// The remaining 10 words sometimes identify the card type. The PROM content from 
 	// an 8 bit Weird Electronics (RTL8019AS) card looks like this:
 	// 001f1102602d49534138455448204242, the last 10 bytes being 'ISA8ETH BB'.
 	// The BB means it's an 8bit card, WW would indicate 16bit bus support.

--- a/tlvc/arch/i86/drivers/net/wd.c
+++ b/tlvc/arch/i86/drivers/net/wd.c
@@ -73,9 +73,9 @@
 #define net_ram		(netif_parms[ETH_WD].ram)
 #define net_flags	(netif_parms[ETH_WD].flags)
 
-#define WD_STAT_RX	0x0001U	/* packet received */
-#define WD_STAT_TX	0x0002U	/* packet sent */
-#define WD_STAT_OF	0x0010U	/* RX ring overflow */
+#define WD_STAT_RX	0x0001	/* packet received */
+#define WD_STAT_TX	0x0002	/* packet sent */
+#define WD_STAT_OF	0x0010	/* RX ring overflow */
 
 #define WD_START_PG	0x00U	/* First page of TX buffer */
 #define WD_STOP_PG4	0x10U	/* Only used for arithmetic */
@@ -92,8 +92,8 @@
 
 #define WD_RESET	0x80U	/* Board reset */
 #define WD_MEMENB	0x40U	/* Enable the shared memory */
-#define WD_IO_EXTENT	32U
-#define WD_8390_OFFSET	16U
+#define WD_IO_EXTENT	32
+#define WD_8390_OFFSET	16
 #define WD_8390_PORT	(net_port + WD_8390_OFFSET)
 #define WD_CMDREG5	5	/* Offset to 16-bit-only ASIC register 5. */
 
@@ -119,32 +119,32 @@
 #define E8390_RX_IRQ_MASK	0x05U
 
 /* Page 0 register offsets. */
-#define EN0_CLDALO	0x01U	/* Low byte of current local dma addr  RD */
-#define EN0_STARTPG	0x01U	/* Starting page of ring bfr WR */
-#define EN0_CLDAHI	0x02U	/* High byte of current local dma addr  RD */
-#define EN0_STOPPG	0x02U	/* Ending page +1 of ring bfr WR */
-#define EN0_BOUNDARY	0x03U	/* Boundary page of ring bfr RD WR */
-#define EN0_TSR		0x04U	/* Transmit status reg RD */
-#define EN0_TPSR	0x04U	/* Transmit starting page WR */
-#define EN0_NCR		0x05U	/* Number of collision reg RD */
-#define EN0_TCNTLO	0x05U	/* Low  byte of tx byte count WR */
-#define EN0_FIFO	0x06U	/* FIFO RD */
-#define EN0_TCNTHI	0x06U	/* High byte of tx byte count WR */
-#define EN0_ISR		0x07U	/* Interrupt status reg RD WR */
-#define EN0_CRDALO	0x08U	/* low byte of current remote dma address RD */
-#define EN0_RSARLO	0x08U	/* Remote start address reg 0 */
-#define EN0_CRDAHI	0x09U	/* high byte, current remote dma address RD */
-#define EN0_RSARHI	0x09U	/* Remote start address reg 1 */
-#define EN0_RCNTLO	0x0aU	/* Remote byte count reg WR */
-#define EN0_RCNTHI	0x0bU	/* Remote byte count reg WR */
-#define EN0_RSR		0x0cU	/* rx status reg RD */
-#define EN0_RXCR	0x0cU	/* RX configuration reg WR */
-#define EN0_TXCR	0x0dU	/* TX configuration reg WR */
-#define EN0_COUNTER0	0x0dU	/* Rcv alignment error counter RD */
-#define EN0_DCFG	0x0eU	/* Data configuration reg WR */
-#define EN0_COUNTER1	0x0eU	/* Rcv CRC error counter RD */
-#define EN0_IMR		0x0fU	/* Interrupt mask reg WR */
-#define EN0_COUNTER2	0x0fU	/* Rcv missed frame error counter RD */
+#define EN0_CLDALO	0x01	/* Low byte of current local dma addr  RD */
+#define EN0_STARTPG	0x01	/* Starting page of ring bfr WR */
+#define EN0_CLDAHI	0x02	/* High byte of current local dma addr  RD */
+#define EN0_STOPPG	0x02	/* Ending page +1 of ring bfr WR */
+#define EN0_BOUNDARY	0x03	/* Boundary page of ring bfr RD WR */
+#define EN0_TSR		0x04	/* Transmit status reg RD */
+#define EN0_TPSR	0x04	/* Transmit starting page WR */
+#define EN0_NCR		0x05	/* Number of collision reg RD */
+#define EN0_TCNTLO	0x05	/* Low  byte of tx byte count WR */
+#define EN0_FIFO	0x06	/* FIFO RD */
+#define EN0_TCNTHI	0x06	/* High byte of tx byte count WR */
+#define EN0_ISR		0x07	/* Interrupt status reg RD WR */
+#define EN0_CRDALO	0x08	/* low byte of current remote dma address RD */
+#define EN0_RSARLO	0x08	/* Remote start address reg 0 */
+#define EN0_CRDAHI	0x09	/* high byte, current remote dma address RD */
+#define EN0_RSARHI	0x09	/* Remote start address reg 1 */
+#define EN0_RCNTLO	0x0a	/* Remote byte count reg WR */
+#define EN0_RCNTHI	0x0b	/* Remote byte count reg WR */
+#define EN0_RSR		0x0c	/* rx status reg RD */
+#define EN0_RXCR	0x0c	/* RX configuration reg WR */
+#define EN0_TXCR	0x0d	/* TX configuration reg WR */
+#define EN0_COUNTER0	0x0d	/* Rcv alignment error counter RD */
+#define EN0_DCFG	0x0e	/* Data configuration reg WR */
+#define EN0_COUNTER1	0x0e	/* Rcv CRC error counter RD */
+#define EN0_IMR		0x0f	/* Interrupt mask reg WR */
+#define EN0_COUNTER2	0x0f	/* Rcv missed frame error counter RD */
 
 /* Page 1 register offsets. */
 #define EN1_PHYS	0x01U	/* This board's physical enet addr RD WR */
@@ -215,6 +215,7 @@ static word_t wd_rx_stat(void);
 static word_t wd_tx_stat(void);
 static void wd_int(int irq, struct pt_regs * regs);
 static void fmemcpy(void *, seg_t, void *, seg_t, size_t, int);
+static void wd_stop(void);
 
 extern struct eth eths[];
 
@@ -283,6 +284,7 @@ static int INITPROC wd_probe(void) {
 #if DEBUG
 	printk("net_flags %04x stop_page %02x verbose %d\n", net_flags, stop_page, verbose);
 #endif
+	wd_stop();	/* make sure interrupts are off */
 
 	return 0;
 }
@@ -332,8 +334,8 @@ static void wd_init_8390(int strategy)
 	outb(E8390_TXOFF, WD_8390_PORT + EN0_TXCR);
 
 	/* Clear the pending interrupts and mask. */
-	outb(0xffU, WD_8390_PORT + EN0_ISR);
-	outb(0x00U, WD_8390_PORT + EN0_IMR);
+	outb(0xff, WD_8390_PORT + EN0_ISR);
+	outb(0x00, WD_8390_PORT + EN0_IMR);
 
 	if (strategy == 0) {	/* full initialization */
 		/* Set the transmit page and receive ring. */
@@ -433,7 +435,7 @@ static size_t wd_pack_get(char *data, size_t len)
 	size_t res = -EIO;
 
 	//clr_irq();	// EXPERIMENTAL
-	outb(0x00U, WD_8390_PORT + EN0_IMR);	// Block interrupts
+	outb(0x00, WD_8390_PORT + EN0_IMR);	// Block interrupts
 	do {
 		/* Remove one frame from the ring. */
 		/* Boundary is always a page behind. */
@@ -443,10 +445,10 @@ static size_t wd_pack_get(char *data, size_t len)
 		if (this_frame != current_rx_page)	/* Very useful for debugging ! */
 			printk("eth: mismatched read page pointers %2x vs %2x.\n",
 				this_frame, current_rx_page);
-		hdr_start = (this_frame - WD_START_PG) << 8U;
+		hdr_start = (this_frame - WD_START_PG) << 8;
 		rxhdr = _MK_FP(net_ram, hdr_start);
 
-		if ((rxhdr->count < 64U) ||
+		if ((rxhdr->count < 64) ||
 		    (rxhdr->count > (MAX_PACKET_ETH + sizeof(e8390_pkt_hdr)))) {
 
 			/* This should not happen! The NIC is programmed to drop

--- a/tlvc/include/linuxmt/netstat.h
+++ b/tlvc/include/linuxmt/netstat.h
@@ -46,7 +46,7 @@ struct netif_stat {
 /* The lower nibble has the autodetected buffer memory size,
  * 1=4k, 2=8k, 3=16k etc. */
 #define	NETIF_AUTO_8BIT	0x10	
-#define NETIF_IS_QEMU	0x20
+#define NETIF_IS_QEMU	0x20	/* unused */
 
 /* Config flags 
  * The first 3 make a number - for coding simplicity (a power of two),


### PR DESCRIPTION
ne2k driver:
- Fixed MAC address retrieval among different cards: Finally found a universal way to read the SAPROM which simplifies the code and fixes a problem with MAC addresses sometimes being incorrectly interpreted on 8bit cards.
- Removed QEMU detection code which was unused and useless now that such detection is done in `init/main.c`.
- Added a temporary hack for the PicoMem ne1k emulator which stores the MAC address incorrectly in the emulated PROM and also claims it is a ne2k (16bit) card. This is obviously confusing the detection logic.
- Some cleanups.

wd driver: 
- Ensure that interrupts are turned off after initialization in an attempt to make IRQs shareable on XT class systems. This change improves the situation, but some cards will hold on to the IRQ line after either initialization or use anyway. So while a `ne1k` and a `wd80xx` card may share IRQ (say) 2 as configured, the first one activated (`net start`) will in many but not all cases hang on to the IRQ line after a subsequent `net stop`. Behaviour is interface-dependent. The use-and-release of IRQ lines generally works better on 16bit ISA machines.
- Cleanups 