### PR TITLE
[net] Update the ee16 driver to use atomic jiffies()

### DIFF
--- a/tlvc/arch/i86/drivers/net/Makefile
+++ b/tlvc/arch/i86/drivers/net/Makefile
@@ -27,7 +27,7 @@ include $(BASEDIR)/Makefile-rules
 #########################################################################
 # Specific rules.
 
-OBJS = netbuf.o
+#OBJS = netlib.o
 ifeq ($(CONFIG_ETH_NE2K), y)
 OBJS += ne2k-asm.o ne2k.o
 endif

--- a/tlvc/arch/i86/drivers/net/ee16.c
+++ b/tlvc/arch/i86/drivers/net/ee16.c
@@ -1429,7 +1429,7 @@ static void ee16_put_packet(unsigned int ioaddr, char *buf, int len)
 #define USE_RESTART_CU 3
 #if USE_RESTART_CU == 2		/* recovery before new packet */
 				/* recovery after: See below, the jury is out on which is best */
-	if (tx_avail < num_tx_bufs && (jiffies - last_tx)) {
+	if (tx_avail < num_tx_bufs && (jiffies() - last_tx)) {
 		ee16_restartCU(tx_reap);
 	}
 #endif
@@ -1469,7 +1469,7 @@ static void ee16_put_packet(unsigned int ioaddr, char *buf, int len)
 #if USE_RESTART_CU == 3
 	/* If this is placed before filling the buffer, we may get underrun errors,
 	 * seemingly from memory contention. TO BE VERIFIED */
-	if (tx_avail < (num_tx_bufs-1) && (jiffies - last_tx)) {
+	if (tx_avail < (num_tx_bufs-1) && (jiffies() - last_tx)) {
 		ee16_restartCU(tx_reap);
 	}
 #endif
@@ -1483,7 +1483,7 @@ static void ee16_put_packet(unsigned int ioaddr, char *buf, int len)
 	else
 		tx_head += TX_BUF_SIZE;
 
-	last_tx = jiffies;	/* may want to track last TX complete int instead */
+	last_tx = jiffies();	/* may want to track last TX complete int instead */
 
 	/* Update the link in the previous block to point to this block.
 	 * This will allow the CU to process this frame and almost always trigger an immediate

--- a/tlvc/arch/i86/kernel/nmi.c
+++ b/tlvc/arch/i86/kernel/nmi.c
@@ -1,0 +1,20 @@
+#include <linuxmt/config.h>
+#include <linuxmt/kernel.h>
+#include <arch/io.h>
+
+/*
+ * NMI handler
+ */
+
+void nmi_handler(int irq, struct pt_regs *regs)
+{
+    printk("NMI FAULT\n");
+
+#ifdef CONFIG_ARCH_PC98
+    if (inb(0x33) & 0x02)
+        printk("Extended slot memory parity error\n");
+
+    outb(0x08,0x37); /* Disable parity check to clear the error */
+    outb(0x09,0x37); /* Enable parity check */
+#endif
+}


### PR DESCRIPTION
... also added missing nmi.c file and removed (forward) leftover in net/Makefile.