### PR TITLE
[kernel,net] ne2k driver rewrite, now completely buffered

### DIFF
--- a/tlvc/arch/i86/drivers/net/ne2k-asm.S
+++ b/tlvc/arch/i86/drivers/net/ne2k-asm.S
@@ -193,19 +193,13 @@ dma_init:
 //-----------------------------------------------------------------------------
 //
 // BX    : NIC memory address (to write to)
-// CX    : byte count
+// CX    : byte count (must leave unharmed)
 // DS:SI : host memory address (to read from)
-// Also using the 3rd arg to the caller (local/user flag) from the stack
+// Returns bytes written in ax
 //-------------------------------------
 
 dma_write:
 
-	push    %cx
-	push	%ds
-
-	inc     %cx     // make byte count even
-	and     $0xfffe,%cx
-	//cli		// Mandatory
 	call    dma_init
 
 	// start DMA write
@@ -218,15 +212,10 @@ dma_write:
 
 	//mov	net_port,%dx
 	add	$io_ne2k_data_io,%dx
-	mov	ne2k_flags,%ax		// Get this before changing the data segment
-	mov	8(%bp),%bx		// get the 3rd arg from the call
-	cmp	$0,%bx			// zero means kernel (buffer)
-	jz	1f			// use kernel data seg
-	mov	current,%bx		// setup for user data seg
-	mov	TASK_USER_DS(%bx),%ds
-1:
+	mov	ne2k_flags,%ax
+	push	%cx		// caller expects CX to be preserved
 	cld
-	test	$ISA_8B,%ax		// checking ne2k_flags
+	test	$ISA_8B,%ax	// check ne2k_flags: 8 or 16 bit
 	jz	wr_loop_w
 
 	// Byte loop
@@ -234,10 +223,9 @@ wr_loop_b:
 	lodsb
 	outb	%al,%dx
 	loop	wr_loop_b
-
 	jmp	wr_loop_done
 
-	// word loop
+	// Word loop
 wr_loop_w:
 	shr	%cx
 3:	lodsw
@@ -245,22 +233,7 @@ wr_loop_w:
 	loop	3b
 
 wr_loop_done:
-	
-	pop	%ds	// get the data segment back
-			// otherwise the net_port reference below won't work
-	// wait for DMA completed
-check_dma_w:
-	mov	net_port,%dx
-	add	$io_ne2k_int_stat,%dx
-	in      %dx,%al
-	and	$0x40,%al	// make sure we're done
-	jz	check_dma_w
-
-	//mov	$0x40,%al       // clear DMA intr bit in ISR
-	out	%al,%dx
-
-	//sti			// Mandatory
-	pop     %cx
+	pop	%cx
 	ret
 
 //-----------------------------------------------------------------------------
@@ -270,28 +243,20 @@ check_dma_w:
 // BX    : NIC memory to read from
 // CX    : byte count
 // ES:DI : host memory to write to
-// AL:	 : 0: buffer is local (kernel), <>0: buffer is far (process)
 
 dma_read:
 
 	push    %di
 	push    %es
 	push	%bx
-	push	%ax
 
 	inc     %cx     // make byte count even
 	and     $0xfffe,%cx
 
-	//cli		// Experimental - disable INTR
 	call    dma_init
 
 	mov     %ds,%bx
-	mov     %bx,%es
-	pop	%ax
-	cmp	$0,%al		// Use local (kernel DS) buffer if zero
-	jz	rbuf_local
-	mov	current,%bx	// use task DS buffer
-	mov	TASK_USER_DS(%bx),%es
+	mov     %bx,%es		// using kernel data segment (heap)
 
 rbuf_local:
 	mov	net_port,%dx	// command register
@@ -318,19 +283,6 @@ word_loop:
 	stosw
 	loop	word_loop
 3:
-	// PROABLY NOT NEEDED
-	//mov	net_port,%dx
-	//add	$io_ne2k_int_stat,%dx
-check_dma_r:
-	//in      %dx,%al
-	//test    $0x40,%al       // dma done?
-	//jz      check_dma_r
-	
-
-	mov     $0x40,%al       // clear ISR (RDC bit only)
-	out     %al,%dx
-	//sti			//Experimental - Enable INTR
-
 	pop	%bx
 	pop	%es
 	pop     %di
@@ -427,8 +379,6 @@ nrs_exit:
 //-----------------------------------------------------------------------------
 // arg1: buffer to receive the data
 // arg2: int - requested read size (max buffer)
-// arg3: int array [2] (return) containing the NIC packet header.
-// arg4: flag whether dest is kernel buffer or proc data
 //
 // returns:
 // AX : < 0 if error, >0 is length read
@@ -440,78 +390,50 @@ ne2k_pack_get:
 	push    %bp
 	mov     %sp,%bp
 	push    %di
-	//push	%es
 
-	//sub 	$4,%sp		// temp space
-	//mov	%sp,%di
-
-	// get the 4 byte header first -> arg3
-	mov	8(%bp),%di	// arg3
 	mov	ne2k_next_pk,%bh
 	xor	%bl,%bl		// Next pkt to read in BX
 
-	mov	$4,%cx		// Bytes to read
-	//mov     %ds,%ax
-	//mov     %ax,%es	// local address space
-	xor	%al,%al		// indicate kernel DS
+	// get the first page - which includes the metadata (header) in front
+	mov	4(%bp),%di	// Buffer address to receive data.
+	mov	$256,%cx
 	call	dma_read
-
 	mov	0(%di),%ax	// AH : next record, AL : status
 	mov	2(%di),%cx	// packet size (without CRC)
 
-	// get the actual data
-
-	//add	$4,%sp
-	mov	4(%bp),%di	// Buffer address to receive data.
-	mov	6(%bp),%dx	// read len
+	mov	6(%bp),%dx	// Adjust read length if necessary,
 	cmp	%cx,%dx		// choose the shorter
-	jnb	npg_cont0
+	jnb	1f		// FIXME: a shortened packet is a damaged packet
+				// of no use, should abort right here
 	mov	%dx,%cx		
 
-#if 0
 	// -------------------------------------------------------------
 	// Packet size check not required since the NIC will not
 	// accept such packets per our initialization. Note, when handling
-	// erroneous packets manually, the rx_get (BOUNDARY) pointer must subsequently
+	// erroneous packets manually, the rx_get (BOUNDARY) pointer must 
 	// be updated do point to the next packet.
 	// If oversized packets still occur, it's a driver problem (most likely
 	// reading the wrong buffer page from the NIC).
 	// -------------------------------------------------------------
