### PR TITLE
[kernel] Bugfix and improvements in process exit code

### DIFF
--- a/tlvc/kernel/exit.c
+++ b/tlvc/kernel/exit.c
@@ -7,31 +7,38 @@
 #include <linuxmt/sched.h>
 #include <linuxmt/errno.h>
 #include <linuxmt/mm.h>
+#include <linuxmt/init.h>
 #include <linuxmt/debug.h>
 
-static void reparent_children(void)
+static void FARPROC reparent_children(void)
 {
-	register struct task_struct *p;
+    register struct task_struct *p;
 
-	for_each_task(p) {
-		if (p->p_parent == current) {
-			/* remove orphaned zombies, no need to reparent them to init*/
-			if (p->state == TASK_ZOMBIE) {
-				debug_wait("Zombie orphan pid %d ppid %d removed\n", p->pid, p->ppid);
-				p->state = TASK_UNUSED;		/* unassign task entry*/
-				next_task_slot = p;
-				task_slots_unused++;
-			}
+    for_each_task(p) {
+        if (p->p_parent == current) {
+            /* remove orphaned zombies, no need to reparent them to init*/
+            if (p->state == TASK_ZOMBIE) {
+                debug_wait("Zombie orphan pid %d ppid %d removed\n", p->pid, p->ppid);
+                p->state = TASK_UNUSED;     /* unassign task entry*/
+                next_task_slot = p;
+                task_slots_unused++;
+            }
 
-			/* reparent orphans to init*/
-			if (p->state != TASK_UNUSED) {
-				debug_wait("Reparenting orphan pid %d ppid %d to init\n",
-					p->pid, p->p_parent->pid);
-				p->p_parent = &task[1];
-				p->ppid = task[1].pid;
-			}
-		}
-	}
+            /* reparent orphans to init*/
+            if (p->state != TASK_UNUSED) {
+                debug_wait("Reparenting orphan pid %d ppid %d to init\n",
+                    p->pid, p->p_parent->pid);
+
+                /* release TTY process group and original session */
+                if (p->tty && (p->tty->pgrp == current->pid))
+                    p->tty->pgrp = 0;
+                p->session = p->pgrp = p->pid;
+
+                p->p_parent = &task[0];
+                p->ppid = task[0].pid;
+            }
+        }
+    }
 }
 
 /* note: 'usage' parameter ignored */
@@ -40,62 +47,69 @@ int sys_wait4(pid_t pid, int *status, int options, void *usage)
     register struct task_struct *p;
     int waitagain;
 
-    debug_wait("WAIT(%d) for %d %s\n", current->pid, pid, (options & WNOHANG)? "nohang": "");
+    debug_wait("WAIT(%P) for %d opts %x\n", pid, options);
 
