### PR TITLE
[kernel,net] Fixes transmit timeout bug in Lance ethernet driver

### DIFF
--- a/tlvc/arch/i86/drivers/net/lance.c
+++ b/tlvc/arch/i86/drivers/net/lance.c
@@ -693,7 +693,8 @@ static int lance_start_xmit(char *data, size_t len)
 	}
 #endif
 	lance_init_ring();
-	outw(0x0043, ioaddr+LANCE_DATA);	/* STRT|INIT|IENA */
+	//outw(0x0043, ioaddr+LANCE_DATA);	/* STRT|INIT|IENA */
+	outw(0x0142, ioaddr+LANCE_DATA);	/* IDON|STRT|IENA */
 
 	tbusy = 0;
 	tstart = jiffies;
@@ -779,7 +780,7 @@ static int lance_start_xmit(char *data, size_t len)
 /* The LANCE interrupt handler. */
 static void lance_interrupt(int irq, struct pt_regs *regs)
 {
-    struct lance_private *lp = thisdev;
+    struct lance_private *lp;
     int csr0, ioaddr;
 
     //kputchar('I');
@@ -839,13 +840,13 @@ static void lance_interrupt(int irq, struct pt_regs *regs)
 	    dirty_tx++;
 	}
 
-#ifndef final_version
-	if (lp->cur_tx - dirty_tx >= TX_RING_SIZE) {
-	    printk("out-of-sync dirty pointer, %d vs. %d.\n",
-		   dirty_tx, lp->cur_tx);
-	    dirty_tx += TX_RING_SIZE;
+//#ifndef final_version
+	if (lp->cur_tx - dirty_tx >= TX_RING_SIZE) {	/* will happen every time cur_tx wraps around */
+	    //printk("le0: out-of-sync dirty pointer, %d vs. %d.\n",
+		   //dirty_tx, lp->cur_tx);
+	    dirty_tx += TX_RING_SIZE;			/* fixes the problem */
 	}
-#endif
+//#endif
 
 	if (tbusy  &&  dirty_tx > (lp->cur_tx - TX_RING_SIZE + 2)) {
 	    /* The ring is no longer full, clear tbusy. */
@@ -856,10 +857,7 @@ static void lance_interrupt(int irq, struct pt_regs *regs)
 	wake_up(&txwait);
     }
 
-    if (csr0 & 0x8000) {
-	//if (csr0 & 0x4000) lp->stats.tx_errors++;	/* already counted */
-	if (csr0 & 0x1000) netif_stat.rx_errors++;
-    }
+    if (csr0 & 0x9000) netif_stat.rx_errors++;
 
     /* Clear the interrupts we've handled. */
     /* we actually cleared thos above, this is simply enabling interrupts again */


### PR DESCRIPTION
After running for a while, the Lance driver would report a transmission timeout problem and attempt to reset the NIC and continue. The reset would fail and the net would hang.

The reason turned out to be a wrap-around in the transmit buffer index, a signed int which is continuously incremented and masked by the (log2) size of the transmit buffer pool. At wrap-around time, the tail of the ring of buffers would appear to be ahead of the head and transmit would wait forever for an available buffer. So, after 32767 packets the error would manifest itself and hang the net.

It is quite possible that this bug is still in the 'big linux' driver where it would take more than 2.1 billion sent packets to reveal itself. That's a lot, even on a busy network.