-	or      %cx,%cx		// zero length
-	jz      npg_err2
-
-	cmp     $1528,%cx	// max - head - crc
-	jnc     npg_err
-#endif
-	// -------------------------------------------------------------
-	// This section did the smart thing when reading the NIC packet header:
-	// Got the entire block (256b) instead of the 4 first bytes. Which was great 
-	// for small packets (telnet, command packets etc.): One read instead of 2.
-	//
-	// Removed when read was changed to put data directly into process address space,
-	// there is no longer anywhere to put the first 4 bytes.
-
-#if 0
+1:
 	sub	$252,%cx	// Got entire packet?
 	jle	npg_cont
 				// If not, get rest.
 	inc	%bh		// Point to next page
-	cmp	$rx_last,%bh	// check wraparound
+	cmp	ne2k_rx_last,%bh	// check wraparound
 	jnz	npg_cont0
 	mov	$rx_head,%bh
-#endif
 
 npg_cont0:
-	//add	$256,%di	// Update destination memory address 
-				// (keep the 4 byte NIC header)
-	push	%cx		// save length
 	push	%ax
-	add	$4,%bx		// Skip the 4 bytes already read
-
-	//mov	$1,%al		// use far transfer
-	mov	10(%bp),%ax	// buffer type flag
+	mov	net_port,%dx
+	add	$io_ne2k_int_stat,%dx
+	mov	$0x40,%al	// Clear RDC interrupt bit
+	out	%al,%dx
+	add	$256,%di	// Update destination memory address 
+				// (keep the 4 byte NIC header)
 	call    dma_read
-	pop     %ax
+	pop	%ax
 
 	// update RX_get pointer (BOUNDARY, end of ring)
 npg_cont:
@@ -525,7 +447,6 @@ npg_cont:
 	dec	%al
 
 npg_next:
-
 	mov	net_port,%dx
 	add	$io_ne2k_rx_get,%dx	// update RX_get (BOUNDARY)
 	out     %al,%dx
@@ -542,10 +463,7 @@ npg_exit:
 
 npg_exit_ok:
 	sti
-	pop	%ax	// return byte count (from %cx)
-	//pop	%es
 	pop     %di
-	//mov	%bp,%sp	// restore stack pointer
 	pop     %bp
 	ret
 
@@ -582,9 +500,8 @@ nts_exit:
 //-----------------------------------------------------------------------------
 // arg1 : packet buffer to transfer
 // arg2 : size in bytes
-// arg3 : 1 if data is far, 0 if kernel data seg
 // returns:
-//	AX : error code
+//	AX : bytes written (no error conditions)
 
 	.global ne2k_pack_put
 
@@ -593,12 +510,15 @@ ne2k_pack_put:
 	push    %bp
 	mov     %sp,%bp
 	push    %si
+	//cli			// DEBUG
 
-	// write packet to chip memory
+	// write packet to NIC memory
 
-	mov     6(%bp),%cx	// arg2 - count
+	mov     6(%bp),%cx	// arg2 - byte count
+	inc	%cx
+	and	$0xfffe,%cx	// make even
 	xor     %bl,%bl
-	mov     $tx_head,%bh
+	mov     $tx_head,%bh	// always the same start address
 	mov     4(%bp),%si	// arg1 - buffer
 	call    dma_write	// copy the data
 
@@ -618,51 +538,15 @@ tx_rdy_wait:
 	mov	net_port,%dx	// command register
 	in	%dx,%al
 	test	$0x4,%al	// Check that previous transmit completed.
-				// If we skip the completion test below
-				// (let the transmit run on its own for 
-				// efficiency) this test makes sense. OTOH
-				// we're doing the same test in write and select
-				// so objectively it's superfluous.
+				// Probably superfluous
 	jnz	tx_rdy_wait
-	//and	$0x18,%al	// Don't do this, it will set RD2 and
-	//or	$6,%al		// cause an extra RDC abort interrupt
 	mov	$6,%al		// set TX + STA
-	out	%al,%dx		// start transfer
-#if 0
-	// EXPERIMENTAL - do we want to wait for completion here?
-	// If we wait, we may as well check error status
-	// and repeat the send if it failed (while we have the data at hand).
-1:	mov	net_port,%dx	// command register
-	in      %dx,%al
-	test    $4,%al		// Wait for completion
-	jnz	1b
-#endif
-	xor     %ax, %ax	// Always zero return
+	out	%al,%dx		// start transfer, let the NIC do the rest
+	mov	%cx,%ax		// return byte count
 
+	//sti
 	pop     %si
 	pop     %bp
-	ret
-
-//-----------------------------------------------------------------------------
-// Get NE2K interrupt status
-//-----------------------------------------------------------------------------
-
-// returns interrupt status reg unmodified
-
-// AX : status
-//   01h = packet received
-//   02h = packet sent
-//   10h = RX ring overflow
-//   40h = Remote DMA complete
-
-	.global ne2k_int_stat
-
-ne2k_int_stat:
-
-	mov	net_port,%dx
-	add	$io_ne2k_int_stat,%dx
-	in      %dx,%al
-	xor	%ah,%ah
 	ret
 
 //--------------------------------------------------------------
@@ -795,7 +679,7 @@ ne2k_init:
 				// clear if 16bit.
 				// That way we get around the QEMU RXE bug too.
 1:	out     %al,%dx
-	mov	%al,ne2k_imask
+	mov	%al,ne2k_imask	// CURRENTLY UNUSED
 
 	// NOTE: The transmitter is not yet enabled, done in the _start routine.
 	// FIXME: Should move the int mask and status reg clearing to 
@@ -837,7 +721,7 @@ ne2k_rx_init:
 	xor	%ax,%ax	// Switch back to page 0, don't touch the other bits
 	mov	net_port,%dx	// command register
 	out	%al,%dx
-	movw	%ax,ne2k_has_data	// ZERO - Insurance, no data available
+	movw	%ax,ne2k_has_data	// no data available
 	ret
 
 //-----------------------------------------------------------------------------
@@ -1225,24 +1109,6 @@ of_exit:
 	pop	%di
 	ret
 
-
-//-----------------------------------------------------------------------------
-// NE2K Remote DMA complete - for now just a placeholder -
-// and the right place to reset the intr status bit.
-//-----------------------------------------------------------------------------
-
-	.global ne2k_rdc
-
-ne2k_rdc:
-
-	mov	net_port,%dx
-	add     $io_ne2k_int_stat,%dx   // reset the interrupt bit
-	mov     $0x40,%al
-	out     %al,%dx
-
-	ret
-
-
 //-----------------------------------------------------------------------------
 // NE2K get error statistics
 // returns 3 bytes in the byte_t array[3] pointed to by arg1.
@@ -1291,33 +1157,7 @@ ne2k_get_errstat:
 
 ne2k_get_tx_stat:
 	mov	net_port,%dx