-    for (;;) {
-	waitagain = 0;
+ for (;;) {
+    waitagain = 0;
 
-	for_each_task(p) {
-	    if (p->p_parent == current && p->state != TASK_UNUSED) {
-		if (p->state == TASK_ZOMBIE || p->state == TASK_STOPPED) {
-		    if (pid == (pid_t)-1 || p->pid == pid || (!pid && p->pgrp == current->pgrp)) {
-			if (status) {
-			    if (verified_memcpy_tofs(status, &p->exit_status, sizeof(int)))
-				return -EFAULT;
-			}
+    for_each_task(p) {
+        if (p->p_parent == current && p->state != TASK_UNUSED) {
+          if (p->state == TASK_ZOMBIE || p->state == TASK_STOPPED) {
+            if (pid == (pid_t)-1 || p->pid == pid || (!pid && p->pgrp == current->pgrp)) {
+                if (p->state == TASK_STOPPED) {
+                    if (!p->exit_status || !(options & WUNTRACED))
+                        continue;
+                }
 
-			/* just return status on stopped state, don't release task*/
-			if (p->state == TASK_STOPPED)
-			    return p->pid;
+                if (status) {
+                    if (verified_memcpy_tofs(status, &p->exit_status, sizeof(int)))
+                        return -EFAULT;
+                }
 
-			p->state = TASK_UNUSED;		/* unassign task entry*/
-			next_task_slot = p;
-			task_slots_unused++;
+                /* just return status on stopped state, don't release task*/
+                if (p->state == TASK_STOPPED)
+                    p->exit_status = 0;
+                else {
+                    p->state = TASK_UNUSED;     /* unassign task entry*/
+                    next_task_slot = p;
+                    task_slots_unused++;
+                }
 
-			debug_wait("WAIT(%d) got %d\n", current->pid, p->pid);
-			return p->pid;
-		    }
-		} else {
-		    /* keep waiting while process has non-zombie/stopped children*/
-		    debug_wait("WAIT(%d) again for pid %d state %d\n", current->pid, p->pid, p->state);
-		    waitagain = 1;
-		}
-	    }
-	}
-
-	if (options & WNOHANG)
-	    return 0;
-	if (!waitagain)
-	    break;
-
-	debug_wait("WAIT(%d) sleep\n", current->pid);
-	interruptible_sleep_on(&current->child_wait);
-	if (current->signal) {
-	    debug_wait("WAIT(%d) return -EINTR\n", current->pid);
-	    return -EINTR;
-	}
-	debug_wait("WAIT(%d) wakeup\n", current->pid);
+                debug_wait("WAIT(%P) got %d\n", p->pid);
+                return p->pid;
+            }
+        } else {
+            /* keep waiting while process has non-zombie children*/
+            debug_wait("WAIT(%P) again for pid %d state %d\n", p->pid, p->state);
+            waitagain = 1;
+        }
+      }
     }
 
-    debug_wait("WAIT(%d) return -ECHILD\n", current->pid);
-	return -ECHILD;
+    if (options & WNOHANG)
+        return 0;
+    if (!waitagain)
+        break;
+
+    debug_wait("WAIT(%P) sleep\n");
+    interruptible_sleep_on(&current->child_wait);
+    if (current->signal) {
+        debug_wait("WAIT(%P) return -EINTR\n");
+        return -EINTR;
+    }
+    debug_wait("WAIT(%P) wakeup\n");
+  }
+
+    debug_wait("WAIT(%P) return -ECHILD\n");
+    return -ECHILD;
 }
 
 void do_exit(int status)
 {
+    int i;
     struct task_struct *parent;
 
-    debug_wait("EXIT(%d) status %d\n", current->pid, status);
+    debug_wait("EXIT(%P) status %d\n", status);
     _close_allfiles();
 
     /* release process group and TTY*/
@@ -104,33 +118,16 @@ void do_exit(int status)
 
     /* Let go of the process */
     current->state = TASK_EXITING;
-    if (current->mm[SEG_CODE])
-	seg_put(current->mm[SEG_CODE]);
-    if (current->mm[SEG_DATA])
-	seg_put(current->mm[SEG_DATA]);
-    current->mm[SEG_CODE] = current->mm[SEG_DATA] = 0;
+    for (i = 0; i < MAX_SEGS; i++) {
+        if (current->mm[i])
+            seg_put(current->mm[i]);
+        current->mm[i] = 0;
+    }
 
     /* free program allocated memory */
     seg_free_pid(current->pid);
 
-#if BLOAT
-    /* Keep all of the family stuff straight */
-    struct task_struct *task;
-    if ((task = current->p_prevsib)) {
-	task->p_nextsib = current->p_nextsib;
-    }
-    if ((task = current->p_nextsib)) {
-	task->p_prevsib = current->p_prevsib;
-    }
-
-    /* Ack. I hate repeating code like this */
-    if ((parent = current->p_parent)->p_child == current) {
-	if ((task = current->p_prevsib) || (task = current->p_nextsib))
-	    parent->p_child = task;
-    }
-#else
     parent = current->p_parent;
-#endif
 
     /* UN*X process take their children out with them...
      * I'm not going to implement that for 0.0.51 because we don't
@@ -141,7 +138,7 @@ void do_exit(int status)
     /* Let the parent know */
     kill_process(current->ppid, SIGCHLD, 1);
 
-    /* Free the text, pwd, and root inodes */
+    /* Free the text, chroot, and current working directory inodes */
     iput(current->t_inode);
     iput(current->fs.root);
     iput(current->fs.pwd);
@@ -154,7 +151,8 @@ void do_exit(int status)
     current->state = TASK_ZOMBIE;
     wake_up(&parent->child_wait);
     schedule();
-    panic("sys_exit\n");
+    /* no return */
+    halt();
 }
 
 void sys_exit(int status)


### PR DESCRIPTION
Fixes bug in reparenting code that caused eternal zombies because of an erroneous reference to the idle task.
Also adds corrected/updated handling of STOPPED processes from ELKS. 