### PR TITLE
[kernel] Add call to BH handler after every syscall

### DIFF
--- a/tlvc/arch/i86/kernel/irqtab.S
+++ b/tlvc/arch/i86/kernel/irqtab.S
@@ -164,7 +164,12 @@ save_regs:
         // strace.c must be compiled with tail optimization off to protect top of stack
         call    trace_end       // syscall return value is top of stack
 #endif
-        call    do_signal       // process signals
+        cmpw    $0,bh_active    // Any active bottom halfs?
+        je      1f              // No
+        call    do_bottom_half  // Run bottom halves
+        //call schedule         // experimental
+
+1:	call    do_signal       // process signals
         cli
         jmp     restore_regs
 //


### PR DESCRIPTION
A small fix with big consequences: Instead of checking for pending bottom-half function calls every clock tick, the BH-list is now checked after every syscall, which speeds up network processing, in particular outgoing traffic, dramatically. Discussed in #238. Thanks @ghaerr.