-	add	$io_ne2k_int_stat,%dx
-	mov	$0x0a,%al	// Clear PTX & TXE bits in ISR
-	out	%al,%dx
-
-	mov	net_port,%dx
 	add	$io_ne2k_tx_stat,%dx
-	in	%dx,%al
-	xor	%ah,%ah
-	ret
-
-//---------------------------------------------------------------------------
-// Ne2k - get RX error status
-// return the content of the RX status register in AX
-//---------------------------------------------------------------------------
-
-	.global ne2k_get_rx_stat
-
-ne2k_get_rx_stat:
-	// called from interrupt RX RDY processing, must reset the 
-	// 
-	mov	net_port,%dx
-	add	$io_ne2k_int_stat,%dx
-	mov	$1,%al		// Clear PRX bit in ISR
-	out	%al,%dx
-
-	mov	net_port,%dx
-	add	$io_ne2k_rx_stat,%dx
 	in	%dx,%al
 	xor	%ah,%ah
 	ret
@@ -1329,7 +1169,6 @@ ne2k_get_rx_stat:
 ne2k_clr_int_reg:
 	mov	net_port,%dx
 	add	$io_ne2k_int_stat,%dx
-	//in	%dx,%al
 	mov	$0x7f,%al
 	out	%al,%dx
 	ret
@@ -1342,11 +1181,6 @@ ne2k_clr_int_reg:
 	.global ne2k_clr_err_cnt
 
 ne2k_clr_err_cnt:
-	mov	net_port,%dx
-	add	$io_ne2k_int_stat,%dx
-	mov	$0x20,%al
-	out	%al,%dx
-
 	mov	net_port,%dx
 	add	$io_ne2k_frame_errs,%dx
 	in	%dx,%al

--- a/tlvc/arch/i86/drivers/net/ne2k-asm.S
+++ b/tlvc/arch/i86/drivers/net/ne2k-asm.S
@@ -28,7 +28,7 @@
 #include <linuxmt/config.h>
 #include <arch/asm-offsets.h>
 #include <linuxmt/netstat.h>
-#include "netbuf.h"
+#include "netlib.h"
 
 	.code16
 
@@ -325,6 +325,7 @@ ne2k_getpage:
 	ret
 
 
+#if NO_LONGER_USED
 //-----------------------------------------------------------------------------
 // Get RX status
 //-----------------------------------------------------------------------------
@@ -373,6 +374,7 @@ nrs_exit:
 	movw	ne2k_has_data,%ax
 #endif
 	ret
+#endif
 
 //-----------------------------------------------------------------------------
 // Get received packet
@@ -454,7 +456,7 @@ npg_next:
 npg_exit:
 	// This is effectively the replacement for the rx_stat routine,
 	// clear the has_data flag if ring buffer is empty.
-	cli			// Ensure we don't get a race condition when
+	//cli			// Ensure we don't get a race condition when
 				// updating ne2k_has_data
 	call	ne2k_getpage
 	cmp	%ah,%bl		// ring buffer empty?
@@ -462,7 +464,7 @@ npg_exit:
 	movw	$0,ne2k_has_data
 
 npg_exit_ok:
-	sti
+	//sti
 	pop     %di
 	pop     %bp
 	ret

--- a/tlvc/arch/i86/drivers/net/ne2k.c
+++ b/tlvc/arch/i86/drivers/net/ne2k.c
@@ -1,14 +1,15 @@
 /*
  *
  * NE2K Ethernet driver - supports NICs using the NS DP8390 and
- * compatible chip sets. 
+ * compatible chip sets with programmed IO (PIO). 
  *
  * 8 bit i/f support and autoconfig added by Helge Skrivervik (@mellvik) april 2022
  * based on the RTL8019AS chip in the interface card from Weird Electronics.
  *
- * TLVC FEB 2023 - Added experimental io buffering (Helge Skrivervik)
+ * TLVC FEB 2023 - Added experimental io buffering (HS)
+ * TLVC MAR 2026 - Completely buffered, adapted to TH/BH interrupt regime (HS)
  *
- * For buffer configuration, see netbuf.h
+ * For buffer configuration, see netlib.h
  */
 
 #include <arch/io.h>
@@ -27,10 +28,10 @@
 #include <linuxmt/kernel.h>
 #include "eth-msgs.h"
 
-// Shared declarations between low and high parts
+// Shared declarations between low (ASM) and high (C) parts
 
 #include "ne2k.h"
-#include "netbuf.h"
+#include "netlib.h"
 
 /* runtime configuration set in /bootopts or defaults in ports.h */
 #define net_irq     (netif_parms[ETH_NE2K].irq)
@@ -39,16 +40,15 @@
 int net_port;	    /* required for ne2k-asm.S */
 
 
-static unsigned char usecount;
-static unsigned char found;
-static unsigned int verbose;
+static byte_t usecount;
+static byte_t found;
+static word_t verbose;
 static struct wait_queue rxwait;
 static struct wait_queue txwait;
 static struct netif_stat netif_stat;
 static byte_t model_name[] = "ne2k";
 static byte_t dev_name[] = "ne0";
 static size_t ne2k_getpkg(char *, size_t);
-struct netbuf *netbuf_init(struct netbuf *, int);
 
 extern int    ne2k_next_pk;
 extern word_t ne2k_flags;
@@ -57,11 +57,16 @@ extern byte_t ne2k_imask;
 extern struct eth eths[];
 extern unsigned char macaddr[];
 
-//#define LOCAL_DEBUG
-#ifdef LOCAL_DEBUG
+#define LOCAL_DEBUG 0
+#if LOCAL_DEBUG
 void kputchar(int);
 #else
 #define kputchar(x)
+#endif
+#if LOCAL_DEBUG > 1
+#define dprintk printk
+#else
+#define dprintk(...)
 #endif
 
 /*
@@ -84,7 +89,7 @@ static size_t ne2k_read(struct inode *inode, struct file *filp, char *data, size
 			    break;
 			}
 			kputchar('b');
-			//printk("b%04x/%d;", rnext, res);
+			dprintk("b%04x/%d;", rnext, res);
 			rnext->len = 0;
 			rnext = rnext->next;
 			break;
@@ -152,11 +157,11 @@ static size_t ne2k_write(struct inode *inode, struct file *file, char *data, siz
 
 	while (1) {
 		prepare_to_wait_interruptible(&txwait);
-#if NET_BUF_STRAT != NO_BUFS
-		n = nxt;
+#if NET_BUF_STRAT == HEAP_BUFS
+		//n = nxt;
 		while (nxt->len) {	/* search for available buffer */
 		    nxt = nxt->next;
