### PR TITLE
[kernel,rawIO] Fix subtle bug in raw IO when using XMS bufs

### DIFF
--- a/tlvc/arch/i86/lib/unreal.S
+++ b/tlvc/arch/i86/lib/unreal.S
@@ -5,8 +5,6 @@
 #
 # int enable_unreal_mode(void)	- Attempt to turn on 80386 unreal mode,
 #				  returns > 0 on success else error code
-# void linear32_fmemcpyw (void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
-#		size_t count)	- Copy words between XMS and far memory
 # void linear32_fmemcpyb (void *dst_off, addr_t dst_seg, void *src_off, addr_t src_seg,
 #		size_t count)	- Copy bytes between XMS and far memory
 # NOTE: the linear32_fmemcpy routines use "unprotected" EBX, EBX, ESI and EDI registers,
@@ -24,7 +22,6 @@
 
 	.global	check_unreal_mode
 	.global	enable_unreal_mode
-	.global	linear32_fmemcpyw
 	.global	linear32_fmemcpyb
 	.global	linear32_fmemset
 //	.global linear32_peekw
@@ -190,6 +187,8 @@ linear32_pokew:
 #		size_t count)
 # WARNING: Requires 32-bit CPU, with unreal mode and A20 gate enabled!
 #          Trashes EBX, ECX, ESI and EDI without saving.
+# Copy 16bit words to/from anywhere in the linear 24/32 bit address space. Add 
+# the extra byte if count is odd.
 #
 linear32_fmemcpyb:
 	push   %es

--- a/tlvc/fs/buffer.c
+++ b/tlvc/fs/buffer.c
@@ -823,8 +823,11 @@ ramdesc_t buffer_seg(struct buffer_head *bh)
     return (bh->b_data? kernel_ds: EBH(bh)->b_L2seg);
 }
 
+#if 0
 char *buffer_data(struct buffer_head *bh)
 {
     return (bh->b_data? bh->b_data: 0); /* L2 addresses are at offset 0 */
+    /* doesn't really do anything - does it? */
 }
+#endif
 #endif /* CONFIG_FS_EXTERNAL_BUFFER | CONFIG_FS_XMS_BUFFER*/

--- a/tlvc/include/linuxmt/fs.h
+++ b/tlvc/include/linuxmt/fs.h
@@ -484,16 +484,16 @@ extern void unmap_brelse(struct buffer_head *);
 extern void brelseL1(struct buffer_head *, int);
 extern void brelseL1_index(int, int);
 ramdesc_t buffer_seg(struct buffer_head *);
-extern char *buffer_data(struct buffer_head *);
+//extern char *buffer_data(struct buffer_head *);
 #else
 #define map_buffer(bh)
 #define unmap_buffer(bh)
 #define brelseL1(bh,copyout)
 #define brelseL1_index(i,copyout)
 #define unmap_brelse(bh) brelse(bh)
-#define buffer_data(bh)  ((bh)->b_data)
 #define buffer_seg(bh)   (kernel_ds)
 #endif
+#define buffer_data(bh)  ((bh)->b_data)
 
 extern size_t block_read(struct inode *, struct file *, char *, size_t);
 extern size_t block_write(struct inode *, struct file *, char *, size_t);


### PR DESCRIPTION
RAW IO means transferring data directly to/from application data space, which - by definition - means low memory, <1M. However, when dealing with data quantities less than a sector, a bounce buffer is required between the IO (512bytes min) and the application. For convenience, the low level raw IO uses a buffer from the L2 buffer pool for this purpose. 

The other difference between raw and block IO at the lowest level is that while block IO is always 1k blocks, raw may be any number of blocks - in practice limited by the available buffer space in the application. The buffer-head member `b_nr_sectors` is used at the driver level to distinguish between the modes. If 0, we're in block mode, doing 1k/2 sectors IO. If non-zero, the value is the number of sectors to transfer.

All this is good, except the driver level assumes that raw IO always means low memory, which isn't the case when using XMS buffers and raw io of small (<512b) amounts of data. This glitch would ignore the upper half of the memory address in such cases and read data into random memory locations, quite often 0, with obvious consequences.

The easy fix is to not flag the IO as raw when using the L2 buffer for bouncing. While working well, this has the side effect of always transferring 2 sectors instead of one. Completely ignorable on faster systems which are likely to have XMS, not necessarily so on slower systems. Thus the fix has a test for xms before clearing the 'raw' flag from such transactions.

This PR also includes a minor edit to `buffer.c` (and `fs.h`) deleting the function `buffer_data(bp)` which 'steps in' when XMS is configured, but does exactly the same as the macro it replaces.

The changes to `unreal.S` are in comments only.