### PR TITLE
[net,kernel] Lance driver supports NE2100 NIC, sys fixes

### DIFF
--- a/tlvccmd/rootfs_template/bin/sys
+++ b/tlvccmd/rootfs_template/bin/sys
@@ -46,6 +46,8 @@ create_dev_dir()
 	mknod $MNT/dev/ne0	c 9 0
 	mknod $MNT/dev/wd0	c 9 1
 	mknod $MNT/dev/3c0	c 9 2
+	mknod $MNT/dev/ee0	c 9 3
+	mknod $MNT/dev/le0	c 9 4
 	mknod $MNT/dev/ptyp0	c 11 8
 	mknod $MNT/dev/ttyp0	c 4 8
 	mknod $MNT/dev/tty1	c 4 0


### PR DESCRIPTION
The LANCE ethernet driver now works with the NE2100 NIC:
- If not a HP (2405A) card, `bootopts` settings for `le0` will be ignored except flags, and but will issue a warning if actual and bootopts IO addresses don't match. IOW the address at which the card is found will always be used.
- Now compiles if XMS is not configured.
- Cleaned up boot messages
- Simplified packet receive function
- Receive errors now trigger an error message in addition to logging stats

Finally, `sys` now creates all network devices.

Interestingly, the NE2100, which is jumper-configured, works when configured to 8bit bus mode. Not reliably, there are occasional checksum errors, but good enough to get data through, although slowly. This indicates that the effort required to make the driver 8bit compatible is likely minimal. The HP 2405A has not yet been tested in 8 bit mode. 