-		    if (nxt == n) break;
+		    if (nxt == tnext) break;	/* tnext may have changed, that's ok */
 		}
 		if (nxt->len == 0) {
 		    kputchar('t');
@@ -167,8 +172,8 @@ static size_t ne2k_write(struct inode *inode, struct file *file, char *data, siz
 		    }
 		    res = len;
 		    nxt->len = len;
-		    //printk("%04x/%d;",nxt, nxt->len);
-		    //mark_bh(NETWORK_BH);
+		    dprintk("%04x/%d;",nxt, nxt->len);
+		    mark_bh(NETWORK_BH);
 		    break;
 		}
 #endif
@@ -191,7 +196,7 @@ static size_t ne2k_write(struct inode *inode, struct file *file, char *data, siz
 	}
 
 	finish_wait(&txwait);
-	if (res>0) mark_bh(NETWORK_BH);
+	//if (res>0) mark_bh(NETWORK_BH);
 	return res;
 }
 
@@ -250,6 +255,8 @@ void ne2k_int_bh(void)
 	kputchar('i');
 	//printk("i%x;",stat);
 	do {
+		/* Reminder: This looks like a good criteria for while() if inverted, but isn't:
+		 * The inverse logic doesn't work! */
 		if (!stat && !ne2k_has_data && !tnext->len) break;
 
 #if 0	/* debug */
@@ -262,7 +269,7 @@ void ne2k_int_bh(void)
 			page = ne2k_clr_oflow(netif_stat.oflow_keep); 
 
 			debug_eth("/CB%04x/ ", page);
-			if (ne2k_has_data)
+			if (ne2k_has_data)	/* In case we didn't purge everything */
 			    wake_up(&rxwait);
 			break; 
 		}
@@ -276,16 +283,16 @@ void ne2k_int_bh(void)
 		if (ne2k_has_data) {		/* Even if we didn't get an RX int, there may be 
 						 * data to pull from the NIC - buffer space 
 						 * permitting */
-#if NET_BUF_STRAT != NO_BUFS
+#if NET_BUF_STRAT == HEAP_BUFS
 		    struct netbuf *nxt = rnext;
 		    do {
 			if (nxt->len == 0) {	/* buffer available */
 			    nxt->len = ne2k_getpkg(nxt->data, MAX_PACKET_ETH);
 			    if (nxt->len < 0) {	/* we may get a bad packet from ne2k_getpkg() */
 				nxt->len = 0;
-				continue;	/* Nothing to read, exit loop */
+				continue;	/* Ignore, continue to next if any */
 			    }
-			    //printk("G%04x/%d/%d;", nxt, nxt->len, ne2k_has_data);
+			    dprintk("G%04x/%d/%d;", nxt, nxt->len, ne2k_has_data);
 			    break; 		/* Important: one pkt per
 						 * loop only - to keep 'ne2k_has_data'
 						 * in sync with reality */
@@ -293,35 +300,26 @@ void ne2k_int_bh(void)
 			nxt = nxt->next;
 			if (nxt == rnext) break;
 		    } while (ne2k_has_data);
+
 		    if (nxt->len) 
 #endif
 			wake_up(&rxwait);
 		}
 
 		if (stat & NE2K_ISR_TX) {
-			tnext->len = 0;
-			tnext = tnext->next;
 			outb(NE2K_ISR_TX, net_port + EN0_ISR);
 			inb(net_port + EN0_TSR);	// Keep NIC happy
 		}
 
-#if NET_BUF_STRAT != NO_BUFS
+#if NET_BUF_STRAT == HEAP_BUFS
 		if (tnext->len) {
 			ne2k_pack_put(tnext->data, tnext->len);
+			tnext->len = 0;
+			tnext = tnext->next;
 			kputchar('x');
 			wake_up(&txwait);
 		}
 #endif
-
-		if (stat & NE2K_ISR_RDC) {
-			/* RDC interrupts are never used and should always be masked.
-		 	 * The dma_read, dma_write routines may fail if the RDC intr
-			 * bit is cleared randomly.
-		 	 * The RDC bit will occasionally be set for other reasons 
-			 * such as an aborted remote DMA transfer. 
-		 	 */
-			outb(NE2K_ISR_RDC, net_port + EN0_ISR);
-		}
 
 		/* Transmit error detected, this should not happen. */
 		if (stat & NE2K_ISR_TXE) { 	
@@ -348,9 +346,19 @@ void ne2k_int_bh(void)
 			ne2k_clr_err_cnt();
 			outb(NE2K_ISR_CNT, net_port + EN0_ISR);
 		}
+
+		if (stat & NE2K_ISR_RDC) {
+			/* RDC interrupts are never used and should always be masked.
+		 	 * The dma_read, dma_write routines may fail if the RDC intr
+			 * bit is cleared randomly.
+		 	 * The RDC bit will occasionally be set for other reasons 
+			 * such as an aborted remote DMA transfer. 
+		 	 */
+			outb(NE2K_ISR_RDC, net_port + EN0_ISR);
+		}
 		stat = inb(net_port + EN0_ISR);		/* Refresh - new interrupts may have arrived */
-		//printk("#%02x;", stat);
-	} while (stat);
+		dprintk("#%02x;", stat);
+	} while (stat&~NE2K_ISR_RDC);			/* no extra loop for an RDC */
 	stat = page;		/* to keep compiler happy */
 }
 
@@ -576,24 +584,17 @@ void INITPROC ne2k_drv_init(void)
 		printk(" (%dk buffer)", 4<<(net_flags&0x3));
 		/* possibly adjust oflow_keep here */
 	}
-#if (NET_BUF_STRAT == NO_BUFS)
-	printk(", flags 0x%02x\n", net_flags);
-#else
 #if NET_BUF_STRAT == HEAP_BUFS
 	/* If no netbufs= in bootopts, initialize from netbuf.h */
 	if (netbufs[NET_RXBUFS] == -1) netbufs[NET_RXBUFS] = NET_IBUFCNT;
 	if (netbufs[NET_TXBUFS] == -1) netbufs[NET_TXBUFS] = NET_OBUFCNT;
-#else	/* Static buffers */
-	netbufs[NET_RXBUFS] = NET_IBUFCNT;
-	netbufs[NET_TXBUFS] = NET_OBUFCNT;
 #endif
 	printk(", flags 0x%02x, bufs %dr/%dt\n", net_flags, netbufs[NET_RXBUFS],
 							    netbufs[NET_TXBUFS]);
-#endif
 
 #if DEBUG_ETH
 	debug_setcallback(2, ne2k_display_status);	/* ^P lists status */
 #endif
-	ne2k_has_data = 0;
+	ne2k_has_data = 0;	// Superfluous
 	eths[ETH_NE2K].stats = &netif_stat;
 }

--- a/tlvc/arch/i86/drivers/net/ne2k.c
+++ b/tlvc/arch/i86/drivers/net/ne2k.c
@@ -42,13 +42,12 @@ int net_port;	    /* required for ne2k-asm.S */
 static unsigned char usecount;
 static unsigned char found;
 static unsigned int verbose;
-static int getpkg_busy;
 static struct wait_queue rxwait;
 static struct wait_queue txwait;
 static struct netif_stat netif_stat;
 static byte_t model_name[] = "ne2k";
 static byte_t dev_name[] = "ne0";
-static size_t ne2k_getpkg(char *, size_t, word_t);
+static size_t ne2k_getpkg(char *, size_t);
 struct netbuf *netbuf_init(struct netbuf *, int);
 
 extern int    ne2k_next_pk;
@@ -58,18 +57,15 @@ extern byte_t ne2k_imask;
 extern struct eth eths[];
 extern unsigned char macaddr[];
 
-/* Distinguish between buffered and non buffered IO */
-/* Don't change these constants, the asm code is using them literally */
-#define BUF_IS_LOCAL 0
-#define BUF_IS_FAR 1
-//static int bufsinuse;
 //#define LOCAL_DEBUG
-#ifndef LOCAL_DEBUG
+#ifdef LOCAL_DEBUG
+void kputchar(int);
+#else
 #define kputchar(x)
 #endif
 
 /*
- * Return a complete packet from buffer or directly from the NIC
+ * Return a complete packet from buffer
  */
 
 static size_t ne2k_read(struct inode *inode, struct file *filp, char *data, size_t len)
@@ -80,31 +76,20 @@ static size_t ne2k_read(struct inode *inode, struct file *filp, char *data, size
 	kputchar('R');
 	while(1) {
 		prepare_to_wait_interruptible(&rxwait);
-#if NET_BUF_STRAT != NO_BUFS
-		if (rnext && rnext->len) {	/* data in buffer */
+		if (rnext->len) {	/* data in buffer */
 			res = rnext->len;
-			verified_memcpy_tofs(data, rnext->data, res);
-			rnext->len = 0;
-			//bufsinuse--;
-			rnext = rnext->next;
+			if (verified_memcpy_tofs(data, rnext->data+4, res)) {
+			    printk("ne0: memcpy error in read\n");
+			    res = 0; 
+			    break;
+			}
 			kputchar('b');
+			//printk("b%04x/%d;", rnext, res);
+			rnext->len = 0;
+			rnext = rnext->next;
 			break;
 		}
-#endif
-		/* The local buffers are empty - or we have no buffers.
-		 * Pull the data directly from the NIC.
-		 * In the buffered case this may happen because the host
-		 * rx buffer is smaller than the NIC buffer.
-		 *
-		 * NOTE: Possible race condition. A RCV INTR may happen
-		 * while we're reading a packet - thus the getpkg_busy semaphore
-		 */
-		if (ne2k_has_data && !getpkg_busy) { 
-		    kputchar('r');
-		    res = ne2k_getpkg(data, len, BUF_IS_FAR);
-		    break;
-		}
-		if (filp->f_flags & O_NONBLOCK) {
+		if ((filp->f_flags & O_NONBLOCK) && !ne2k_has_data) {
 			res = -EAGAIN;
 			break;
 		}
@@ -114,29 +99,24 @@ static size_t ne2k_read(struct inode *inode, struct file *filp, char *data, size
 			break;
 		}
 	}
+	if (ne2k_has_data) mark_bh(NETWORK_BH);
 	finish_wait(&rxwait);
 	return res;
 }
 
 /*
  * Get a packet from the NIC.
- * Called from the INTR routine and from read(),
- * thus the semaphore.
  */
 
-static size_t ne2k_getpkg(char *data, size_t len, word_t type) {
+static size_t ne2k_getpkg(char *data, size_t len) {
 
 	size_t size;
-	word_t nhdr[2];	/* buffer header from the NIC, for debugging */
+	word_t *nhdr = (word_t *)data;
 
-	clr_irq();
-	if (getpkg_busy) { set_irq(); return(0);}	/* busy, just return */
-	getpkg_busy++;				/* set the busy flag */
-	set_irq();
-
-	size = ne2k_pack_get(data, len, nhdr, type);
+	ne2k_pack_get(data, len);
+	size = nhdr[1];
 	//printk("r%04x|%04x/",nhdr[0], nhdr[1]);	// NIC buffer header
-	debug_eth("ne0: read: req %d, got %d real %d\n", len, size, nhdr[1]);
+	debug_eth("ne0: read: req %d, got %d\n", len, size);
 
 	//if ((nhdr[1] > size) || (nhdr[0] == 0)) {
 	if ((nhdr[0]&~0x7f21) || (nhdr[0] == 0)) {	//EXPERIMENTAL: Upper byte = block #, max 7f
@@ -144,32 +124,16 @@ static size_t ne2k_getpkg(char *data, size_t len, word_t type) {
 		/* Sanity check, this should not happen.
 		 * If this happens, we're reading garbage from the NIC, all pointers
 		 * may be invalid: Clear device and buffers.
-		 *	
-		 * Likely reason: We have a 8 bit interface running with 16k buffer enabled.
-		 * 
-		 * May want to add more tests for nhdr[0]:
-		 * 	Low byte should be 1 or 21	(receive status reg)
-		 *	High byte is a pointer to the next packet in the NIC ring buffer,
-		 *		should be < 0x80 and > 0x45
+		 * Probably a 8 bit interface running with 16k buffer enabled.
 		 */
 
 		netif_stat.rq_errors++;
 		//printk("$%04x.%02x$", ne2k_getpage(), ne2k_next_pk&0xff);
 		if (verbose) printk(EMSG_DMGPKT, dev_name, nhdr[0], nhdr[1]);
-#if 0
-		if (nhdr[0] == 0) { 	// When this happens, the NIC has serious trouble,
-					// need to reset as if we had a buffer overflow.
-			size = ne2k_clr_oflow(0); 
-			//printk("<%04x>", res);
-		} else
-#endif
-		{
-			ne2k_rx_init();	// Resets the ring buffer pointers to initial values,
-					// effectively purging the buffer.
-			size = -EIO;
-		}
+		ne2k_rx_init();	// Resets the ring buffer pointers to initial values,
+				// effectively purging the buffer.
+		size = -EIO;
 	}
-	getpkg_busy = 0;	/* clear busy-flag */
 	return(size);
 }
 
@@ -179,54 +143,55 @@ static size_t ne2k_getpkg(char *data, size_t len, word_t type) {
 
 static size_t ne2k_write(struct inode *inode, struct file *file, char *data, size_t len)
 {
-	size_t res;
+	size_t res = 0;
+	struct netbuf *n, *nxt = tnext;
 
-	//printk("T");
+	kputchar('T');
+	if (len > MAX_PACKET_ETH) len = MAX_PACKET_ETH;
+	if (len < 64) len = 64;
+
 	while (1) {
 		prepare_to_wait_interruptible(&txwait);
-		/* NOTE: tx_stat() checks the command reg, not the tx_status_reg! */
-		if (ne2k_tx_stat() != NE2K_ISR_TX) {
 #if NET_BUF_STRAT != NO_BUFS
-		    if (tnext) {
-			/* transmiter is busy, put the data in a buffer if available */
-			struct netbuf *nxt = tnext;
-			while (nxt->len) {	/* search for available buffer */
-			    if (nxt == tnext) break;
-			    nxt = nxt->next;
-			}
-			if (nxt->len == 0) {
-			    kputchar('t');
-			    nxt->len = len;
-			    verified_memcpy_fromfs(nxt->data, data, len);
-			    res = len;
-			    break;
-			}
-		    }
-#endif
-		    if (file->f_flags & O_NONBLOCK) {
-			res = -EAGAIN;
-			break;
-		    }
-		    do_wait();
-		    if(current->signal) {
-			res = -EINTR;
-			break;
-		    }
+		n = nxt;
+		while (nxt->len) {	/* search for available buffer */
+		    nxt = nxt->next;
+		    if (nxt == n) break;
 		}
-
-		/* NIC is ready, send the data, no buffering */
-		if (len > MAX_PACKET_ETH) len = MAX_PACKET_ETH;
-
-		if (len < 64) len = 64;  		/* issue #133 */
-		outb(0, net_port + EN0_IMR);	/* block interrupts from the NIC while moving data to it */
-		ne2k_pack_put(data, len, BUF_IS_FAR);
-		outb(ne2k_imask, net_port + EN0_IMR);	/* reenable int's */
-
-		res = len;
-		break;
+		if (nxt->len == 0) {
+		    kputchar('t');
+		    if (verified_memcpy_fromfs(nxt->data, data, len)) {
+			printk("ne0: memcpy error in write\n");
+			res = -EIO; 
+			break;
+		    }
+		    res = len;
+		    nxt->len = len;
+		    //printk("%04x/%d;",nxt, nxt->len);
+		    //mark_bh(NETWORK_BH);
+		    break;
+		}
+#endif
+	/* No buffer available. Returning w/o sending means a lost packet and a retransmit cycle,
+	 * which is more than 3 secs, while waiting for a buffer to become available 
+	 * will take only a few ms.
+	 * FIXME May want to put in a counter, so we don't get stuck. */
+#if 0
+		if (file->f_flags & O_NONBLOCK) {
+		    res = -EAGAIN;
+		    break;
+		}
+#endif
+		do_wait();
+		if(current->signal) {
+		    res = -EINTR;
+		    break;
+		}
+		kputchar('Z');
 	}
 
 	finish_wait(&txwait);
+	if (res>0) mark_bh(NETWORK_BH);
 	return res;
 }
 
@@ -240,30 +205,23 @@ int ne2k_select(struct inode *inode, struct file *filp, int sel_type)
 
 	switch (sel_type) {
 		case SEL_OUT:
-			if ((ne2k_tx_stat() == NE2K_ISR_TX) 
-#if NET_BUF_STRAT != NO_BUFS
-				|| (tnext && !tnext->len)
-#endif
-			) {
-				kputchar('t');
+			if (tnext->len == 0) {
+				kputchar('s');
 				res = 1;
 				break;
 			}
-			kputchar('T');
+			kputchar('S');
 			select_wait(&txwait);
 			break;
 
 		case SEL_IN:
-			if (ne2k_has_data
-#if NET_BUF_STRAT != NO_BUFS
-			|| (rnext && rnext->len)
-#endif
-			) {
+			if (rnext->len) {
 				kputchar('w');
 				res = 1;
 				break;
 			}
 			kputchar('W');
+			//mark_bh(NETWORK_BH);	// EXPERIMENTAL
 			select_wait(&rxwait);
 			break;
 
@@ -280,16 +238,23 @@ int ne2k_select(struct inode *inode, struct file *filp, int sel_type)
 
 static void ne2k_int(int irq, struct pt_regs *regs)
 {
+	kputchar('I');
+	mark_bh(NETWORK_BH);
+}
+
+void ne2k_int_bh(void)
+{
 	word_t stat, page;
 
-	kputchar('I');
-	outb(0x20,0x20);	/* EOI to primary controller */
-	while (1) {
-		stat = ne2k_int_stat();
-		if (!stat) break; 	/* If zero, we're done! */
+	stat = inb(net_port + EN0_ISR);
+	kputchar('i');
+	//printk("i%x;",stat);
+	do {
+		if (!stat && !ne2k_has_data && !tnext->len) break;
+
 #if 0	/* debug */
 		page = ne2k_getpage();
-		printk("$%04x.%02x$", page,ne2k_next_pk&0xff);
+		printk("$%02x.%04x.%02x$", stat, page, ne2k_next_pk&0xff);
 #endif
         	if (stat & NE2K_ISR_OF) {
 			netif_stat.oflow_errors++;
@@ -297,76 +262,74 @@ static void ne2k_int(int irq, struct pt_regs *regs)
 			page = ne2k_clr_oflow(netif_stat.oflow_keep); 
 
 			debug_eth("/CB%04x/ ", page);
-			//printk("%04x/ ", page);
-
 			if (ne2k_has_data)
-				wake_up(&rxwait);
+			    wake_up(&rxwait);
 			break; 
 		}
 
 		if (stat & NE2K_ISR_RX) {
-			kputchar('i');
+			kputchar('j');
 			ne2k_has_data = 1;
+			outb(NE2K_ISR_RX, net_port + EN0_ISR);
 		}
 
 		if (ne2k_has_data) {		/* Even if we didn't get an RX int, there may be 
 						 * data to pull from the NIC - buffer space 
-						 * permitting ... */
+						 * permitting */
 #if NET_BUF_STRAT != NO_BUFS
 		    struct netbuf *nxt = rnext;
-		    if (rnext && !getpkg_busy) {	/* sanity check: 0 buffers is a real possibility */
-			while (ne2k_has_data) {
-			    if (nxt->len == 0) {	/* buffer available */
-				nxt->len = ne2k_getpkg(nxt->data, MAX_PACKET_ETH, BUF_IS_LOCAL);
-				//bufsinuse++;	/* DEBUG */
-				//kputchar('0'+bufsinuse);
-			    } 
-			    nxt = nxt->next;
-			    if (nxt == rnext) break;
-			}
-		    }
+		    do {
+			if (nxt->len == 0) {	/* buffer available */
+			    nxt->len = ne2k_getpkg(nxt->data, MAX_PACKET_ETH);
+			    if (nxt->len < 0) {	/* we may get a bad packet from ne2k_getpkg() */
+				nxt->len = 0;
+				continue;	/* Nothing to read, exit loop */
+			    }
+			    //printk("G%04x/%d/%d;", nxt, nxt->len, ne2k_has_data);
+			    break; 		/* Important: one pkt per
+						 * loop only - to keep 'ne2k_has_data'
+						 * in sync with reality */
+			} 
+			nxt = nxt->next;
+			if (nxt == rnext) break;
+		    } while (ne2k_has_data);
+		    if (nxt->len) 
 #endif
-		    wake_up(&rxwait);
-		    outb(NE2K_ISR_RX, net_port + EN0_ISR);
+			wake_up(&rxwait);
 		}
 
 		if (stat & NE2K_ISR_TX) {
-			kputchar('x');
+			tnext->len = 0;
+			tnext = tnext->next;
+			outb(NE2K_ISR_TX, net_port + EN0_ISR);
+			inb(net_port + EN0_TSR);	// Keep NIC happy
+		}
+
 #if NET_BUF_STRAT != NO_BUFS
-			if (tnext && tnext->len) {
-				ne2k_pack_put(tnext->data, tnext->len, BUF_IS_LOCAL);
-				tnext->len = 0;
-				tnext = tnext->next;
-			}
-#endif
-			outb(NE2K_ISR_TX, net_port + EN0_ISR); // Clear intr bit
-			inb(net_port + EN0_TSR);	/* really needed? */
+		if (tnext->len) {
+			ne2k_pack_put(tnext->data, tnext->len);
+			kputchar('x');
 			wake_up(&txwait);
 		}
-		//printk("%02X/%d/", stat, ne2k_has_data);
-		/* shortcut for speed */
-		if (!(stat&~(NE2K_ISR_TX|NE2K_ISR_RX|NE2K_ISR_OF))) continue;
+#endif
 
-		/* These don't happen very often */
 		if (stat & NE2K_ISR_RDC) {
-			//printk("ne0: Warning - RDC intr. (0x%02x)\n", stat);
-			/* RDC interrupts should be masked in the low level driver.
-		 	 * The dma_read, dma_write routines will fail if the RDC intr
-			 * bit is cleared elsewhere.
-		 	 * OTOH: The RDC bit will occasionally be set for other reasons 
-			 * (such as an aborted remote DMA transfer). In such cases the
-			 * RDC bit must be reset here, otherwise this function will loop.
+			/* RDC interrupts are never used and should always be masked.
+		 	 * The dma_read, dma_write routines may fail if the RDC intr
+			 * bit is cleared randomly.
+		 	 * The RDC bit will occasionally be set for other reasons 
+			 * such as an aborted remote DMA transfer. 
 		 	 */
-			ne2k_rdc();
+			outb(NE2K_ISR_RDC, net_port + EN0_ISR);
 		}
 
+		/* Transmit error detected, this should not happen. */
 		if (stat & NE2K_ISR_TXE) { 	
 			int k;
-			/* transmit error detected, this should not happen. */
-			/* ne2k_get_tx_stat resets this bit in the ISR */
 			netif_stat.tx_errors++;
-			k = ne2k_get_tx_stat();	// read tx status reg to keep the NIC happy
+			k = ne2k_get_tx_stat();
 			if (verbose) printk(EMSG_TXERR, dev_name, k);
+			outb(NE2K_ISR_TXE, net_port + EN0_ISR);
 		}
 
 		/* RXErrors occur almost exclusively when using an 8 bit interface.
@@ -374,8 +337,6 @@ static void ne2k_int(int irq, struct pt_regs *regs)
 		 * Therefore the asm level code will unmask RXE intr only if the NIC is 
 		 * running in 8 bit mode */
 		if (stat & NE2K_ISR_RXE) { 	
-			/* Receive error detected, may happen when traffic is heavy */
-			/* The 8 bit interface gets lots of these, all CRC, packet dropped */
 			/* Don't do anything, just count, report & clr */
 			netif_stat.rx_errors++;
 			if (verbose) printk(EMSG_RXERR, dev_name, inb(net_port + EN0_RSR));
@@ -385,9 +346,11 @@ static void ne2k_int(int irq, struct pt_regs *regs)
 			/* The tally counters will overflow on 8 bit interfaces with
 		 	 * lots of overruns.  Just clear the condition */
 			ne2k_clr_err_cnt();
+			outb(NE2K_ISR_CNT, net_port + EN0_ISR);
 		}
-	}
-	//printk(".%02x", ne2k_int_stat());
+		stat = inb(net_port + EN0_ISR);		/* Refresh - new interrupts may have arrived */
+		//printk("#%02x;", stat);
+	} while (stat);
 	stat = page;		/* to keep compiler happy */
 }
 
@@ -450,16 +413,13 @@ static int ne2k_open(struct inode *inode, struct file *file)
 		net_ibuf = (struct netbuf *)heap_alloc(sizeof(struct netbuf) * (netbufs[NET_RXBUFS] + 
 				netbufs[NET_TXBUFS]), HEAP_TAG_NETWORK);
 		net_obuf = net_ibuf + netbufs[NET_RXBUFS];
-#endif
-#if NET_BUF_STRAT != NO_BUFS
 		//printk("eth: using %d/%d buffers\n", netbufs[NET_RXBUFS], netbufs[NET_TXBUFS]);
 		tnext = netbuf_init(net_obuf, netbufs[NET_TXBUFS]);
 		rnext = netbuf_init(net_ibuf, netbufs[NET_RXBUFS]);
-		//bufsinuse = 0;
 #endif
 
 		ne2k_start();
-		//outb(0xff, net_port + EN0_ISR); /* EXPERIMENTAL; DELETE */
+		init_bh(NETWORK_BH, ne2k_int_bh);
 	}
 	return 0;
 }

--- a/tlvc/arch/i86/drivers/net/ne2k.h
+++ b/tlvc/arch/i86/drivers/net/ne2k.h
@@ -37,7 +37,6 @@
 #define EN0_DCFG	0x0eU	/* Data configuration reg WR */
 #define EN0_IMR		0x0fU	/* Interrupt mask reg WR */
 
-/* From low level NE2K MAC */
 #ifndef __ASSEMBLER__
 
 extern word_t ne2k_int_stat();
@@ -55,8 +54,8 @@ extern void   ne2k_addr_set(byte_t *);
 extern word_t ne2k_rx_stat();
 extern word_t ne2k_tx_stat();
 
-extern word_t ne2k_pack_get(char *, word_t, word_t *, word_t);
-extern word_t ne2k_pack_put(char *, word_t, word_t);
+extern word_t ne2k_pack_get(char *, word_t);
+extern word_t ne2k_pack_put(char *, word_t);
 
 extern word_t ne2k_test();
 

--- a/tlvc/arch/i86/drivers/net/netlib.c
+++ b/tlvc/arch/i86/drivers/net/netlib.c
@@ -2,7 +2,7 @@
  * Initialize IO buffers 
  */
 
-#include "netbuf.h"
+#include "netlib.h"
 #include <linuxmt/kernel.h>
 #include <linuxmt/heap.h>
 
@@ -35,5 +35,20 @@ void netbuf_release(struct netbuf *buf) {
 		//printk("netbuf rel %x\n", n->data);
 		n = n->next;
 	} while (n != buf);
+}
+#endif
+
+#if NET_BUF_STRAT == PAGE_BUFS
+
+struct page *pbuf_init(struct pbuf *p)
+{
+	if (!(p->base = heap_alloc(PBUF_COUNT<<8, HEAP_TAG_NETWORK))) {
+		printk("eth: Page buffer alloc failed\n");
+		return NULL;
+	}
+	p->head = 1;
+	p->tail = 0;
+	p->top = p->base + (PBUF_COUNT<<8);
+	return p->base;
 }
 #endif

--- a/tlvc/arch/i86/drivers/net/netlib.h
+++ b/tlvc/arch/i86/drivers/net/netlib.h
@@ -32,6 +32,22 @@
  * AGAIN: zero buffers is always a valid choice - which complicates the driver 
  * somewhat but makes benchmarking much more convenient.
  */
+/*
+ * March 2026 (HS): Added pagebuffers, 256 byte buffers modeled after the ne2k
+ * NIC buffers, a very simple scheme in which a packet is stored in as many pages
+ * as it takes and no inherent structure other than a 2 word header holding the 
+ * size of the packet (i.e. how many pages it takes) and a status word. For
+ * convenience, the 2 word header is kept while only the first word (size) is
+ * used.
+ * Memory allocation is thusly in pages and for coding efficiency the number of
+ * pages must be a power of 2, conveniently 32, 8k bytes. For now, this buffer
+ * strategy applies to incoming packets only. When selected, there is no output
+ * buffering.
+ * Initially, when page buffers are used, the buffer setting in bootopts is ignored.
+ */
+/* March 2026 (HS): Removed the non-buffered option and the static buffer option.
+ * IOW the driver always uses buffers, kernel reads and writes never touch
+ * the device */
 
 #define NET_RXBUFS  0 	/* indexes */
 #define NET_TXBUFS  1
@@ -39,48 +55,50 @@
 #define NO_BUFS     0	/* buffer support not compiled in */
 #define STATIC_BUFS 1	/* use static buffer allocation, ignore netbufs= in bootopts */
 #define HEAP_BUFS   2	/* allocate buffers from kernel heap */
+#define PAGE_BUFS   3	/* Use page buffers for receving, no buffers for output */
 
-/* Set the current strategy */
+/* Set the default strategy */
+//#define NET_BUF_STRAT	PAGE_BUFS
 #define NET_BUF_STRAT	HEAP_BUFS
 
-/* Use when strategy is STATIC_BUFS or HEAP_BUFS - in the latter case only 
- * if netbufs= is missing from /bootopts */
-#define NET_OBUFCNT 0
+/* Default buffer allocations (1 or more), in case
+ * netbufs= is missing from /bootopts */
+#define NET_OBUFCNT 2
 #define NET_IBUFCNT 2
 
 #ifndef __ASSEMBLER__
 
 #include <linuxmt/limits.h>
 
+struct netbuf *netbuf_init(struct netbuf *, int);
 extern int netbufs[];
 
 struct netbuf {
 	int len;			/* ZERO if available */
 	struct netbuf *next;
-#if NET_BUF_STRAT == HEAP_BUFS 
 	char *data;	/* allocate from heap */
-#else
-	char data[MAX_PACKET_ETH];
-#endif
 };
+
+struct page {
+	char c[256];
+};
+
+struct pbuf {		/* packet buffers split into pages */
+	struct page   *top;	/* MUST be first! */
+	struct page   *base;
+	unsigned char head;	/* always 1 ahead */
+	unsigned char tail;
+};
+
+#define PBUF_COUNT	32	/* Always power of 2 */
 
 void netbuf_release(struct netbuf *);
 
-#if NET_BUF_STRAT == HEAP_BUFS
 struct netbuf *net_ibuf;
 struct netbuf *rnext;
 
 struct netbuf *net_obuf;
-struct netbuf *tnext;
-#endif
-
-#if NET_BUF_STRAT == STATIC_BUFS
-struct netbuf net_ibuf[NET_IBUFCNT];
-struct netbuf *rnext;
-
-struct netbuf net_obuf[NET_OBUFCNT];
-struct netbuf *tnext;
-#endif
+struct netbuf *tnext, *pnext;
 
 #endif /* ASSEMBLER */
 


### PR DESCRIPTION
With reference to the discussion in #237, this represents the first cut of a new generation of network drivers: Completely buffered and interrupt driven, taking advantage of the new TH/BH interrupt handler structure and simplifying the interface between kernel IO and device IO.

The buffer mechanism itself is unchanged from the original implementation (2023) but the optional static buffers and the 'no buffers' option have been removed. The interrupt handler and the read/write routines have been simplified and optimized, as has the assembler code. The low level read from the NIC now always reads 256 bytes in the first read operation - instead of only 4 to get the header with the packet length. If the packet is smaller than 252 bytes including headers, this is the only operation required - and obvious optimization compared to always doing two read operations when packed are small, which typically is the case in `telnet` connections. When packets are larger the difference is nil, if smaller it's negligible. This is the way the read operation worked from approximately 2018 until direct reads into user space were implemented in ~2020.

A nasty race condition in write/xmit led to a long and thorough rabbit hunt through most of the driver which uncovered some esoteric (and not-so-esoteric) bugs along the way and overall contributed to the driver now being at least as robust as before the structural change. Error handling in particular has improved and delays when buffers are temporarily unavailable have been minimized. Testing/rabbit hunting entailed 3 hardware platforms and 3 different ne?k interfaces plus QEMU, literally thousands of test runs across all of them.

This driver is the first to take full advantage of the TH/BH structure and the experiences have been very encouraging. It's now a valuable role model for repeating the structural changes in other net drivers, starting with the SMC/WD driver. Alongside this the new buffer structure mentioned in #237 is coming along nicely, and with it the option to place the buffers anywhere in memory.

EDIT: About performance - see next post.